### PR TITLE
feat: Fetch fresh grocery prices from GitHub Pages for installed apps

### DIFF
--- a/.github/workflows/scrape-grocery-prices.yml
+++ b/.github/workflows/scrape-grocery-prices.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   scrape:
@@ -64,3 +66,12 @@ jobs:
             git commit -m "chore: update grocery prices $(date -u +%Y-%m-%d)"
             git push
           fi
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./monthy_budget_flutter/assets
+          keep_files: false
+          commit_message: "chore: update grocery prices for GitHub Pages"

--- a/monthy_budget_flutter/android/app/src/main/AndroidManifest.xml
+++ b/monthy_budget_flutter/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="orcamento_mensal"
         android:name="${applicationName}"

--- a/monthy_budget_flutter/lib/services/grocery_service.dart
+++ b/monthy_budget_flutter/lib/services/grocery_service.dart
@@ -1,42 +1,104 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/grocery_data.dart';
 
-/// Service that loads grocery price data from the bundled JSON asset
-/// and caches it in SharedPreferences (same pattern as SettingsService).
+/// Service that loads grocery price data.
+///
+/// Fetch order:
+///   1. Remote (GitHub Pages) — if TTL has expired
+///   2. SharedPreferences cache — if remote fails or TTL hasn't expired
+///   3. Bundled asset — first-launch fallback
 class GroceryService {
   static const _cacheKey = 'grocery_prices_cache';
+  static const _lastFetchKey = 'grocery_prices_last_fetch';
   static const _assetPath = 'assets/grocery_prices.json';
 
-  /// Load grocery data. Tries the bundled asset first, falls back to cache.
+  /// GitHub Pages URL where the daily-scraped JSON is published.
+  /// Repo: lfrmonteiro99/monthy_budget  →  gh-pages branch
+  static const _remoteUrl =
+      'https://lfrmonteiro99.github.io/monthy_budget/grocery_prices.json';
+
+  /// How often the app should try fetching fresh data (12 hours).
+  static const _fetchTtl = Duration(hours: 12);
+
+  /// Load grocery data.
+  /// Tries remote first (if stale), then cache, then bundled asset.
   Future<GroceryData> load() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // Check if we should attempt a remote fetch
+    if (_shouldFetchRemote(prefs)) {
+      final remoteData = await _fetchRemote(prefs);
+      if (remoteData != null) return remoteData;
+    }
+
+    // Try cached data
+    final cached = _loadFromPrefs(prefs);
+    if (cached != null) return cached;
+
+    // First launch fallback: load from bundled asset
+    return _loadFromAsset(prefs);
+  }
+
+  /// Returns true when the cache is older than [_fetchTtl] or doesn't exist.
+  bool _shouldFetchRemote(SharedPreferences prefs) {
+    final lastFetch = prefs.getInt(_lastFetchKey);
+    if (lastFetch == null) return true;
+    final elapsed = DateTime.now().millisecondsSinceEpoch - lastFetch;
+    return elapsed >= _fetchTtl.inMilliseconds;
+  }
+
+  /// Fetch JSON from GitHub Pages, parse it, cache it. Returns null on failure.
+  Future<GroceryData?> _fetchRemote(SharedPreferences prefs) async {
     try {
-      // Load from the bundled asset (updated by GitHub Actions daily)
+      final response = await http
+          .get(Uri.parse(_remoteUrl))
+          .timeout(const Duration(seconds: 15));
+
+      if (response.statusCode != 200) return null;
+
+      final raw = response.body;
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      final data = GroceryData.fromJson(json);
+
+      // Persist to cache
+      await prefs.setString(_cacheKey, raw);
+      await prefs.setInt(
+          _lastFetchKey, DateTime.now().millisecondsSinceEpoch);
+
+      return data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Load from SharedPreferences cache. Returns null if empty.
+  GroceryData? _loadFromPrefs(SharedPreferences prefs) {
+    try {
+      final raw = prefs.getString(_cacheKey);
+      if (raw == null) return null;
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return GroceryData.fromJson(json);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Load from the bundled asset and seed the cache.
+  Future<GroceryData> _loadFromAsset(SharedPreferences prefs) async {
+    try {
       final raw = await rootBundle.loadString(_assetPath);
       final json = jsonDecode(raw) as Map<String, dynamic>;
       final data = GroceryData.fromJson(json);
 
-      // Cache it in SharedPreferences for offline access
-      final prefs = await SharedPreferences.getInstance();
+      // Seed the cache so subsequent loads don't need the asset
       await prefs.setString(_cacheKey, raw);
 
       return data;
     } catch (_) {
-      // Fallback: try loading from cache
-      return _loadFromCache();
+      return const GroceryData();
     }
-  }
-
-  Future<GroceryData> _loadFromCache() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(_cacheKey);
-      if (raw != null) {
-        final json = jsonDecode(raw) as Map<String, dynamic>;
-        return GroceryData.fromJson(json);
-      }
-    } catch (_) {}
-    return const GroceryData();
   }
 }

--- a/monthy_budget_flutter/pubspec.yaml
+++ b/monthy_budget_flutter/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.5.0
+  http: ^1.2.0
   fl_chart: ^0.70.2
   intl: ^0.20.0
 


### PR DESCRIPTION
Bundled assets only update when the app is rebuilt. Users with the app already installed never saw new prices. This adds:
- GitHub Pages deployment step to the scrape workflow (gh-pages branch)
- http package + remote fetch with 12-hour TTL in GroceryService
- INTERNET permission in the release AndroidManifest
- Graceful fallback chain: remote → cache → bundled asset

https://claude.ai/code/session_01EJJxfE2ksLUs4bgBoy9zMk