### PR TITLE
chore(release): v2026.4.6 — downgrade Kotlin to 2.1.0

### DIFF
--- a/monthy_budget_flutter/android/settings.gradle.kts
+++ b/monthy_budget_flutter/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")

--- a/monthy_budget_flutter/pubspec.yaml
+++ b/monthy_budget_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: monthly_management
 description: "Calculadora de Orcamento Mensal - Portuguese monthly budget calculator with IRS tax tables"
 publish_to: 'none'
 
-version: 2026.4.5+260400005
+version: 2026.4.6+260400006
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
Automated delivery from branch `fix-kotlin-version`.

## Linked Issue
Fixes #789

## Release Notes
- Automated delivery for branch `fix-kotlin-version`.
- chore(release): v2026.4.6 — downgrade Kotlin to 2.1.0 for stable release builds #789
