### PR TITLE
chore(release): v2026.3.8

### DIFF
--- a/monthy_budget_flutter/CHANGELOG.md
+++ b/monthy_budget_flutter/CHANGELOG.md
@@ -2,46 +2,69 @@
 
 All notable changes to this project will be documented in this file.
 
-## v2026.3.5 - 2026-03-06
+## v2026.3.8 - 2026-03-09
 
 
 
-### Bug Fixes
+### Documentation
 
-- Align release build with Supabase dart-defines (#77) (#85) ([object], [object], [object], [object])
+- Design multi-country pricing architecture (#217) (#218) ([object], [object], [object], [object], [object], [object], [object])
+
+- Add scale-out preparation guidance (#346) (Fixes #346) ([object], [object], [object])
+
+
+### Features
+
+- Make asset loading country-aware (#231) (Fixes #231) ([object], [object], [object])
+
+- Add freshness and stale-store UX (#340) (Fixes #340) ([object], [object], [object])
+
+- Complete milestone 5 country-aware rollout (#326) (Fixes #326) ([object], [object], [object])
 
 
 ### Other Changes
 
-- Claude/new-session-HsuIN (#79)
+- Fix agent-delivery extracting wrong issue number from commits (#225) ([object], [object], [object])
 
-* fix: show user-friendly auth error messages instead of raw exceptions
+- Add coverage reporting, l10n validation, and SAST to CI/CD #132 (#248) ([object], [object], [object], [object])
 
-Map Supabase auth exceptions (network errors, invalid credentials,
-unconfirmed email, rate limits) to localized user-facing messages
-in EN, PT, ES, and FR.
+- Add constructor validation for monetary fields #122 (#249) ([object], [object])
 
-https://claude.ai/code/session_01B5gGgK1EpvMvLPgMR1Qt2o
+- Refactor main.dart - split AppHome into separate files #124 (#256) ([object], [object])
 
-* fix: fail CI build when Supabase secrets are missing
+- Replace hardcoded strings with localized equivalents #123 (#259) ([object], [object])
 
-Instead of silently falling back to placeholder values when
-SUPABASE_URL or SUPABASE_ANON_KEY secrets are not configured,
-the build job now fails immediately with a clear error message.
-This prevents releasing APKs with broken Supabase configuration.
+- Fix UTF-8 encoding issues in Spanish and French ARB files #134 (#255) ([object], [object])
 
-https://claude.ai/code/session_01B5gGgK1EpvMvLPgMR1Qt2o
+- Add ParsedReceipt and ReceiptLineItem models #273 (Fixes #273) ([object], [object], [object])
 
-* fix: restore authError getters dropped during merge
+- Add receipt scanner localization strings #286 (Fixes #286) ([object], [object], [object])
 
-The merge from origin/main overwrote the generated l10n files,
-dropping 5 authError* getters that were added on this branch.
-Re-added them to all locale files.
+- Add google_mlkit_text_recognition and image_picker deps #277 (Fixes #277) ([object], [object], [object])
 
-https://claude.ai/code/session_01B5gGgK1EpvMvLPgMR1Qt2o
+- Implement ATCUD QR code parser for Portuguese invoices #274 (Fixes #274) ([object], [object], [object])
 
----------
+- Implement receipt text parser for Portuguese receipts #278 (Fixes #278) ([object], [object], [object])
 
-Co-authored-by: lfrmonteiro99 <lfrmonteiro99@gmail.com>
-Co-authored-by: Claude <noreply@anthropic.com> ([object])
+- Implement fuzzy matching for receipt items #279 (Fixes #279) ([object], [object], [object])
+
+- Add AI fallback matching for unmapped receipt items #280 (Fixes #280) ([object], [object], [object])
+
+- Fix unnecessary cast in MerchantRegistryService #276 (Fixes #276) ([object], [object], [object])
+
+- Implement ReceiptScanService QR code pipeline #281 (Fixes #281) ([object], [object], [object])
+
+- Add OCR pipeline and full scan orchestration #282 (Fixes #282) ([object], [object], [object])
+
+- Show scan receipt prompt when all shopping items checked #285 (Fixes #283) ([object], [object], [object])
+
+- Merge branch 'main' into issue-220-store-scraper-interface
+
+- Handle scanReceipt case in app_home switch #284 (Fixes #284) ([object], [object], [object])
+
+- Include receipt scanner l10n keys for post-shopping prompt #285 (Fixes #285) ([object], [object], [object])
+
+- Add quantity/unit to ShoppingItem, fix dedup aggregation, hide empty tabs #332 #333 #334 (Fixes #332) ([object], [object], [object], [object], [object])
+
+- Replace sourceMealLabel with sourceMealLabels (N:N) (Fixes #338) ([object], [object])
 

--- a/monthy_budget_flutter/pubspec.yaml
+++ b/monthy_budget_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: orcamento_mensal
 description: "Calculadora de Orcamento Mensal - Portuguese monthly budget calculator with IRS tax tables"
 publish_to: 'none'
 
-version: 2026.3.5+260300005
+version: 2026.3.8+260300008
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Linked Issue
Fixes #360

## Release Notes
- Replace `sourceMealLabel` with `sourceMealLabels` (N:N meal-to-ingredient relationships)
- Meal planner tracks recipe names per ingredient for shopping list
- `mergeIntoList` unions meal labels on deduplication
- `groupByMeal` supports items in multiple meal groups
- Supabase migration: `source_meal_labels text[]` column
- Grocery milestone 5: country-aware rollout

## Release
`release:minor`