### PR TITLE
feat: add product favorites with settings management and priority dis…

### DIFF
--- a/monthy_budget_flutter/lib/main.dart
+++ b/monthy_budget_flutter/lib/main.dart
@@ -4,6 +4,7 @@ import 'models/grocery_data.dart';
 import 'utils/calculations.dart';
 import 'services/settings_service.dart';
 import 'services/grocery_service.dart';
+import 'services/favorites_service.dart';
 import 'screens/dashboard_screen.dart';
 import 'screens/settings_screen.dart';
 import 'screens/grocery_screen.dart';
@@ -39,8 +40,10 @@ class AppHome extends StatefulWidget {
 class _AppHomeState extends State<AppHome> {
   final _settingsService = SettingsService();
   final _groceryService = GroceryService();
+  final _favoritesService = FavoritesService();
   AppSettings _settings = const AppSettings();
   GroceryData _groceryData = const GroceryData();
+  List<String> _favorites = [];
   bool _loaded = false;
   int _currentIndex = 0;
 
@@ -54,10 +57,12 @@ class _AppHomeState extends State<AppHome> {
     final results = await Future.wait([
       _settingsService.load(),
       _groceryService.load(),
+      _favoritesService.load(),
     ]);
     setState(() {
       _settings = results[0] as AppSettings;
       _groceryData = results[1] as GroceryData;
+      _favorites = results[2] as List<String>;
       _loaded = true;
     });
   }
@@ -67,6 +72,13 @@ class _AppHomeState extends State<AppHome> {
       _settings = settings;
     });
     _settingsService.save(settings);
+  }
+
+  void _saveFavorites(List<String> favorites) {
+    setState(() {
+      _favorites = favorites;
+    });
+    _favoritesService.save(favorites);
   }
 
   @override
@@ -106,12 +118,18 @@ class _AppHomeState extends State<AppHome> {
               builder: (_) => SettingsScreen(
                 settings: _settings,
                 onSave: _saveSettings,
+                favorites: _favorites,
+                onSaveFavorites: _saveFavorites,
               ),
             ),
           );
         },
       ),
