### PR TITLE
Wire expense attachment upload to Supabase Storage

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -484,7 +484,7 @@ class _AppHomeState extends State<AppHome> with WidgetsBindingObserver {
   ({String category, double percent})? _topCategoryUsage() {
     final budgetByCategory = <String, double>{};
     for (final item in _settings.expenses.where((e) => e.enabled && e.amount > 0)) {
-      budgetByCategory.update(item.category.name, (v) => v + item.amount,
+      budgetByCategory.update(item.category, (v) => v + item.amount,
           ifAbsent: () => item.amount);
     }
     if (budgetByCategory.isEmpty) return null;
@@ -1351,7 +1351,22 @@ class _AppHomeState extends State<AppHome> with WidgetsBindingObserver {
       customCategories: _customCategories,
     );
     if (result != null) {
-      _addActualExpense(result.expense);
+      var expense = result.expense;
+      if (result.newAttachmentFiles.isNotEmpty) {
+        final urls = await _actualExpenseService.uploadAttachments(
+          result.newAttachmentFiles,
+          widget.householdId,
+          expense.id,
+        );
+        if (urls.isNotEmpty) {
+          final allUrls = [
+            ...?expense.attachmentUrls,
+            ...urls,
+          ];
+          expense = expense.copyWith(attachmentUrls: allUrls);
+        }
+      }
+      _addActualExpense(expense);
     }
   }
 

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/add_expense_sheet.dart';
 import '../widgets/export_bottom_sheet.dart';
 import '../widgets/info_icon_button.dart';
 import '../services/export_service.dart';
+import '../services/actual_expense_service.dart';
 import '../onboarding/expense_tracker_tour.dart';
 
 class ExpenseTrackerScreen extends StatefulWidget {
@@ -65,6 +66,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
 
   final _searchController = TextEditingController();
   final _exportService = ExportService();
+  final _expenseService = ActualExpenseService();
   bool _tourShown = false;
   TutorialCoachMark? _activeTour;
 
@@ -128,7 +130,21 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
       customCategories: widget.customCategories,
     );
     if (result != null && mounted) {
-      final expense = result.expense;
+      var expense = result.expense;
+      if (result.newAttachmentFiles.isNotEmpty) {
+        final urls = await _expenseService.uploadAttachments(
+          result.newAttachmentFiles,
+          widget.householdId,
+          expense.id,
+        );
+        if (urls.isNotEmpty) {
+          final allUrls = [
+            ...?expense.attachmentUrls,
+            ...urls,
+          ];
+          expense = expense.copyWith(attachmentUrls: allUrls);
+        }
+      }
       await widget.onAdd(expense);
       setState(() => _expenses = [..._expenses, expense]
         ..sort((a, b) => b.date.compareTo(a.date)));
@@ -145,7 +161,21 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
       onDelete: _deleteExpense,
     );
     if (result != null && mounted) {
-      final updated = result.expense;
+      var updated = result.expense;
+      if (result.newAttachmentFiles.isNotEmpty) {
+        final urls = await _expenseService.uploadAttachments(
+          result.newAttachmentFiles,
+          widget.householdId,
+          updated.id,
+        );
+        if (urls.isNotEmpty) {
+          final allUrls = [
+            ...?updated.attachmentUrls,
+            ...urls,
+          ];
+          updated = updated.copyWith(attachmentUrls: allUrls);
+        }
+      }
       await widget.onUpdate(updated);
       setState(() {
         _expenses = _expenses

--- a/monthy_budget_flutter/lib/services/actual_expense_service.dart
+++ b/monthy_budget_flutter/lib/services/actual_expense_service.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../models/actual_expense.dart';
 
@@ -32,7 +35,47 @@ class ActualExpenseService {
           '${expense.date.year}-${expense.date.month.toString().padLeft(2, '0')}-${expense.date.day.toString().padLeft(2, '0')}',
       'description': expense.description,
       'month_key': expense.monthKey,
+      'attachment_urls': expense.attachmentUrls,
+      'location_lat': expense.locationLat,
+      'location_lng': expense.locationLng,
+      'location_address': expense.locationAddress,
     }).eq('id', expense.id);
+  }
+
+  /// Uploads [files] to Supabase Storage under
+  /// `expense-attachments/$householdId/$expenseId/` and returns the public URLs.
+  ///
+  /// Handles missing bucket gracefully by logging and returning an empty list.
+  Future<List<String>> uploadAttachments(
+    List<File> files,
+    String householdId,
+    String expenseId,
+  ) async {
+    if (files.isEmpty) return [];
+
+    final urls = <String>[];
+    const bucket = 'expense-attachments';
+
+    for (final file in files) {
+      final fileName = file.path.split(Platform.pathSeparator).last;
+      final storagePath = '$householdId/$expenseId/$fileName';
+
+      try {
+        await _client.storage.from(bucket).upload(
+              storagePath,
+              file,
+              fileOptions: const FileOptions(upsert: true),
+            );
+        final publicUrl =
+            _client.storage.from(bucket).getPublicUrl(storagePath);
+        urls.add(publicUrl);
+      } catch (e) {
+        debugPrint('Failed to upload attachment $fileName: $e');
+        // Continue with remaining files rather than aborting the whole batch.
+      }
+    }
+
+    return urls;
   }
 
   Future<void> delete(String id) async {

--- a/monthy_budget_flutter/test/models/actual_expense_test.dart
+++ b/monthy_budget_flutter/test/models/actual_expense_test.dart
@@ -218,6 +218,128 @@ void main() {
       });
     });
 
+    group('toSupabase attachment and location fields', () {
+      test('includes attachment_urls when present', () {
+        final expense = ActualExpense(
+          id: 'exp_att',
+          category: 'outros',
+          amount: 10.0,
+          date: DateTime(2026, 3, 5),
+          monthKey: '2026-03',
+          attachmentUrls: ['https://storage/a.jpg', 'https://storage/b.jpg'],
+        );
+
+        final map = expense.toSupabase('hh_1');
+        expect(map['attachment_urls'], ['https://storage/a.jpg', 'https://storage/b.jpg']);
+      });
+
+      test('omits attachment_urls when null', () {
+        final expense = ActualExpense(
+          id: 'exp_noatt',
+          category: 'outros',
+          amount: 10.0,
+          date: DateTime(2026, 3, 5),
+          monthKey: '2026-03',
+        );
+
+        final map = expense.toSupabase('hh_1');
+        expect(map.containsKey('attachment_urls'), false);
+      });
+
+      test('omits attachment_urls when empty list', () {
+        final expense = ActualExpense(
+          id: 'exp_empty',
+          category: 'outros',
+          amount: 10.0,
+          date: DateTime(2026, 3, 5),
+          monthKey: '2026-03',
+          attachmentUrls: [],
+        );
+
+        final map = expense.toSupabase('hh_1');
+        expect(map.containsKey('attachment_urls'), false);
+      });
+
+      test('includes location fields when present', () {
+        final expense = ActualExpense(
+          id: 'exp_loc',
+          category: 'alimentacao',
+          amount: 25.0,
+          date: DateTime(2026, 3, 10),
+          monthKey: '2026-03',
+          locationLat: 38.7223,
+          locationLng: -9.1393,
+          locationAddress: 'Lisbon, Portugal',
+        );
+
+        final map = expense.toSupabase('hh_1');
+        expect(map['location_lat'], 38.7223);
+        expect(map['location_lng'], -9.1393);
+        expect(map['location_address'], 'Lisbon, Portugal');
+      });
+
+      test('omits location fields when null', () {
+        final expense = ActualExpense(
+          id: 'exp_noloc',
+          category: 'outros',
+          amount: 10.0,
+          date: DateTime(2026, 3, 5),
+          monthKey: '2026-03',
+        );
+
+        final map = expense.toSupabase('hh_1');
+        expect(map.containsKey('location_lat'), false);
+        expect(map.containsKey('location_lng'), false);
+        expect(map.containsKey('location_address'), false);
+      });
+    });
+
+    group('fromSupabase attachment and location fields', () {
+      test('parses attachment_urls and location fields', () {
+        final map = {
+          'id': 'exp_full',
+          'category': 'alimentacao',
+          'amount': 42.5,
+          'expense_date': '2026-03-10',
+          'description': null,
+          'month_key': '2026-03',
+          'attachment_urls': ['https://storage/a.jpg'],
+          'location_lat': 38.7223,
+          'location_lng': -9.1393,
+          'location_address': 'Lisbon',
+        };
+
+        final expense = ActualExpense.fromSupabase(map);
+
+        expect(expense.attachmentUrls, ['https://storage/a.jpg']);
+        expect(expense.locationLat, 38.7223);
+        expect(expense.locationLng, -9.1393);
+        expect(expense.locationAddress, 'Lisbon');
+      });
+
+      test('handles null attachment and location fields', () {
+        final map = {
+          'id': 'exp_null',
+          'category': 'lazer',
+          'amount': 15,
+          'expense_date': '2026-01-20',
+          'description': null,
+          'month_key': '2026-01',
+          'attachment_urls': null,
+          'location_lat': null,
+          'location_lng': null,
+          'location_address': null,
+        };
+
+        final expense = ActualExpense.fromSupabase(map);
+
+        expect(expense.attachmentUrls, isNull);
+        expect(expense.locationLat, isNull);
+        expect(expense.locationLng, isNull);
+        expect(expense.locationAddress, isNull);
+      });
+    });
+
     group('copyWith', () {
       final original = ActualExpense(
         id: 'exp_orig',
@@ -269,6 +391,28 @@ void main() {
         expect(copy.amount, 200.0);
         expect(copy.isFromRecurring, true);
         expect(copy.id, original.id);
+      });
+
+      test('updates attachmentUrls via copyWith', () {
+        final copy = original.copyWith(
+          attachmentUrls: ['https://storage/new.jpg'],
+        );
+
+        expect(copy.attachmentUrls, ['https://storage/new.jpg']);
+        expect(copy.id, original.id);
+        expect(copy.category, original.category);
+      });
+
+      test('updates location fields via copyWith', () {
+        final copy = original.copyWith(
+          locationLat: 40.0,
+          locationLng: -8.0,
+          locationAddress: 'Coimbra',
+        );
+
+        expect(copy.locationLat, 40.0);
+        expect(copy.locationLng, -8.0);
+        expect(copy.locationAddress, 'Coimbra');
       });
     });
   });
