### PR TITLE
feat: support filtering stale grocery stores from comparisons

### DIFF
--- a/monthy_budget_flutter/lib/models/grocery_data.dart
+++ b/monthy_budget_flutter/lib/models/grocery_data.dart
@@ -13,6 +13,12 @@ class GroceryData {
   final String generatedAt;
   final List<GroceryStoreSummary> storeSummaries;
 
+  /// Raw listings retained for re-derivation during filtering.
+  final List<GroceryBundleListing> _listings;
+
+  /// Catalog product index retained for re-derivation during filtering.
+  final Map<String, GroceryCatalogProduct> _catalogProducts;
+
   const GroceryData({
     this.metadata = const GroceryMetadata(),
     this.decoIndex = const DecoIndex(),
@@ -23,7 +29,10 @@ class GroceryData {
     this.currencyCode = '',
     this.generatedAt = '',
     this.storeSummaries = const [],
-  });
+    List<GroceryBundleListing> listings = const [],
+    Map<String, GroceryCatalogProduct> catalogProducts = const {},
+  })  : _listings = listings,
+        _catalogProducts = catalogProducts;
 
   factory GroceryData.fromJson(Map<String, dynamic> json) {
     if (_looksLikeCountryBundle(json)) {
@@ -101,6 +110,8 @@ class GroceryData {
       currencyCode: currencyCode,
       generatedAt: generatedAt,
       storeSummaries: statuses,
+      listings: listings,
+      catalogProducts: catalogProducts,
     );
   }
 
@@ -283,7 +294,6 @@ class GroceryData {
   /// when there are no stores.
   GroceryStoreStatus get overallFreshness {
     if (storeSummaries.isEmpty) return GroceryStoreStatus.fresh;
-    // Enum declaration order matches severity: fresh(0) < stale(1) < partial(2) < failed(3)
     var worst = GroceryStoreStatus.fresh;
     for (final summary in storeSummaries) {
       if (summary.status.index > worst.index) {
@@ -291,6 +301,51 @@ class GroceryData {
       }
     }
     return worst;
+  }
+
+  /// Store names with [GroceryStoreStatus.fresh] status.
+  Set<String> get freshStoreNames => {
+        for (final summary in storeSummaries)
+          if (summary.status == GroceryStoreStatus.fresh) summary.storeName,
+      };
+
+  /// Returns a new [GroceryData] containing only listings from fresh stores.
+  GroceryData filterByFreshStores() {
+    if (!hasStoreSummaries || !hasDegradedStores) return this;
+
+    final freshIds = {
+      for (final summary in storeSummaries)
+        if (summary.status == GroceryStoreStatus.fresh) summary.storeId,
+    };
+
+    final filteredListings =
+        _listings.where((l) => freshIds.contains(l.storeId)).toList();
+
+    final filteredProducts =
+        _deriveProducts(filteredListings, _catalogProducts);
+    final filteredComparisons =
+        _deriveComparisons(filteredListings, _catalogProducts);
+    final filteredCategorySummary =
+        _deriveCategorySummary(filteredListings, _catalogProducts);
+    final filteredMetadata = GroceryMetadata(
+      scrapedAt: metadata.scrapedAt,
+      totalProducts: filteredProducts.length,
+      totalComparisons: filteredComparisons.length,
+    );
+
+    return GroceryData(
+      metadata: filteredMetadata,
+      decoIndex: decoIndex,
+      products: filteredProducts,
+      comparisons: filteredComparisons,
+      categorySummary: filteredCategorySummary,
+      countryCode: countryCode,
+      currencyCode: currencyCode,
+      generatedAt: generatedAt,
+      storeSummaries: storeSummaries,
+      listings: _listings,
+      catalogProducts: _catalogProducts,
+    );
   }
 
   List<Product> toCatalogProducts() {

--- a/monthy_budget_flutter/lib/screens/grocery_screen.dart
+++ b/monthy_budget_flutter/lib/screens/grocery_screen.dart
@@ -47,6 +47,7 @@ class _GroceryScreenState extends State<GroceryScreen> {
   String _searchQuery = '';
   String? _selectedCategory;
   bool _tourShown = false;
+  bool _hideStaleStores = false;
 
   @override
   void initState() {
@@ -81,14 +82,26 @@ class _GroceryScreenState extends State<GroceryScreen> {
     });
   }
 
+  bool get _canFilterStaleStores =>
+      widget.groceryData != null &&
+      widget.groceryData!.hasDegradedStores &&
+      widget.products.isNotEmpty;
+
+  List<Product> get _effectiveProducts {
+    if (_hideStaleStores && _canFilterStaleStores) {
+      return widget.groceryData!.filterByFreshStores().toCatalogProducts();
+    }
+    return widget.products;
+  }
+
   List<String> get _categories {
-    final cats = widget.products.map((p) => p.category).toSet().toList();
+    final cats = _effectiveProducts.map((p) => p.category).toSet().toList();
     cats.sort();
     return cats;
   }
 
   List<Product> get _filtered {
-    var list = widget.products;
+    var list = _effectiveProducts;
     if (_selectedCategory != null) {
       list = list.where((p) => p.category == _selectedCategory).toList();
     }
@@ -258,6 +271,39 @@ class _GroceryScreenState extends State<GroceryScreen> {
                     scrollDirection: Axis.horizontal,
                     padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
                     children: [
+                      if (_canFilterStaleStores) ...[
+                        FilterChip(
+                          label: Text(
+                            l10n.groceryHideStaleStores,
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500,
+                              color: _hideStaleStores
+                                  ? AppColors.onPrimary(context)
+                                  : AppColors.textSecondary(context),
+                            ),
+                          ),
+                          selected: _hideStaleStores,
+                          onSelected: (value) =>
+                              setState(() => _hideStaleStores = value),
+                          selectedColor: AppColors.warning(context),
+                          backgroundColor: AppColors.surface(context),
+                          side: BorderSide(
+                            color: _hideStaleStores
+                                ? AppColors.warning(context)
+                                : AppColors.border(context),
+                          ),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          showCheckmark: false,
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: VisualDensity.compact,
+                        ),
+                        const SizedBox(width: 8),
+                      ],
                       _chip(l10n.groceryAll, _selectedCategory == null,
                           () => setState(() => _selectedCategory = null)),
                       ..._categories.map((cat) => Padding(

--- a/monthy_budget_flutter/test/functional/grocery_stale_filter_screen_test.dart
+++ b/monthy_budget_flutter/test/functional/grocery_stale_filter_screen_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/grocery_data.dart';
+import 'package:monthly_management/models/product.dart';
+import 'package:monthly_management/screens/grocery_screen.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  // Build a GroceryData with mixed store statuses so the filter chip appears
+  final groceryData = GroceryData.fromJson({
+    'country_code': 'PT',
+    'currency_code': 'EUR',
+    'generated_at': '2026-03-21T10:00:00Z',
+    'products': [
+      {
+        'id': 'milk_1l',
+        'display_name': 'Whole Milk 1L',
+        'category': 'Dairy',
+        'size_unit': 'L',
+      },
+    ],
+    'stores': [
+      {'store_id': 'continente', 'store_name': 'Continente'},
+      {'store_id': 'pingo_doce', 'store_name': 'Pingo Doce'},
+    ],
+    'store_statuses': [
+      {
+        'store_id': 'continente',
+        'store_name': 'Continente',
+        'status': 'fresh',
+        'listing_count': 10,
+      },
+      {
+        'store_id': 'pingo_doce',
+        'store_name': 'Pingo Doce',
+        'status': 'partial',
+        'listing_count': 5,
+      },
+    ],
+    'listings': [
+      {
+        'canonical_product_id': 'milk_1l',
+        'product_name': 'Whole Milk 1L',
+        'store_id': 'continente',
+        'category': 'Dairy',
+        'price': 1.29,
+        'price_per_base_unit': 1.29,
+        'base_unit': 'L',
+      },
+      {
+        'canonical_product_id': 'milk_1l',
+        'product_name': 'Whole Milk 1L',
+        'store_id': 'pingo_doce',
+        'category': 'Dairy',
+        'price': 1.39,
+        'price_per_base_unit': 1.39,
+        'base_unit': 'L',
+      },
+    ],
+  });
+
+  testWidgets('Hide stale stores chip appears when degraded stores exist',
+      (tester) async {
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        GroceryScreen(
+          products: groceryData.toCatalogProducts(),
+          groceryData: groceryData,
+        ),
+      ),
+    );
+
+    expect(find.text('Hide stale stores'), findsOneWidget);
+  });
+
+  testWidgets('Hide stale stores chip does not appear when no degraded stores',
+      (tester) async {
+    final allFreshData = const GroceryData(
+      countryCode: 'PT',
+      currencyCode: 'EUR',
+      storeSummaries: [
+        GroceryStoreSummary(
+          storeId: 'continente',
+          storeName: 'Continente',
+          status: GroceryStoreStatus.fresh,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        GroceryScreen(
+          products: const [
+            Product(
+              id: 'p1',
+              name: 'Milk',
+              category: 'Dairy',
+              avgPrice: 1.5,
+              unit: 'L',
+            ),
+          ],
+          groceryData: allFreshData,
+        ),
+      ),
+    );
+
+    expect(find.text('Hide stale stores'), findsNothing);
+  });
+
+  testWidgets('Toggling filter does not crash and product list remains visible',
+      (tester) async {
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        GroceryScreen(
+          products: groceryData.toCatalogProducts(),
+          groceryData: groceryData,
+        ),
+      ),
+    );
+
+    // Products are visible before toggling
+    expect(find.text('Whole Milk 1L'), findsOneWidget);
+
+    // Toggle the filter on
+    await tester.tap(find.text('Hide stale stores'));
+    await tester.pumpAndSettle();
+
+    // Products should still be visible (fresh store data remains)
+    expect(find.text('Whole Milk 1L'), findsOneWidget);
+
+    // Toggle the filter off
+    await tester.tap(find.text('Hide stale stores'));
+    await tester.pumpAndSettle();
+
+    // Products still visible
+    expect(find.text('Whole Milk 1L'), findsOneWidget);
+  });
+
+  testWidgets('Filter chip does not appear when products list is empty',
+      (tester) async {
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        GroceryScreen(
+          products: const [],
+          groceryData: groceryData,
+        ),
+      ),
+    );
+
+    // Empty state should show, no filter chip
+    expect(find.text('Hide stale stores'), findsNothing);
+  });
+}

--- a/monthy_budget_flutter/test/models/grocery_stale_filter_test.dart
+++ b/monthy_budget_flutter/test/models/grocery_stale_filter_test.dart
@@ -1,0 +1,238 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/grocery_data.dart';
+
+void main() {
+  group('GroceryData stale store filtering', () {
+    late GroceryData data;
+
+    setUp(() {
+      data = GroceryData.fromJson({
+        'country_code': 'PT',
+        'currency_code': 'EUR',
+        'generated_at': '2026-03-21T10:00:00Z',
+        'products': [
+          {
+            'id': 'milk_1l',
+            'display_name': 'Whole Milk 1L',
+            'category': 'Dairy',
+            'brand': 'Mimosa',
+            'size_unit': 'L',
+          },
+          {
+            'id': 'bread_500g',
+            'display_name': 'Bread 500g',
+            'category': 'Bakery',
+            'size_unit': 'kg',
+          },
+        ],
+        'stores': [
+          {'store_id': 'continente', 'store_name': 'Continente'},
+          {'store_id': 'pingo_doce', 'store_name': 'Pingo Doce'},
+          {'store_id': 'auchan', 'store_name': 'Auchan'},
+        ],
+        'store_statuses': [
+          {
+            'country_code': 'PT',
+            'store_id': 'continente',
+            'store_name': 'Continente',
+            'status': 'fresh',
+            'listing_count': 20,
+            'matched_count': 18,
+            'unmatched_count': 2,
+          },
+          {
+            'country_code': 'PT',
+            'store_id': 'pingo_doce',
+            'store_name': 'Pingo Doce',
+            'status': 'partial',
+            'listing_count': 12,
+            'matched_count': 9,
+            'unmatched_count': 3,
+          },
+          {
+            'country_code': 'PT',
+            'store_id': 'auchan',
+            'store_name': 'Auchan',
+            'status': 'failed',
+            'listing_count': 0,
+            'matched_count': 0,
+            'unmatched_count': 0,
+          },
+        ],
+        'listings': [
+          {
+            'canonical_product_id': 'milk_1l',
+            'product_name': 'Whole Milk 1L',
+            'store_id': 'continente',
+            'category': 'Dairy',
+            'price': 1.29,
+            'price_per_base_unit': 1.29,
+            'base_unit': 'L',
+          },
+          {
+            'canonical_product_id': 'milk_1l',
+            'product_name': 'Whole Milk 1L',
+            'store_id': 'pingo_doce',
+            'category': 'Dairy',
+            'price': 1.39,
+            'price_per_base_unit': 1.39,
+            'base_unit': 'L',
+          },
+          {
+            'canonical_product_id': 'bread_500g',
+            'product_name': 'Bread 500g',
+            'store_id': 'continente',
+            'category': 'Bakery',
+            'price': 0.99,
+            'price_per_base_unit': 1.98,
+            'base_unit': 'kg',
+          },
+          {
+            'canonical_product_id': 'bread_500g',
+            'product_name': 'Bread 500g',
+            'store_id': 'pingo_doce',
+            'category': 'Bakery',
+            'price': 1.09,
+            'price_per_base_unit': 2.18,
+            'base_unit': 'kg',
+          },
+          {
+            'canonical_product_id': 'bread_500g',
+            'product_name': 'Bread 500g',
+            'store_id': 'auchan',
+            'category': 'Bakery',
+            'price': 0.89,
+            'price_per_base_unit': 1.78,
+            'base_unit': 'kg',
+          },
+        ],
+      });
+    });
+
+    test('unfiltered data includes all stores', () {
+      // Milk has 2 stores (continente + pingo_doce), Bread has 3
+      expect(data.products.length, 2);
+      expect(data.comparisons.length, 2);
+      // Bread comparison includes all 3 stores
+      final breadComparison = data.comparisons.firstWhere(
+        (c) => c.productName == 'Bread 500g',
+      );
+      expect(breadComparison.prices.length, 3);
+    });
+
+    test('filterByFreshStores removes stale and failed store data', () {
+      final filtered = data.filterByFreshStores();
+
+      // Only Continente is fresh, so each product has exactly 1 store listing
+      // With only 1 listing per product, comparisons need at least 2 stores
+      expect(filtered.products.length, 2);
+      expect(filtered.comparisons.length, 0);
+
+      // Products should only reflect fresh store prices
+      final milk = filtered.products.firstWhere((p) => p.name == 'Whole Milk 1L');
+      expect(milk.price, closeTo(1.29, 0.001)); // Only Continente price
+
+      final bread = filtered.products.firstWhere((p) => p.name == 'Bread 500g');
+      expect(bread.price, closeTo(0.99, 0.001)); // Only Continente price
+    });
+
+    test('filterByFreshStores preserves metadata and country info', () {
+      final filtered = data.filterByFreshStores();
+
+      expect(filtered.countryCode, 'PT');
+      expect(filtered.currencyCode, 'EUR');
+      expect(filtered.generatedAt, data.generatedAt);
+      expect(filtered.storeSummaries, data.storeSummaries);
+    });
+
+    test('filterByFreshStores returns same data when all stores are fresh', () {
+      final allFreshData = GroceryData.fromJson({
+        'country_code': 'PT',
+        'currency_code': 'EUR',
+        'generated_at': '2026-03-21T10:00:00Z',
+        'products': [
+          {
+            'id': 'milk_1l',
+            'display_name': 'Whole Milk 1L',
+            'category': 'Dairy',
+          },
+        ],
+        'stores': [
+          {'store_id': 'continente', 'store_name': 'Continente'},
+          {'store_id': 'pingo_doce', 'store_name': 'Pingo Doce'},
+        ],
+        'store_statuses': [
+          {
+            'store_id': 'continente',
+            'store_name': 'Continente',
+            'status': 'fresh',
+            'listing_count': 10,
+          },
+          {
+            'store_id': 'pingo_doce',
+            'store_name': 'Pingo Doce',
+            'status': 'fresh',
+            'listing_count': 8,
+          },
+        ],
+        'listings': [
+          {
+            'canonical_product_id': 'milk_1l',
+            'product_name': 'Whole Milk 1L',
+            'store_id': 'continente',
+            'category': 'Dairy',
+            'price': 1.29,
+          },
+          {
+            'canonical_product_id': 'milk_1l',
+            'product_name': 'Whole Milk 1L',
+            'store_id': 'pingo_doce',
+            'category': 'Dairy',
+            'price': 1.39,
+          },
+        ],
+      });
+
+      final filtered = allFreshData.filterByFreshStores();
+      expect(filtered.products.length, allFreshData.products.length);
+      expect(filtered.comparisons.length, allFreshData.comparisons.length);
+    });
+
+    test('filterByFreshStores on legacy (non-bundle) data returns same instance', () {
+      final legacyData = GroceryData.fromJson({
+        'metadata': {
+          'scraped_at': '2026-03-21T10:00:00Z',
+          'total_products': 1,
+        },
+        'products': [
+          {
+            'name': 'Milk',
+            'price': 1.49,
+            'category': 'Dairy',
+            'store': 'Continente',
+          },
+        ],
+      });
+
+      final filtered = legacyData.filterByFreshStores();
+      // No store summaries means no filtering possible; returns same data
+      expect(filtered.products.length, legacyData.products.length);
+    });
+
+    test('freshStoreNames returns only fresh store names', () {
+      final freshNames = data.freshStoreNames;
+      expect(freshNames, contains('Continente'));
+      expect(freshNames, isNot(contains('Pingo Doce')));
+      expect(freshNames, isNot(contains('Auchan')));
+    });
+
+    test('toCatalogProducts on filtered data reflects fresh-only prices', () {
+      final filtered = data.filterByFreshStores();
+      final catalogProducts = filtered.toCatalogProducts();
+
+      expect(catalogProducts.length, 2);
+      final milk = catalogProducts.firstWhere((p) => p.name == 'Whole Milk 1L');
+      expect(milk.avgPrice, closeTo(1.29, 0.001));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Automated delivery from branch `issue-253-filter-stale-stores`.

## Linked Issue
Fixes #253

## Release Notes
- Automated delivery for branch `issue-253-filter-stale-stores`.
- issue-253: add stale store filtering for grocery comparisons #253