-      GroceryScreen(groceryData: _groceryData),
+      GroceryScreen(
+        groceryData: _groceryData,
+        favorites: _favorites,
+        onFavoritesChanged: _saveFavorites,
+      ),
     ];
 
     return Scaffold(

--- a/monthy_budget_flutter/lib/screens/grocery_screen.dart
+++ b/monthy_budget_flutter/lib/screens/grocery_screen.dart
@@ -4,8 +4,15 @@ import '../utils/formatters.dart';
 
 class GroceryScreen extends StatefulWidget {
   final GroceryData groceryData;
+  final List<String> favorites;
+  final ValueChanged<List<String>> onFavoritesChanged;
 
-  const GroceryScreen({super.key, required this.groceryData});
+  const GroceryScreen({
+    super.key,
+    required this.groceryData,
+    required this.favorites,
+    required this.onFavoritesChanged,
+  });
 
   @override
   State<GroceryScreen> createState() => _GroceryScreenState();
@@ -15,6 +22,7 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
   late TabController _tabController;
   String _searchQuery = '';
   String? _selectedCategory;
+  bool _showFavoritesOnly = false;
 
   @override
   void initState() {
@@ -26,6 +34,29 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
   void dispose() {
     _tabController.dispose();
     super.dispose();
+  }
+
+  bool _isFavorite(String productName) {
+    final lower = productName.toLowerCase();
+    return widget.favorites.any((fav) => lower.contains(fav.toLowerCase()));
+  }
+
+  void _toggleFavoriteFromProduct(String productName) {
+    // Find which favorite keyword matched, or add the product name as a new favorite
+    final lower = productName.toLowerCase();
+    final matchIdx = widget.favorites.indexWhere((f) => lower.contains(f.toLowerCase()));
+    final updated = List<String>.from(widget.favorites);
+    if (matchIdx >= 0) {
+      updated.removeAt(matchIdx);
+    } else {
+      // Extract a short keyword: first 2-3 meaningful words
+      final words = productName.split(RegExp(r'\s+'))
+          .where((w) => w.length > 2)
+          .take(3)
+          .join(' ');
+      if (words.isNotEmpty) updated.add(words);
+    }
+    widget.onFavoritesChanged(updated);
   }
 
   @override
@@ -177,9 +208,18 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
       );
     }
 
-    final filtered = _searchQuery.isEmpty
+    // Filter by search
+    var filtered = _searchQuery.isEmpty
         ? comparisons
         : comparisons.where((c) => c.productName.toLowerCase().contains(_searchQuery.toLowerCase())).toList();
+
+    // Separate favorites from rest
+    final favItems = filtered.where((c) => _isFavorite(c.productName)).toList();
+    final otherItems = filtered.where((c) => !_isFavorite(c.productName)).toList();
+
+    // When toggle is on, show only favorites
+    final displayItems = _showFavoritesOnly ? favItems : [...favItems, ...otherItems];
+    final hasFavorites = widget.favorites.isNotEmpty;
 
     return Column(
       children: [
@@ -211,10 +251,49 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
             children: [
               Icon(Icons.savings, size: 14, color: Colors.green.shade400),
               const SizedBox(width: 6),
-              Text(
-                '${filtered.length} produtos comparáveis',
-                style: const TextStyle(fontSize: 12, color: Color(0xFF64748B), fontWeight: FontWeight.w500),
+              Expanded(
+                child: Text(
+                  '${filtered.length} produtos comparáveis',
+                  style: const TextStyle(fontSize: 12, color: Color(0xFF64748B), fontWeight: FontWeight.w500),
+                ),
               ),
+              if (hasFavorites)
+                GestureDetector(
+                  onTap: () => setState(() => _showFavoritesOnly = !_showFavoritesOnly),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                    decoration: BoxDecoration(
+                      color: _showFavoritesOnly
+                          ? const Color(0xFFEF4444).withValues(alpha: 0.08)
+                          : Colors.white,
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                        color: _showFavoritesOnly
+                            ? const Color(0xFFEF4444).withValues(alpha: 0.4)
+                            : const Color(0xFFE2E8F0),
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          _showFavoritesOnly ? Icons.favorite : Icons.favorite_border,
+                          size: 13,
+                          color: _showFavoritesOnly ? const Color(0xFFEF4444) : const Color(0xFF94A3B8),
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          'Favoritos',
+                          style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: _showFavoritesOnly ? const Color(0xFFEF4444) : const Color(0xFF94A3B8),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
             ],
           ),
         ),
@@ -222,8 +301,38 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
         Expanded(
           child: ListView.builder(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: filtered.length,
-            itemBuilder: (_, i) => _buildComparisonCard(filtered[i]),
+            itemCount: displayItems.length + (hasFavorites && !_showFavoritesOnly && favItems.isNotEmpty && otherItems.isNotEmpty ? 1 : 0),
+            itemBuilder: (_, i) {
+              // Insert a separator between favorites and the rest
+              final separatorIndex = favItems.length;
+              if (hasFavorites && !_showFavoritesOnly && favItems.isNotEmpty && otherItems.isNotEmpty && i == separatorIndex) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Row(
+                    children: [
+                      Expanded(child: Container(height: 1, color: const Color(0xFFE2E8F0))),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Text(
+                          'OUTROS PRODUTOS',
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.grey.shade400,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                      ),
+                      Expanded(child: Container(height: 1, color: const Color(0xFFE2E8F0))),
+                    ],
+                  ),
+                );
+              }
+              final idx = (hasFavorites && !_showFavoritesOnly && favItems.isNotEmpty && otherItems.isNotEmpty && i > separatorIndex)
+                  ? i - 1
+                  : i;
+              return _buildComparisonCard(displayItems[idx]);
+            },
           ),
         ),
       ],
@@ -231,18 +340,23 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
   }
 
   Widget _buildComparisonCard(ProductComparison comparison) {
+    final isFav = _isFavorite(comparison.productName);
+
     return Container(
       margin: const EdgeInsets.only(bottom: 10),
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: isFav ? const Color(0xFFFFF5F5) : Colors.white,
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: const Color(0xFFF1F5F9)),
+        border: Border.all(
+          color: isFav ? const Color(0xFFEF4444).withValues(alpha: 0.2) : const Color(0xFFF1F5F9),
+        ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Expanded(
                 child: Text(
@@ -252,6 +366,7 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
+              const SizedBox(width: 8),
               if (comparison.potentialSavings > 0)
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
@@ -264,6 +379,18 @@ class _GroceryScreenState extends State<GroceryScreen> with SingleTickerProvider
                     style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: Color(0xFF059669)),
                   ),
                 ),
+              const SizedBox(width: 6),
+              GestureDetector(
+                onTap: () => _toggleFavoriteFromProduct(comparison.productName),
+                child: Padding(
+                  padding: const EdgeInsets.all(2),
+                  child: Icon(
+                    isFav ? Icons.favorite : Icons.favorite_border,
+                    size: 20,
+                    color: isFav ? const Color(0xFFEF4444) : const Color(0xFFCBD5E1),
+                  ),
+                ),
+              ),
             ],
           ),
           const SizedBox(height: 10),