@@ -380,7 +524,7 @@ void main() {
             id: 'e1',
             label: 'Rent',
             amount: 500,
-            category: ExpenseCategory.habitacao,
+            category: 'habitacao',
             isFixed: true,
             enabled: true,
           ),
@@ -412,7 +556,7 @@ void main() {
             id: 'e_food',
             label: 'Food',
             amount: 300,
-            category: ExpenseCategory.alimentacao,
+            category: 'alimentacao',
             isFixed: true,
             enabled: true,
           ),
@@ -448,7 +592,7 @@ void main() {
             id: 'e_danger',
             label: 'High',
             amount: 310,
-            category: ExpenseCategory.lazer,
+            category: 'lazer',
             isFixed: true,
             enabled: true,
           ),
@@ -516,7 +660,7 @@ void main() {
             id: 'e_hab',
             label: 'Rent',
             amount: 500,
-            category: ExpenseCategory.habitacao,
+            category: 'habitacao',
             isFixed: true,
             enabled: true,
           ),
@@ -555,7 +699,7 @@ void main() {
             id: 'e_dis',
             label: 'Disabled',
             amount: 200,
-            category: ExpenseCategory.saude,
+            category: 'saude',
             isFixed: true,
             enabled: false,
           ),
@@ -577,7 +721,7 @@ void main() {
             id: 'e_var',
             label: 'Variable',
             amount: 0,
-            category: ExpenseCategory.lazer,
+            category: 'lazer',
             isFixed: false,
             enabled: true,
           ),


