### PR TITLE
Fix expense type switch erasing value

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -1587,6 +1587,7 @@
             }
         }
     },
+    "expenseTypeLabel": "TYPE",
     "expenseFixed": "Fixed",
     "expenseVariable": "Variable",
     "monthlyBudgetHint": "Budget for {month}",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -1505,6 +1505,7 @@
             }
         }
     },
+    "expenseTypeLabel": "TIPO",
     "expenseFixed": "Fijo",
     "expenseVariable": "Variable",
     "monthlyBudgetHint": "Presupuesto para {month}",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -1505,6 +1505,7 @@
             }
         }
     },
+    "expenseTypeLabel": "TYPE",
     "expenseFixed": "Fixe",
     "expenseVariable": "Variable",
     "monthlyBudgetHint": "Budget pour {month}",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -3718,6 +3718,7 @@
             }
         }
     },
+    "expenseTypeLabel": "TIPO",
     "expenseFixed": "Fixo",
     "@expenseFixed": {
         "description": "Fixed expense type label"

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -5267,6 +5267,12 @@ abstract class S {
   /// **'{count} resultados'**
   String searchResultCount(int count);
 
+  /// No description provided for @expenseTypeLabel.
+  ///
+  /// In pt, this message translates to:
+  /// **'TIPO'**
+  String get expenseTypeLabel;
+
   /// Fixed expense type label
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -2840,6 +2840,9 @@ class SEn extends S {
   }
 
   @override
+  String get expenseTypeLabel => 'TYPE';
+
+  @override
   String get expenseFixed => 'Fixed';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -2852,6 +2852,9 @@ class SEs extends S {
   }
 
   @override
+  String get expenseTypeLabel => 'TIPO';
+
+  @override
   String get expenseFixed => 'Fijo';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -2858,6 +2858,9 @@ class SFr extends S {
   }
 
   @override
+  String get expenseTypeLabel => 'TYPE';
+
+  @override
   String get expenseFixed => 'Fixe';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -2850,6 +2850,9 @@ class SPt extends S {
   }
 
   @override
+  String get expenseTypeLabel => 'TIPO';
+
+  @override
   String get expenseFixed => 'Fixo';
 
   @override

--- a/monthy_budget_flutter/lib/screens/settings_screen.dart
+++ b/monthy_budget_flutter/lib/screens/settings_screen.dart
@@ -1463,6 +1463,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       },
                     ),
                     const SizedBox(height: 12),
+                    // ── Expense Type (Fixed / Variable) ──
+                    _label(l10n.expenseTypeLabel),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        _expenseTypeChip(
+                          label: l10n.expenseFixed,
+                          selected: expense.isFixed,
+                          onTap: () => _updateExpense(expense.id, (e) => e.copyWith(isFixed: true)),
+                        ),
+                        const SizedBox(width: 8),
+                        _expenseTypeChip(
+                          label: l10n.expenseVariable,
+                          selected: !expense.isFixed,
+                          onTap: () => _updateExpense(expense.id, (e) => e.copyWith(isFixed: false)),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
                     // ── Monthly Budget ──
                     _label(l10n.settingsMonthlyBudgetLabel),
                     const SizedBox(height: 8),
@@ -3554,6 +3573,34 @@ class _SettingsScreenState extends State<SettingsScreen> {
         text,
         style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: AppColors.textSecondary(context), letterSpacing: 0.5),
       );