--- a/monthy_budget_flutter/lib/screens/settings_screen.dart
+++ b/monthy_budget_flutter/lib/screens/settings_screen.dart
@@ -6,8 +6,16 @@ import '../utils/formatters.dart';
 class SettingsScreen extends StatefulWidget {
   final AppSettings settings;
   final ValueChanged<AppSettings> onSave;
+  final List<String> favorites;
+  final ValueChanged<List<String>> onSaveFavorites;
 
-  const SettingsScreen({super.key, required this.settings, required this.onSave});
+  const SettingsScreen({
+    super.key,
+    required this.settings,
+    required this.onSave,
+    required this.favorites,
+    required this.onSaveFavorites,
+  });
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -15,12 +23,30 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   late AppSettings _draft;
+  late List<String> _favorites;
   String? _openSection = 'personal';
+  final _customProductController = TextEditingController();
+
+  static const _suggestions = [
+    'Leite', 'Pao', 'Ovos', 'Arroz', 'Massa', 'Manteiga',
+    'Iogurte', 'Queijo', 'Frango', 'Carne', 'Peixe', 'Atum',
+    'Tomate', 'Batata', 'Cebola', 'Alho', 'Cenoura',
+    'Macas', 'Bananas', 'Laranjas', 'Uvas',
+    'Azeite', 'Cafe', 'Acucar', 'Agua', 'Sumo', 'Cerveja',
+    'Detergente', 'Papel Higienico', 'Champô',
+  ];
 
   @override
   void initState() {
     super.initState();
     _draft = widget.settings;
+    _favorites = List<String>.from(widget.favorites);
+  }
+
+  @override
+  void dispose() {
+    _customProductController.dispose();
+    super.dispose();
   }
 
   bool get _isCasado =>
@@ -35,7 +61,31 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   void _handleSave() {
     widget.onSave(_draft);
+    widget.onSaveFavorites(_favorites);
     Navigator.of(context).pop();
+  }
+
+  void _toggleFavorite(String product) {
+    setState(() {
+      final lower = product.toLowerCase();
+      final idx = _favorites.indexWhere((f) => f.toLowerCase() == lower);
+      if (idx >= 0) {
+        _favorites.removeAt(idx);
+      } else {
+        _favorites.add(product);
+      }
+    });
+  }
+
+  void _addCustomProduct() {
+    final text = _customProductController.text.trim();
+    if (text.isEmpty) return;
+    final lower = text.toLowerCase();
+    if (_favorites.any((f) => f.toLowerCase() == lower)) return;
+    setState(() {
+      _favorites.add(text);
+      _customProductController.clear();
+    });
   }
 
   void _addExpense() {
@@ -159,6 +209,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       onTap: () => _toggleSection('dashboard'),
                     ),
                     if (_openSection == 'dashboard') _buildDashboardSection(),
+                    _SectionHeader(
+                      icon: Icons.favorite,
+                      title: 'Produtos Favoritos',
+                      isOpen: _openSection == 'favorites',
+                      onTap: () => _toggleSection('favorites'),
+                    ),
+                    if (_openSection == 'favorites') _buildFavoritesSection(),
                     const SizedBox(height: 32),
                   ],
                 ),