### PR DESCRIPTION
## Linked Issue
Fixes #506

## Summary
- Added `uploadAttachments()` method to `ActualExpenseService` that uploads files to Supabase Storage bucket `expense-attachments` at path `$householdId/$expenseId/$filename`
- Updated `update()` method in `ActualExpenseService` to persist `attachment_urls`, `location_lat`, `location_lng`, `location_address` fields
- Wired attachment uploads in `ExpenseTrackerScreen._addExpense()` and `_editExpense()` -- files are uploaded before saving the expense, and resulting URLs are merged with any existing ones
- Wired attachment uploads in `AppHome._openAddExpenseSheet()` for the same behavior
- Added model-level tests for attachment/location field serialization (`toSupabase`, `fromSupabase`, `copyWith`)

## Release Notes
Expense attachments (photos) are now uploaded to Supabase Storage when adding or editing expenses. Location and attachment data is now persisted during expense updates.

## Test plan
- [x] `flutter analyze` passes with no new issues
- [x] All 38 model tests pass (`test/models/actual_expense_test.dart`)
- [ ] Manual: add expense with photo attachment, verify file appears in Supabase Storage bucket
- [ ] Manual: edit expense, add new attachment, verify existing URLs preserved and new one added
- [ ] Manual: add expense from app_home FAB with attachment, verify upload works