### PR TITLE
feat(meal-planner): compact meal card layout

### DIFF
--- a/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
+++ b/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
@@ -849,22 +849,6 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
     );
   }
 
-  void _setFeedback(int dayIndex, MealType mealType, MealFeedback feedback) {
-    final plan = _plan!;
-    final updatedDays = plan.days.map((d) {
-      if (d.dayIndex == dayIndex && d.mealType == mealType) {
-        return d.copyWith(
-          feedback: d.feedback == feedback ? MealFeedback.none : feedback,
-        );
-      }
-      return d;
-    }).toList();
-    final updated = plan.copyWithDays(updatedDays);
-    _service.save(updated, widget.householdId);
-    setState(() => _plan = updated);
-    _recomputeBudgetInsight();
-  }
-
   void _setRating(int dayIndex, MealType mealType, int rating) {
     final plan = _plan;
     if (plan == null) return;


### PR DESCRIPTION
## Linked Issue
Fixes #808

## Summary
- Replace the `_showDetails` toggle + detail panels with an always-visible horizontally scrollable chip row (pantry, nutrition, budget, waste)
- Move "Add week to shopping list" and batch cooking buttons into the week navigator row
- Replace 3 `OutlinedButton.icon` action buttons (Ingredients/Preparation/Swap) with compact icon-only buttons
- Remove `MealFeedbackButton` (thumbs up/down/skip), keep only `StarRatingRow` for rating
- Compact course display: single course shows name only, multi-course uses inline icon+name+swap rows
- Reduce padding, font sizes, and spacing throughout card and expanded ingredients section
- Net reduction of ~97 lines of UI code

## Release Notes
Redesigned meal planner card layout for a more compact display, reducing vertical space waste by collapsing detail panels into a chip row, using icon-only action buttons, and removing redundant feedback buttons.

## Test plan
- [ ] Verify meal cards display correctly with single-course meals
- [ ] Verify multi-course meals show compact inline rows (soup, main, dessert)
- [ ] Verify chip row shows pantry, nutrition, budget, and waste chips
- [ ] Verify tapping nutrition chip opens bottom sheet with dashboard
- [ ] Verify tapping budget chip opens budget detail sheet
- [ ] Verify icon buttons (ingredients, prep guide, swap) work correctly
- [ ] Verify star rating still functions on each card
- [ ] Verify expanded ingredients section displays with compact layout
- [ ] Verify "Add week to shopping list" button works in week navigator row

https://claude.ai/code/session_018DSaQZt2qRFQimKsrDsXDa