+
+  Widget _expenseTypeChip({
+    required String label,
+    required bool selected,
+    required VoidCallback onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primaryLight(context) : AppColors.background(context),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? AppColors.primary(context) : AppColors.border(context),
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+            color: selected ? AppColors.primary(context) : AppColors.textSecondary(context),
+          ),
+        ),
+      ),
+    );
+  }
 
   Widget _salarySectionHeader(IconData icon, String title) {
     return Row(

--- a/monthy_budget_flutter/test/models/expense_item_test.dart
+++ b/monthy_budget_flutter/test/models/expense_item_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/app_settings.dart';
+
+void main() {
+  group('ExpenseItem', () {
+    group('copyWith isFixed toggle', () {
+      test('switching from fixed to variable preserves amount', () {
+        const expense = ExpenseItem(
+          id: 'e1',
+          label: 'Rent',
+          amount: 700,
+          category: 'habitacao',
+          enabled: true,
+          isFixed: true,
+        );
+
+        final toggled = expense.copyWith(isFixed: false);
+
+        expect(toggled.isFixed, isFalse);
+        expect(toggled.amount, 700.0);
+        expect(toggled.label, 'Rent');
+        expect(toggled.category, 'habitacao');
+        expect(toggled.enabled, isTrue);
+      });
+
+      test('switching from variable to fixed preserves amount', () {
+        const expense = ExpenseItem(
+          id: 'e2',
+          label: 'Groceries',
+          amount: 350,
+          category: 'alimentacao',
+          enabled: true,
+          isFixed: false,
+        );
+
+        final toggled = expense.copyWith(isFixed: true);
+
+        expect(toggled.isFixed, isTrue);
+        expect(toggled.amount, 350.0);
+        expect(toggled.label, 'Groceries');
+      });
+    });
+
+    group('JSON serialization with isFixed', () {
+      test('round-trips isFixed=true', () {
+        const expense = ExpenseItem(
+          id: 'e3',
+          label: 'Internet',
+          amount: 40,
+          category: 'telecomunicacoes',
+          isFixed: true,
+        );
+
+        final json = expense.toJson();
+        final decoded = ExpenseItem.fromJson(json);
+
+        expect(decoded.isFixed, isTrue);
+        expect(decoded.amount, 40.0);
+        expect(decoded.label, 'Internet');
+      });
+
+      test('round-trips isFixed=false', () {
+        const expense = ExpenseItem(
+          id: 'e4',
+          label: 'Entertainment',
+          amount: 150,
+          category: 'lazer',
+          isFixed: false,
+        );
+
+        final json = expense.toJson();
+        final decoded = ExpenseItem.fromJson(json);
+
+        expect(decoded.isFixed, isFalse);
+        expect(decoded.amount, 150.0);
+      });
+
+      test('missing isFixed in JSON defaults to true', () {
+        final json = {
+          'id': 'e5',
+          'label': 'Test',
+          'amount': 100,
+          'category': 'outros',
+          'enabled': true,
+        };
+
+        final decoded = ExpenseItem.fromJson(json);
+        expect(decoded.isFixed, isTrue);
+      });
+    });
+
+    group('AppSettings round-trip with isFixed', () {
+      test('preserves isFixed across full settings serialization', () {
+        final settings = AppSettings(
+          expenses: const [
+            ExpenseItem(
+              id: 'rent',
+              label: 'Rent',
+              amount: 700,
+              category: 'habitacao',
+              isFixed: true,
+            ),
+            ExpenseItem(
+              id: 'food',
+              label: 'Food',
+              amount: 300,
+              category: 'alimentacao',
+              isFixed: false,
+            ),
+          ],
+        );
+
+        final decoded = AppSettings.fromJsonString(settings.toJsonString());
+
+        final rent = decoded.expenses.firstWhere((e) => e.id == 'rent');
+        expect(rent.isFixed, isTrue);
+        expect(rent.amount, 700.0);
+
+        final food = decoded.expenses.firstWhere((e) => e.id == 'food');
+        expect(food.isFixed, isFalse);
+        expect(food.amount, 300.0);
+      });
+
+      test('toggling isFixed in expense list preserves all amounts', () {
+        const original = [
+          ExpenseItem(
+            id: 'e1',
+            label: 'Rent',
+            amount: 700,
+            category: 'habitacao',
+            isFixed: true,
+          ),
+          ExpenseItem(
+            id: 'e2',
+            label: 'Food',
+            amount: 300,
+            category: 'alimentacao',
+            isFixed: true,
+          ),
+        ];
+
+        // Simulate toggling e1 from fixed to variable
+        final updated = original
+            .map((e) => e.id == 'e1' ? e.copyWith(isFixed: false) : e)
+            .toList();
+
+        final settings = AppSettings(expenses: updated);
+        final decoded = AppSettings.fromJsonString(settings.toJsonString());
+
+        final e1 = decoded.expenses.firstWhere((e) => e.id == 'e1');
+        expect(e1.isFixed, isFalse);
+        expect(e1.amount, 700.0, reason: 'Amount must be preserved after type switch');
+
+        final e2 = decoded.expenses.firstWhere((e) => e.id == 'e2');
+        expect(e2.isFixed, isTrue);
+        expect(e2.amount, 300.0, reason: 'Unmodified expense must remain unchanged');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Automated delivery from branch `issue-17-fix-expense-type-switch`.

## Linked Issue
Fixes #17

## Release Notes
- Automated delivery for branch `issue-17-fix-expense-type-switch`.
- issue-17: add fixed/variable expense type toggle in settings #17
