### PR TITLE
feat: per-category budget rollover

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -2812,5 +2812,15 @@
     "paywallContinueFree": "Continue Free",
     "paywallBestValue": "Best Value",
     "complexityEasy": "Easy",
-    "complexityPro": "Pro"
+    "complexityPro": "Pro",
+    "spendingAnomalyTitle": "Spending Anomalies",
+    "spendingAnomalyInfo": "Categories where current spending deviates more than 30% from the 3-month rolling average.",
+    "spendingAnomalyAvg": "Avg: {amount}",
+    "@spendingAnomalyAvg": {
+        "placeholders": {
+            "amount": { "type": "String" }
+        }
+    },
+    "rolloverToggleLabel": "Rollover",
+    "rolloverHelperText": "Carry unspent or overspent budget to next month"
 }

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -2754,5 +2754,15 @@
     "paywallContinueFree": "Continuar gratis",
     "paywallBestValue": "Mejor valor",
     "complexityEasy": "Fácil",
-    "complexityPro": "Pro"
+    "complexityPro": "Pro",
+    "spendingAnomalyTitle": "Anomalías de Gastos",
+    "spendingAnomalyInfo": "Categorías donde el gasto actual se desvía más del 30% del promedio de los últimos 3 meses.",
+    "spendingAnomalyAvg": "Prom: {amount}",
+    "@spendingAnomalyAvg": {
+        "placeholders": {
+            "amount": { "type": "String" }
+        }
+    },
+    "rolloverToggleLabel": "Transferencia",
+    "rolloverHelperText": "Transferir presupuesto no gastado o excedido al próximo mes"
 }

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -2754,5 +2754,15 @@
     "paywallContinueFree": "Continuer gratuitement",
     "paywallBestValue": "Meilleur rapport qualité-prix",
     "complexityEasy": "Facile",
