### PR TITLE
fix: resolve Gradle Kotlin build error for release APK

### DIFF
--- a/monthy_budget_flutter/android/app/build.gradle.kts
+++ b/monthy_budget_flutter/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Base64
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -30,13 +32,13 @@ android {
         // Extract ADMOB_APP_ID from --dart-define for AndroidManifest placeholder.
         // dart-defines are passed as a comma-separated, base64-encoded list in
         // the Gradle property "dart-defines".
-        val dartDefines = (project.findProperty("dart-defines") as? String)
+        val dartDefines: Map<String, String> = (project.findProperty("dart-defines") as? String)
             ?.split(",")
-            ?.associate { encoded ->
-                val decoded = String(java.util.Base64.getDecoder().decode(encoded))
+            ?.associate { encoded: String ->
+                val decoded = String(Base64.getDecoder().decode(encoded))
                 val parts = decoded.split("=", limit = 2)
                 parts[0] to (parts.getOrNull(1) ?: "")
-            } ?: emptyMap()
+            } ?: emptyMap<String, String>()
 
         val admobAppId = dartDefines["ADMOB_APP_ID"] ?: ""
         manifestPlaceholders["admobAppId"] = admobAppId


### PR DESCRIPTION
## Summary
Automated delivery from branch `issue-784-fix-gradle-build`.

## Linked Issue
Fixes #784

## Release Notes
- Automated delivery for branch `issue-784-fix-gradle-build`.
- fix: resolve java.util.Base64 in build.gradle.kts for release builds #784
