### PR TITLE
issue-446: persist setup wizard flag when creating households #446

### DIFF
--- a/monthy_budget_flutter/lib/screens/auth/household_setup_screen.dart
+++ b/monthy_budget_flutter/lib/screens/auth/household_setup_screen.dart
@@ -1,18 +1,30 @@
 import 'package:flutter/material.dart';
 import '../../l10n/generated/app_localizations.dart';
+import '../../models/app_settings.dart';
 import '../../services/household_service.dart';
+import '../../services/settings_service.dart';
 import '../../theme/app_colors.dart';
 
 class HouseholdSetupScreen extends StatefulWidget {
   final void Function(HouseholdProfile profile) onSetupComplete;
-  const HouseholdSetupScreen({super.key, required this.onSetupComplete});
+  final Future<HouseholdProfile> Function(String name)? createHousehold;
+  final Future<HouseholdProfile> Function(String inviteCode)? joinHousehold;
+  final Future<void> Function(AppSettings settings, String householdId)?
+      saveSettings;
+
+  const HouseholdSetupScreen({
+    super.key,
+    required this.onSetupComplete,
+    this.createHousehold,
+    this.joinHousehold,
+    this.saveSettings,
+  });
 
   @override
   State<HouseholdSetupScreen> createState() => _HouseholdSetupScreenState();
 }
 
 class _HouseholdSetupScreenState extends State<HouseholdSetupScreen> {
-  final _service = HouseholdService();
   final _nameCtrl = TextEditingController();
   final _codeCtrl = TextEditingController();
   bool _creating = true;
@@ -36,9 +48,21 @@ class _HouseholdSetupScreenState extends State<HouseholdSetupScreen> {
       if (_creating) {
         final name = _nameCtrl.text.trim();
         if (name.isEmpty) throw Exception(S.of(context).householdNameRequired);
-        profile = await _service.createHousehold(name);
+        profile = widget.createHousehold != null
+            ? await widget.createHousehold!(name)
+            : await HouseholdService().createHousehold(name);
+        // Explicitly write setupWizardCompleted: false so the wizard
+        // is guaranteed to appear regardless of what the RPC seeds.
+        if (widget.saveSettings != null) {
+          await widget.saveSettings!(const AppSettings(), profile.householdId);
+        } else {
+          await SettingsService().save(const AppSettings(), profile.householdId);
+        }
       } else {
-        profile = await _service.joinHousehold(_codeCtrl.text.trim());
+        final inviteCode = _codeCtrl.text.trim();
+        profile = widget.joinHousehold != null
+            ? await widget.joinHousehold!(inviteCode)
+            : await HouseholdService().joinHousehold(inviteCode);
       }
       widget.onSetupComplete(profile);
     } catch (e) {

--- a/monthy_budget_flutter/test/screens/household_setup_screen_test.dart
+++ b/monthy_budget_flutter/test/screens/household_setup_screen_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/screens/auth/household_setup_screen.dart';
+import 'package:monthly_management/services/household_service.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  testWidgets(
+    'creating a household persists setupWizardCompleted as false',
+    (tester) async {
+      final createdNames = <String>[];
+      final savedSettings = <AppSettings>[];
+      final savedHouseholdIds = <String>[];
+      HouseholdProfile? completedProfile;
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          HouseholdSetupScreen(
+            createHousehold: (name) async {
+              createdNames.add(name);
+              return const HouseholdProfile(
+                householdId: 'house-1',
+                householdName: 'Smith Family',
+                role: 'admin',
+              );
+            },
+            saveSettings: (settings, householdId) async {
+              savedSettings.add(settings);
+              savedHouseholdIds.add(householdId);
+            },
+            onSetupComplete: (profile) => completedProfile = profile,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Smith Family');
+      await tester.tap(find.text('Create Household'));
+      await tester.pumpAndSettle();
+
+      expect(createdNames, ['Smith Family']);
+      expect(savedHouseholdIds, ['house-1']);
+      expect(savedSettings.single.setupWizardCompleted, isFalse);
+      expect(completedProfile?.householdId, 'house-1');
+    },
+  );
+
+  testWidgets('joining a household does not overwrite setup wizard state', (
+    tester,
+  ) async {
+    final joinedCodes = <String>[];
+    final savedSettings = <AppSettings>[];
+
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        HouseholdSetupScreen(
+          joinHousehold: (inviteCode) async {
+            joinedCodes.add(inviteCode);
+            return const HouseholdProfile(
+              householdId: 'house-2',
+              householdName: 'Joined Family',
+              role: 'member',
+            );
+          },
+          saveSettings: (settings, householdId) async {
+            savedSettings.add(settings);
+          },
+          onSetupComplete: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Join with code'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'abc123');
+    await tester.tap(find.text('Join Household'));
+    await tester.pumpAndSettle();
+
+    expect(joinedCodes, ['abc123']);
+    expect(savedSettings, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- write default app settings immediately after household creation so new accounts store setupWizardCompleted: false
- make the household setup screen easy to widget-test through optional callback hooks
- add a widget regression test for create and join flows

Fixes #446

## Release Notes
- guarantee that new households persist an incomplete setup-wizard state so onboarding appears reliably