@@ -573,6 +630,132 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 onChanged: (_) => _toggleChart(chart),
               )),
         ],
+      ),
+    );
+  }
+
+  Widget _buildFavoritesSection() {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Info box
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFFF7ED),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: const Color(0xFFFED7AA)),
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.tips_and_updates, size: 18, color: Color(0xFFF97316)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    'Os produtos favoritos aparecem em destaque no topo das comparacoes.',
+                    style: TextStyle(fontSize: 12, color: Colors.orange.shade800, height: 1.4),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          // Current favorites
+          if (_favorites.isNotEmpty) ...[
+            _label('OS MEUS FAVORITOS'),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _favorites.map((f) => _buildFavoriteChip(f, isSelected: true)).toList(),
+            ),
+            const SizedBox(height: 20),
+          ],
+          // Add custom
+          _label('ADICIONAR PRODUTO'),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _customProductController,
+                  onSubmitted: (_) => _addCustomProduct(),
+                  decoration: _inputDecoration('ex: Cereais, Salmao...').copyWith(
+                    prefixIcon: const Icon(Icons.add, size: 18, color: Color(0xFF94A3B8)),
+                    contentPadding: const EdgeInsets.symmetric(vertical: 12),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 46,
+                child: ElevatedButton(
+                  onPressed: _addCustomProduct,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF3B82F6),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    elevation: 0,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                  child: const Icon(Icons.add, size: 20),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          // Suggestions
+          _label('SUGESTOES'),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: _suggestions.map((s) {
+              final isSelected = _favorites.any((f) => f.toLowerCase() == s.toLowerCase());
+              return _buildFavoriteChip(s, isSelected: isSelected);
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFavoriteChip(String label, {required bool isSelected}) {
+    return GestureDetector(
+      onTap: () => _toggleFavorite(label),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? const Color(0xFFEF4444).withValues(alpha: 0.08) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: isSelected ? const Color(0xFFEF4444).withValues(alpha: 0.4) : const Color(0xFFE2E8F0),
+            width: isSelected ? 1.5 : 1,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              isSelected ? Icons.favorite : Icons.favorite_border,
+              size: 14,
+              color: isSelected ? const Color(0xFFEF4444) : const Color(0xFFCBD5E1),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+                color: isSelected ? const Color(0xFFEF4444) : const Color(0xFF64748B),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/monthy_budget_flutter/lib/services/favorites_service.dart
+++ b/monthy_budget_flutter/lib/services/favorites_service.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _storageKey = 'grocery_favorites';
+
+class FavoritesService {
+  Future<List<String>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_storageKey);
+    if (raw == null) return [];
+    try {
+      return List<String>.from(json.decode(raw));
+    } catch (_) {
+      return [];
+    }
+  }
+
+  Future<void> save(List<String> favorites) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, json.encode(favorites));
+  }
+}


### PR DESCRIPTION
…play

Settings → new "Produtos Favoritos" section:
- 29 curated Portuguese grocery suggestion chips (Leite, Pão, Ovos, Arroz…)
- Custom product text field to add anything not in suggestions
- Tap chips to toggle on/off, visual heart icon + red tint for selected
- Orange info banner explaining how favorites work

Grocery → Comparisons tab integration:
- Heart icon on every comparison card to quick-toggle favorites
- Favorite products float to top of the list automatically
- Visual separator "OUTROS PRODUTOS" divides favorites from rest
- Favorite cards get subtle red tint background + red border
- "Favoritos" filter chip to show only favorites
- Keyword matching: favorite "Leite" matches any product containing "leite"

Persistence:
- New FavoritesService (SharedPreferences, key: grocery_favorites)
- Loaded at app startup alongside settings and grocery data
- Synced bidirectionally between Settings and Grocery screens

https://claude.ai/code/session_0196dqBxm4urk2nFvMv2fy15