### PR TITLE
chore(release): v2026.4.5 — fix Kotlin language version for APK build

### DIFF
--- a/monthy_budget_flutter/android/app/build.gradle.kts
+++ b/monthy_budget_flutter/android/app/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
+        languageVersion = "2.0"
     }
 
     defaultConfig {

--- a/monthy_budget_flutter/pubspec.yaml
+++ b/monthy_budget_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: monthly_management
 description: "Calculadora de Orcamento Mensal - Portuguese monthly budget calculator with IRS tax tables"
 publish_to: 'none'
 
-version: 2026.4.4+260400004
+version: 2026.4.5+260400005
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
Automated delivery from branch `issue-789-kotlin-fix`.

## Linked Issue
Fixes #789

## Release Notes
- Automated delivery for branch `issue-789-kotlin-fix`.
- chore(release): v2026.4.5 — set Kotlin languageVersion to 2.0 for release builds #789