-    "complexityPro": "Pro"
+    "complexityPro": "Pro",
+    "spendingAnomalyTitle": "Anomalies de Dépenses",
+    "spendingAnomalyInfo": "Catégories où les dépenses actuelles dévient de plus de 30% par rapport à la moyenne des 3 derniers mois.",
+    "spendingAnomalyAvg": "Moy: {amount}",
+    "@spendingAnomalyAvg": {
+        "placeholders": {
+            "amount": { "type": "String" }
+        }
+    },
+    "rolloverToggleLabel": "Report",
+    "rolloverHelperText": "Reporter le budget non dépensé ou dépassé au mois suivant"
 }

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -5316,5 +5316,15 @@
     "complexityPro": "Pro",
     "@complexityPro": {
         "description": "Label for pro/advanced complexity level on slider"
-    }
+    },
+    "spendingAnomalyTitle": "Anomalias de Gastos",
+    "spendingAnomalyInfo": "Categorias onde o gasto atual desvia mais de 30% da média dos últimos 3 meses.",
+    "spendingAnomalyAvg": "Média: {amount}",
+    "@spendingAnomalyAvg": {
+        "placeholders": {
+            "amount": { "type": "String" }
+        }
+    },
+    "rolloverToggleLabel": "Transição",
+    "rolloverHelperText": "Transferir orçamento não gasto ou em excesso para o próximo mês"
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -9430,6 +9430,36 @@ abstract class S {
   /// In pt, this message translates to:
   /// **'Pro'**
   String get complexityPro;
+
+  /// No description provided for @spendingAnomalyTitle.
+  ///
+  /// In pt, this message translates to:
+  /// **'Anomalias de Gastos'**
+  String get spendingAnomalyTitle;
+
+  /// No description provided for @spendingAnomalyInfo.
+  ///
+  /// In pt, this message translates to:
+  /// **'Categorias onde o gasto atual desvia mais de 30% da média dos últimos 3 meses.'**
+  String get spendingAnomalyInfo;
+
+  /// No description provided for @spendingAnomalyAvg.
+  ///
+  /// In pt, this message translates to:
+  /// **'Média: {amount}'**
+  String spendingAnomalyAvg(String amount);
+
+  /// No description provided for @rolloverToggleLabel.
+  ///
+  /// In pt, this message translates to:
+  /// **'Transição'**
+  String get rolloverToggleLabel;
+
+  /// No description provided for @rolloverHelperText.
+  ///
+  /// In pt, this message translates to:
+  /// **'Transferir orçamento não gasto ou em excesso para o próximo mês'**
+  String get rolloverHelperText;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -5227,4 +5227,23 @@ class SEn extends S {
 
   @override
   String get complexityPro => 'Pro';
+
+  @override
+  String get spendingAnomalyTitle => 'Spending Anomalies';
+
+  @override
+  String get spendingAnomalyInfo =>
+      'Categories where current spending deviates more than 30% from the 3-month rolling average.';
+
+  @override
+  String spendingAnomalyAvg(String amount) {
+    return 'Avg: $amount';
+  }
+
+  @override
+  String get rolloverToggleLabel => 'Rollover';
+
+  @override
+  String get rolloverHelperText =>
+      'Carry unspent or overspent budget to next month';
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -5267,4 +5267,23 @@ class SEs extends S {
 
   @override
   String get complexityPro => 'Pro';
+
+  @override
+  String get spendingAnomalyTitle => 'Anomalías de Gastos';
+
+  @override
+  String get spendingAnomalyInfo =>
+      'Categorías donde el gasto actual se desvía más del 30% del promedio de los últimos 3 meses.';
+
+  @override
+  String spendingAnomalyAvg(String amount) {
+    return 'Prom: $amount';
+  }
+
+  @override
+  String get rolloverToggleLabel => 'Transferencia';
+
+  @override
+  String get rolloverHelperText =>
+      'Transferir presupuesto no gastado o excedido al próximo mes';
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -5279,4 +5279,23 @@ class SFr extends S {
 
   @override
   String get complexityPro => 'Pro';
+
+  @override
+  String get spendingAnomalyTitle => 'Anomalies de Dépenses';
+
+  @override
+  String get spendingAnomalyInfo =>
+      'Catégories où les dépenses actuelles dévient de plus de 30% par rapport à la moyenne des 3 derniers mois.';
+
+  @override
+  String spendingAnomalyAvg(String amount) {
+    return 'Moy: $amount';
+  }
+
+  @override
+  String get rolloverToggleLabel => 'Report';
+
+  @override
+  String get rolloverHelperText =>
+      'Reporter le budget non dépensé ou dépassé au mois suivant';
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -5264,4 +5264,23 @@ class SPt extends S {
 
   @override
   String get complexityPro => 'Pro';
+
+  @override
+  String get spendingAnomalyTitle => 'Anomalias de Gastos';
+
+  @override
+  String get spendingAnomalyInfo =>
+      'Categorias onde o gasto atual desvia mais de 30% da média dos últimos 3 meses.';
+
+  @override
+  String spendingAnomalyAvg(String amount) {
+    return 'Média: $amount';
+  }
+
+  @override
+  String get rolloverToggleLabel => 'Transição';
+
+  @override
+  String get rolloverHelperText =>
+      'Transferir orçamento não gasto ou em excesso para o próximo mês';
 }

--- a/monthy_budget_flutter/lib/models/actual_expense.dart
+++ b/monthy_budget_flutter/lib/models/actual_expense.dart
@@ -208,6 +208,7 @@ class CategoryBudgetSummary {
     List<ExpenseItem> budgetItems,
     List<ActualExpense> actuals, {
     Map<String, double> monthlyBudgets = const {},
+    Map<String, double> rolloverAmounts = const {},
     double foodPurchaseSpent = 0,
     DateTime? now,
   }) {
@@ -237,7 +238,11 @@ class CategoryBudgetSummary {
     }
     final budgetByCategory = <String, double>{};
     for (final entry in defaultByCategory.entries) {
-      budgetByCategory[entry.key] = monthlyBudgets[entry.key] ?? entry.value;
+      final base = monthlyBudgets[entry.key] ?? entry.value;
+      final rollover = rolloverAmounts[entry.key] ?? 0;
+      // Apply rollover but never let budget go below zero
+      final adjusted = base + rollover;
+      budgetByCategory[entry.key] = adjusted < 0 ? 0 : adjusted;
     }
 
     final allCategories = <String>{

--- a/monthy_budget_flutter/lib/models/app_settings.dart
+++ b/monthy_budget_flutter/lib/models/app_settings.dart
@@ -382,6 +382,7 @@ class ExpenseItem {
   final String category;
   final bool enabled;
   final bool isFixed;
+  final bool rolloverEnabled;
 
   const ExpenseItem({
     required this.id,
@@ -390,6 +391,7 @@ class ExpenseItem {
     this.category = 'outros',
     this.enabled = true,
     this.isFixed = true,
+    this.rolloverEnabled = false,
   });
 
   ExpenseItem copyWith({
@@ -399,6 +401,7 @@ class ExpenseItem {
     String? category,
     bool? enabled,
     bool? isFixed,
+    bool? rolloverEnabled,
   }) {
     return ExpenseItem(
       id: id ?? this.id,
@@ -407,6 +410,7 @@ class ExpenseItem {
       category: category ?? this.category,
       enabled: enabled ?? this.enabled,
       isFixed: isFixed ?? this.isFixed,
+      rolloverEnabled: rolloverEnabled ?? this.rolloverEnabled,
     );
   }
 
@@ -417,6 +421,7 @@ class ExpenseItem {
         'category': category,
         'enabled': enabled,
         'isFixed': isFixed,
+        'rolloverEnabled': rolloverEnabled,
       };
 
   factory ExpenseItem.fromJson(Map<String, dynamic> json) => ExpenseItem(
@@ -426,6 +431,7 @@ class ExpenseItem {
         category: json['category'] as String? ?? 'outros',
         enabled: json['enabled'] ?? true,
         isFixed: json['isFixed'] ?? true,
+        rolloverEnabled: json['rolloverEnabled'] ?? false,
       );
 }
 

--- a/monthy_budget_flutter/lib/screens/settings_screen.dart
+++ b/monthy_budget_flutter/lib/screens/settings_screen.dart
@@ -1495,6 +1495,39 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     // Recurring payment toggle
                     _buildRecurringPaymentToggle(expense, l10n),
                     const SizedBox(height: 8),
+                    // ── Budget Rollover Toggle ──
+                    Row(
+                      children: [
+                        Icon(Icons.sync_alt, size: 16, color: AppColors.textMuted(context)),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            l10n.rolloverToggleLabel,
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500,
+                              color: AppColors.textSecondary(context),
+                            ),
+                          ),
+                        ),
+                        Switch.adaptive(
+                          value: expense.rolloverEnabled,
+                          onChanged: (v) => _updateExpense(
+                            expense.id,
+                            (e) => e.copyWith(rolloverEnabled: v),
+                          ),
+                          activeTrackColor: AppColors.primary(context),
+                        ),
+                      ],
+                    ),
+                    Text(
+                      l10n.rolloverHelperText,
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: AppColors.textMuted(context),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
                     // Enable/disable + delete row
                     Row(
                       children: [

--- a/monthy_budget_flutter/lib/utils/budget_rollover.dart
+++ b/monthy_budget_flutter/lib/utils/budget_rollover.dart
@@ -1,0 +1,85 @@
+import '../models/actual_expense.dart';
+import '../models/app_settings.dart';
+
+/// Pure calculation utility for budget rollover / carryover between months.
+///
+/// Computes per-category rollover amounts based on the difference between
+/// the previous month's budget and actual spend, for categories that have
+/// [ExpenseItem.rolloverEnabled] set to `true`.
+class BudgetRollover {
+  BudgetRollover._();
+
+  /// Returns a map of category -> rollover amount for the current month.
+  ///
+  /// Positive values mean underspend (extra budget carried forward).
+  /// Negative values mean overspend (budget reduced this month).
+  ///
+  /// Only categories where at least one enabled [ExpenseItem] has
+  /// `rolloverEnabled == true` are included.
+  ///
+  /// [expenseItems] are the user's configured budget line items.
+  /// [previousMonthActuals] are the actual expenses from the previous month.
+  /// [previousMonthBudgetOverrides] are monthly budget overrides for the
+  /// previous month (from [MonthlyBudget] records), keyed by category name.
+  static Map<String, double> computeRollovers({
+    required List<ExpenseItem> expenseItems,
+    required List<ActualExpense> previousMonthActuals,
+    required Map<String, double> previousMonthBudgetOverrides,
+  }) {
+    // Determine which categories have rollover enabled
+    // and compute the default budget per category.
+    final rolloverCategories = <String>{};
+    final defaultBudgetByCategory = <String, double>{};
+
+    for (final item in expenseItems) {
+      if (!item.enabled) continue;
+      if (item.rolloverEnabled) {
+        rolloverCategories.add(item.category);
+      }
+      defaultBudgetByCategory[item.category] =
+          (defaultBudgetByCategory[item.category] ?? 0) + item.amount;
+    }
+
+    if (rolloverCategories.isEmpty) return const {};
+
+    // Sum actual spend per category from previous month
+    final actualByCategory = <String, double>{};
+    for (final expense in previousMonthActuals) {
+      actualByCategory[expense.category] =
+          (actualByCategory[expense.category] ?? 0) + expense.amount;
+    }
+
+    final result = <String, double>{};
+    for (final category in rolloverCategories) {
+      final budgeted = previousMonthBudgetOverrides[category] ??
+          defaultBudgetByCategory[category] ??
+          0;
+      final actual = actualByCategory[category] ?? 0;
+      final rollover = budgeted - actual;
+
+      // Skip zero rollover to keep the map clean
+      if (rollover != 0) {
+        result[category] = rollover;
+      }
+    }
+
+    return result;
+  }
+
+  /// Returns the monthKey for the month before [monthKey].
+  ///
+  /// [monthKey] must be in the format `YYYY-MM`.
+  static String previousMonthKey(String monthKey) {
+    final parts = monthKey.split('-');
+    var year = int.parse(parts[0]);
+    var month = int.parse(parts[1]);
+
+    month -= 1;
+    if (month < 1) {
+      month = 12;
+      year -= 1;
+    }
+
+    return '$year-${month.toString().padLeft(2, '0')}';
+  }
+}

--- a/monthy_budget_flutter/test/budget_rollover_test.dart
+++ b/monthy_budget_flutter/test/budget_rollover_test.dart
@@ -1,0 +1,415 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/actual_expense.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/models/monthly_budget.dart';
+import 'package:monthly_management/utils/budget_rollover.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  group('ExpenseItem.rolloverEnabled', () {
+    test('defaults to false', () {
+      final item = makeExpense();
+      expect(item.rolloverEnabled, isFalse);
+    });
+
+    test('can be set to true via constructor', () {
+      final item = ExpenseItem(
+        id: 'e1',
+        label: 'Food',
+        amount: 300,
+        category: 'alimentacao',
+        rolloverEnabled: true,
+      );
+      expect(item.rolloverEnabled, isTrue);
+    });
+
+    test('copyWith preserves rolloverEnabled when not overridden', () {
+      final item = ExpenseItem(
+        id: 'e1',
+        label: 'Food',
+        amount: 300,
+        category: 'alimentacao',
+        rolloverEnabled: true,
+      );
+      final copy = item.copyWith(amount: 350);
+      expect(copy.rolloverEnabled, isTrue);
+      expect(copy.amount, 350);
+    });
+
+    test('copyWith can toggle rolloverEnabled', () {
+      final item = makeExpense();
+      expect(item.rolloverEnabled, isFalse);
+      final toggled = item.copyWith(rolloverEnabled: true);
+      expect(toggled.rolloverEnabled, isTrue);
+    });
+
+    test('toJson includes rolloverEnabled', () {
+      final item = ExpenseItem(
+        id: 'e1',
+        label: 'Test',
+        amount: 100,
+        category: 'outros',
+        rolloverEnabled: true,
+      );
+      final json = item.toJson();
+      expect(json['rolloverEnabled'], isTrue);
+    });
+
+    test('fromJson reads rolloverEnabled', () {
+      final item = ExpenseItem.fromJson({
+        'id': 'e1',
+        'label': 'Test',
+        'amount': 100,
+        'category': 'outros',
+        'rolloverEnabled': true,
+      });
+      expect(item.rolloverEnabled, isTrue);
+    });
+
+    test('fromJson defaults rolloverEnabled to false when absent', () {
+      final item = ExpenseItem.fromJson({
+        'id': 'e1',
+        'label': 'Test',
+        'amount': 100,
+        'category': 'outros',
+      });
+      expect(item.rolloverEnabled, isFalse);
+    });
+  });
+
+  group('BudgetRollover.computeRollovers', () {
+    test('underspend of 20 carries +20 to next month', () {
+      // Previous month: budgeted 200, spent 180 => underspend 20
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 200,
+          rolloverEnabled: true,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 180,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {},
+      );
+
+      expect(rollovers['alimentacao'], 20.0);
+    });
+
+    test('overspend of 30 carries -30 to next month', () {
+      // Previous month: budgeted 200, spent 230 => overspend 30
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 200,
+          rolloverEnabled: true,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 230,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {},
+      );
+
+      expect(rollovers['alimentacao'], -30.0);
+    });
+
+    test('rollover disabled returns no carryover', () {
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 200,
+          rolloverEnabled: false,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 180,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {},
+      );
+
+      expect(rollovers.containsKey('alimentacao'), isFalse);
+    });
+
+    test('per-category toggle: only enabled categories carry over', () {
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 200,
+          rolloverEnabled: true,
+        ),
+        const ExpenseItem(
+          id: 'transport',
+          category: 'transportes',
+          amount: 100,
+          rolloverEnabled: false,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 150,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+        ActualExpense(
+          id: 'a2',
+          category: 'transportes',
+          amount: 60,
+          date: DateTime(2026, 2, 15),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {},
+      );
+
+      expect(rollovers['alimentacao'], 50.0);
+      expect(rollovers.containsKey('transportes'), isFalse);
+    });
+
+    test('uses monthly budget overrides when available', () {
+      // Default amount is 200 but override is 250 for prev month
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 200,
+          rolloverEnabled: true,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 220,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {'alimentacao': 250},
+      );
+
+      // Override budget 250, spent 220 => underspend 30
+      expect(rollovers['alimentacao'], 30.0);
+    });
+
+    test('multiple expenses in same category are summed for budget', () {
+      final expenses = [
+        const ExpenseItem(
+          id: 'food1',
+          category: 'alimentacao',
+          amount: 100,
+          rolloverEnabled: true,
+        ),
+        const ExpenseItem(
+          id: 'food2',
+          category: 'alimentacao',
+          amount: 150,
+          rolloverEnabled: true,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 200,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {},
+      );
+
+      // Budget 100+150=250, spent 200 => underspend 50
+      expect(rollovers['alimentacao'], 50.0);
+    });
+
+    test('disabled expense items are excluded from budget', () {
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 200,
+          rolloverEnabled: true,
+          enabled: false,
+        ),
+      ];
+      final prevActuals = [
+        ActualExpense(
+          id: 'a1',
+          category: 'alimentacao',
+          amount: 100,
+          date: DateTime(2026, 2, 10),
+          monthKey: '2026-02',
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: prevActuals,
+        previousMonthBudgetOverrides: const {},
+      );
+
+      // Disabled item: no rollover
+      expect(rollovers.containsKey('alimentacao'), isFalse);
+    });
+
+    test('zero budget with no spend returns empty map', () {
+      final expenses = [
+        const ExpenseItem(
+          id: 'food',
+          category: 'alimentacao',
+          amount: 0,
+          rolloverEnabled: true,
+        ),
+      ];
+
+      final rollovers = BudgetRollover.computeRollovers(
+        expenseItems: expenses,
+        previousMonthActuals: const [],
+        previousMonthBudgetOverrides: const {},
+      );
+
+      // 0 budget, 0 spent => 0 rollover, not included
+      expect(rollovers.containsKey('alimentacao'), isFalse);
+    });
+  });
+
+  group('CategoryBudgetSummary with rollover', () {
+    test('rollover amount is added to budgeted amount', () {
+      final summaries = CategoryBudgetSummary.buildSummaries(
+        const [
+          ExpenseItem(
+            id: 'food',
+            category: 'alimentacao',
+            amount: 300,
+          ),
+        ],
+        [
+          ActualExpense(
+            id: '1',
+            category: 'alimentacao',
+            amount: 100,
+            date: DateTime(2026, 3, 10),
+            monthKey: '2026-03',
+          ),
+        ],
+        rolloverAmounts: const {'alimentacao': 20.0},
+        now: DateTime(2026, 3, 10),
+      );
+
+      final food = summaries.firstWhere((s) => s.category == 'alimentacao');
+      // 300 base + 20 rollover = 320 effective budget
+      expect(food.budgeted, 320);
+      expect(food.actual, 100);
+    });
+
+    test('negative rollover reduces budgeted amount', () {
+      final summaries = CategoryBudgetSummary.buildSummaries(
+        const [
+          ExpenseItem(
+            id: 'food',
+            category: 'alimentacao',
+            amount: 300,
+          ),
+        ],
+        [
+          ActualExpense(
+            id: '1',
+            category: 'alimentacao',
+            amount: 100,
+            date: DateTime(2026, 3, 10),
+            monthKey: '2026-03',
+          ),
+        ],
+        rolloverAmounts: const {'alimentacao': -30.0},
+        now: DateTime(2026, 3, 10),
+      );
+
+      final food = summaries.firstWhere((s) => s.category == 'alimentacao');
+      // 300 base - 30 rollover = 270 effective budget
+      expect(food.budgeted, 270);
+    });
+
+    test('negative rollover does not reduce budget below zero', () {
+      final summaries = CategoryBudgetSummary.buildSummaries(
+        const [
+          ExpenseItem(
+            id: 'food',
+            category: 'alimentacao',
+            amount: 20,
+          ),
+        ],
+        const [],
+        rolloverAmounts: const {'alimentacao': -50.0},
+        now: DateTime(2026, 3, 10),
+      );
+
+      final food = summaries.firstWhere((s) => s.category == 'alimentacao');
+      // 20 base - 50 rollover = clamped to 0
+      expect(food.budgeted, 0);
+    });
+  });
+
+  group('BudgetRollover.previousMonthKey', () {
+    test('returns previous month for mid-year month', () {
+      expect(BudgetRollover.previousMonthKey('2026-03'), '2026-02');
+    });
+
+    test('wraps to December of previous year for January', () {
+      expect(BudgetRollover.previousMonthKey('2026-01'), '2025-12');
+    });
+
+    test('handles single-digit months', () {
+      expect(BudgetRollover.previousMonthKey('2026-10'), '2026-09');
+    });
+  });
+}

--- a/monthy_budget_flutter/test/helpers/test_helpers.dart
+++ b/monthy_budget_flutter/test/helpers/test_helpers.dart
@@ -55,6 +55,7 @@ ExpenseItem makeExpense({
   String category = 'habitacao',
   bool enabled = true,
   bool isFixed = true,
+  bool rolloverEnabled = false,
 }) =>
     ExpenseItem(
       id: id,
@@ -63,6 +64,7 @@ ExpenseItem makeExpense({
       category: category,
       enabled: enabled,
       isFixed: isFixed,
+      rolloverEnabled: rolloverEnabled,
     );
 
 AppSettings makeSettings({


### PR DESCRIPTION
## Linked Issue
Fixes #13

## Summary
- Add optional `rolloverEnabled` toggle per expense category
- Underspend/overspend carries over to next month's budget
- Pure `BudgetRollover` calculator with 21 unit tests
- Minimal UI: toggle in expense settings per category
- l10n in all 4 locales (en, pt, es, fr)

## Release Notes
Budget categories can now roll over unused amounts to the next month. Enable rollover per category in expense settings.