### PR TITLE
claude/budget-calculator-app: fix PR review issues — category overrid…

### DIFF
--- a/monthy_budget_flutter/lib/models/actual_expense.dart
+++ b/monthy_budget_flutter/lib/models/actual_expense.dart
@@ -149,13 +149,17 @@ class CategoryBudgetSummary {
           (actualsByCategory['alimentacao'] ?? 0) + foodPurchaseSpent;
     }
 
-    final budgetByCategory = <String, double>{};
+    // Sum per-category default amounts, then apply monthly overrides
+    final defaultByCategory = <String, double>{};
     for (final item in budgetItems) {
       if (!item.enabled) continue;
       final catName = item.category.name;
-      final effectiveAmount = monthlyBudgets[catName] ?? item.amount;
-      budgetByCategory[catName] =
-          (budgetByCategory[catName] ?? 0) + effectiveAmount;
+      defaultByCategory[catName] =
+          (defaultByCategory[catName] ?? 0) + item.amount;
+    }
+    final budgetByCategory = <String, double>{};
+    for (final entry in defaultByCategory.entries) {
+      budgetByCategory[entry.key] = monthlyBudgets[entry.key] ?? entry.value;
     }
 
     final allCategories = <String>{

--- a/monthy_budget_flutter/lib/utils/budget_streaks.dart
+++ b/monthy_budget_flutter/lib/utils/budget_streaks.dart
@@ -52,21 +52,21 @@ AllStreaks calculateStreaks({
 
   if (monthKeys.isEmpty) return const AllStreaks();
 
-  // Calculate total budget from expense items
-  final totalBudget = expenses
-      .where((e) => e.enabled)
-      .fold(0.0, (sum, e) {
-    return sum + (monthlyBudgets[e.category.name] ?? e.amount);
-  });
-
-  // Per-category budgets
-  final budgetByCategory = <String, double>{};
+  // Sum per-category default amounts from expense items
+  final defaultByCategory = <String, double>{};
   for (final item in expenses) {
     if (!item.enabled) continue;
     final catName = item.category.name;
-    final effectiveAmount = monthlyBudgets[catName] ?? item.amount;
-    budgetByCategory[catName] = (budgetByCategory[catName] ?? 0) + effectiveAmount;
+    defaultByCategory[catName] = (defaultByCategory[catName] ?? 0) + item.amount;
   }
+
+  // Apply monthly overrides at category level
+  final budgetByCategory = <String, double>{};
+  for (final entry in defaultByCategory.entries) {
+    budgetByCategory[entry.key] = monthlyBudgets[entry.key] ?? entry.value;
+  }
+
+  final totalBudget = budgetByCategory.values.fold(0.0, (sum, v) => sum + v);
 
   int bronzeCount = 0;
   int silverCount = 0;

--- a/monthy_budget_flutter/lib/utils/calculations.dart
+++ b/monthy_budget_flutter/lib/utils/calculations.dart
@@ -134,10 +134,14 @@ BudgetSummary calculateBudgetSummary(
   final totalSS = calcs.fold(0.0, (sum, s) => sum + s.socialSecurity + s.mealAllowance.ssTaxOnMeal);
   final totalDeductions = totalIRS + totalSS;
 
-  final totalExpenses = expenses
-      .where((e) => e.enabled)
-      .fold(0.0, (sum, e) {
-    return sum + (monthlyBudgets[e.category.name] ?? e.amount);
+  // Sum per-category default amounts, then apply monthly overrides
+  final defaultByCategory = <String, double>{};
+  for (final e in expenses.where((e) => e.enabled)) {
+    defaultByCategory[e.category.name] =
+        (defaultByCategory[e.category.name] ?? 0) + e.amount;
+  }
+  final totalExpenses = defaultByCategory.entries.fold(0.0, (sum, entry) {
+    return sum + (monthlyBudgets[entry.key] ?? entry.value);
   });
 
   final netLiquidity = _round2(totalNetWithMeal - totalExpenses);

--- a/monthy_budget_flutter/scripts/scrape_supermarkets_and_generate_updates.cjs
+++ b/monthy_budget_flutter/scripts/scrape_supermarkets_and_generate_updates.cjs
@@ -390,9 +390,14 @@ function unitFromName(name) {
   return 'un';
 }
 
-function bestMatchesForProduct(productName, scrapedItems) {
+function bestMatchesForProduct(productName, scrapedItems, productUnit) {
   const byStore = new Map();
   for (const it of scrapedItems) {
+    // Filter by unit compatibility when product unit is known
+    if (productUnit) {
+      const scrapedUnit = unitFromName(it.name);
+      if (scrapedUnit !== productUnit) continue;
+    }
     const score = similarity(productName, it.name);
     if (score < MATCH_MIN_SCORE) continue;
     if (tokenIntersectionCount(productName, it.name) < 1) continue;
@@ -498,7 +503,7 @@ async function main() {
 
   const updates = [];
   for (const p of existingProducts) {
-    const matches = bestMatchesForProduct(p.name, cleaned);
+    const matches = bestMatchesForProduct(p.name, cleaned, p.unit);
     if (matches.length < UPDATE_MIN_STORES) continue;
     const avgScore = matches.reduce((acc, x) => acc + x.score, 0) / matches.length;
     if (avgScore < UPDATE_MIN_AVG_SCORE) continue;

--- a/monthy_budget_flutter/test/screens/paywall_screen_test.dart
+++ b/monthy_budget_flutter/test/screens/paywall_screen_test.dart
@@ -87,8 +87,9 @@ void main() {
       });
 
       testWidgets('shows CTA labels for each tier', (tester) async {
+        // Use active trial so Free card is not "Current Plan"
         final state = SubscriptionState(
-          trialStartDate: DateTime.now().subtract(const Duration(days: 30)),
+          trialStartDate: DateTime.now(),
         );
 
         await tester.pumpWidget(_wrap(
@@ -316,6 +317,8 @@ void main() {
           ),
         ));
 
+        await tester.scrollUntilVisible(find.text('Start Premium'), 200);
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Start Premium'));
         expect(selectedTier, SubscriptionTier.premium);
       });
@@ -334,6 +337,8 @@ void main() {
           ),
         ));
 
+        await tester.scrollUntilVisible(find.text('Start Family'), 200);
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Start Family'));
         expect(selectedTier, SubscriptionTier.family);
       });
@@ -341,8 +346,9 @@ void main() {
       testWidgets('calls onSelectTier with free when "Continue Free" tapped',
           (tester) async {
         SubscriptionTier? selectedTier;
+        // Use active trial so Free card shows "Continue Free" (not "Current Plan")
         final state = SubscriptionState(
-          trialStartDate: DateTime.now().subtract(const Duration(days: 30)),
+          trialStartDate: DateTime.now(),
         );
 
         await tester.pumpWidget(_wrap(

--- a/monthy_budget_flutter/test/widgets/feature_discovery_card_test.dart
+++ b/monthy_budget_flutter/test/widgets/feature_discovery_card_test.dart
@@ -242,7 +242,7 @@ void main() {
         PremiumLockOverlay(
           isLocked: true,
           onTapLocked: () {},
-          child: const Text('Locked Content'),
+          child: const SizedBox(width: 200, height: 200, child: Text('Locked Content')),
         ),
       ));
 
@@ -255,7 +255,7 @@ void main() {
         PremiumLockOverlay(
           isLocked: true,
           onTapLocked: () {},
-          child: const Text('Content'),
+          child: const SizedBox(width: 200, height: 200, child: Text('Content')),
         ),
       ));
 
@@ -268,7 +268,7 @@ void main() {
           isLocked: true,
           onTapLocked: () {},
           featureName: 'AI Coach',
-          child: const Text('Content'),
+          child: const SizedBox(width: 200, height: 200, child: Text('Content')),
         ),
       ));
 
@@ -295,7 +295,7 @@ void main() {
         PremiumLockOverlay(
           isLocked: true,
           onTapLocked: () {},
-          child: const Text('Dimmed'),
+          child: const SizedBox(width: 200, height: 200, child: Text('Dimmed')),
         ),
       ));
 
@@ -308,11 +308,14 @@ void main() {
         PremiumLockOverlay(
           isLocked: true,
           onTapLocked: () {},
-          child: const Text('Locked'),
+          child: const SizedBox(width: 200, height: 200, child: Text('Locked')),
         ),
       ));
 
-      final absorber = tester.widget<AbsorbPointer>(find.byType(AbsorbPointer));
+      final absorber = tester.widget<AbsorbPointer>(find.descendant(
+        of: find.byType(PremiumLockOverlay),
+        matching: find.byType(AbsorbPointer),
+      ));
       expect(absorber.absorbing, true);
     });
   });


### PR DESCRIPTION
…e duplication, scraper unit filtering, test failures

Fix monthly budget override applied per-expense-row instead of per-category (inflating totals when multiple expenses share a category). Add unit filtering to scraper product matching to prevent mixing kg/L/un prices. Fix 9 pre-existing subscription test failures: paywall tests used expired-trial state causing wrong CTA labels and off-screen taps, PremiumLockOverlay tests had unconstrained layout overflow and ambiguous AbsorbPointer finder.