### PR TITLE
issue-867: refactor(recurring-expenses): rewrite on Calm widget library

### DIFF
--- a/monthy_budget_flutter/lib/screens/recurring_expenses_screen.dart
+++ b/monthy_budget_flutter/lib/screens/recurring_expenses_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:monthly_management/widgets/calm/calm.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../models/recurring_expense.dart';
 import '../models/custom_category.dart';
 import '../models/app_settings.dart';
 import '../services/recurring_expense_service.dart';
 import '../theme/app_colors.dart';
+import '../theme/app_theme.dart';
 import '../utils/formatters.dart';
 import '../utils/category_icons.dart';
 import '../onboarding/recurring_expenses_tour.dart';
@@ -95,7 +97,7 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
           TextButton(
             onPressed: () => Navigator.pop(context, true),
             child: Text(l10n.delete,
-                style: TextStyle(color: AppColors.error(context))),
+                style: TextStyle(color: AppColors.bad(context))),
           ),
         ],
       ),
@@ -131,10 +133,9 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
 
   Future<RecurringExpense?> _showEditSheet(
       [RecurringExpense? existing]) async {
-    return showModalBottomSheet<RecurringExpense>(
-      context: context,
+    return CalmBottomSheet.show<RecurringExpense>(
+      context,
       isScrollControlled: true,
-      backgroundColor: Colors.transparent,
       builder: (_) => _EditRecurringSheet(
         existing: existing,
         customCategories: widget.customCategories,
@@ -142,145 +143,181 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
     );
   }
 
+  double get _totalMonthly =>
+      _expenses.where((e) => e.isActive).fold(0.0, (sum, e) => sum + e.amount);
+
   @override
   Widget build(BuildContext context) {
     final l10n = S.of(context);
+    final activeCount = _expenses.where((e) => e.isActive).length;
 
-    return Scaffold(
-      backgroundColor: AppColors.background(context),
-      appBar: AppBar(
-        title: Text(l10n.recurringExpenses),
-        backgroundColor: AppColors.surface(context),
-        foregroundColor: AppColors.textPrimary(context),
-        elevation: 0,
-      ),
+    return CalmScaffold(
+      title: l10n.recurringExpenses,
       floatingActionButton: FloatingActionButton(
         key: RecurringExpensesTourKeys.addFab,
         onPressed: () => _addOrEdit(),
-        backgroundColor: AppColors.primary(context),
-        child: Icon(Icons.add, color: AppColors.onPrimary(context)),
+        backgroundColor: AppColors.ink(context),
+        foregroundColor: AppColors.bg(context),
+        elevation: 0,
+        child: const Icon(Icons.add),
       ),
       body: _expenses.isEmpty
           ? Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.repeat, size: 48,
-                        color: AppColors.dragHandle(context)),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n.recurringExpenseEmpty,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: AppColors.textMuted(context),
-                        fontSize: 14,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    OutlinedButton.icon(
-                      onPressed: () => _addOrEdit(),
-                      icon: const Icon(Icons.add, size: 18),
-                      label: Text(l10n.recurringExpenseAdd),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: AppColors.primary(context),
-                        side: BorderSide(color: AppColors.primary(context)),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 20, vertical: 10),
-                      ),
-                    ),
-                  ],
+              child: CalmEmptyState(
+                icon: Icons.event_repeat_outlined,
+                title: 'Sem pagamentos recorrentes', // TODO(l10n): move to ARB (Wave H)
+                body: 'Adicione para gerar automaticamente todos os meses.', // TODO(l10n): move to ARB (Wave H)
+                action: CalmEmptyStateAction(
+                  label: l10n.recurringExpenseAdd,
+                  onPressed: () => _addOrEdit(),
                 ),
               ),
             )
-          : ListView.separated(
-              padding: const EdgeInsets.all(16),
-              itemCount: _expenses.length,
-              separatorBuilder: (_, _) => const SizedBox(height: 8),
-              itemBuilder: (_, i) {
-                final e = _expenses[i];
-                return Container(
-                  key: i == 0 ? RecurringExpensesTourKeys.expenseItem : null,
-                  decoration: BoxDecoration(
-                    color: AppColors.surface(context),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: AppColors.border(context)),
-                  ),
-                  child: ListTile(
-                    contentPadding:
-                        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                    leading: CircleAvatar(
-                      backgroundColor: e.isActive
-                          ? AppColors.primaryLight(context)
-                          : AppColors.surfaceVariant(context),
-                      child: Icon(
-                        Icons.repeat,
-                        color: e.isActive
-                            ? AppColors.primary(context)
-                            : AppColors.textMuted(context),
-                        size: 20,
-                      ),
-                    ),
-                    title: Text(
-                      _localizedCategory(e.category, l10n),
-                      style: TextStyle(
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.textPrimary(context),
-                      ),
-                    ),
-                    subtitle: Text(
-                      [
-                        formatCurrency(e.amount),
-                        if (e.dayOfMonth != null) '${l10n.recurringExpenseDayOfMonth} ${e.dayOfMonth}',
-                        if (e.description != null && e.description!.isNotEmpty)
-                          e.description!,
-                        if (!e.isActive) l10n.recurringExpenseInactive,
-                      ].join(' · '),
-                      style: TextStyle(
-                        color: AppColors.textSecondary(context),
-                        fontSize: 13,
-                      ),
-                    ),
-                    trailing: PopupMenuButton<String>(
-                      onSelected: (action) {
-                        switch (action) {
-                          case 'edit':
-                            _addOrEdit(e);
-                          case 'toggle':
-                            _toggleActive(e);
-                          case 'delete':
-                            _delete(e);
-                        }
-                      },
-                      itemBuilder: (_) => [
-                        PopupMenuItem(
-                          value: 'edit',
-                          child: Text(l10n.recurringExpenseEdit),
-                        ),
-                        PopupMenuItem(
-                          value: 'toggle',
-                          child: Text(e.isActive
-                              ? l10n.recurringExpenseInactive
-                              : l10n.recurringExpenseActive),
-                        ),
-                        PopupMenuItem(
-                          value: 'delete',
-                          child: Text(l10n.delete,
-                              style: TextStyle(color: AppColors.error(context))),
-                        ),
-                      ],
+          : CustomScrollView(
+              slivers: [
+                // Hero — total monthly recurring
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 24, bottom: 24),
+                    child: CalmHero(
+                      eyebrow: 'RECORRENTES', // TODO(l10n): move to ARB (Wave H)
+                      amount: formatCurrency(_totalMonthly),
+                      subtitle: '$activeCount ${activeCount == 1 ? 'subscrição ativa' : 'subscrições ativas'}', // TODO(l10n): move to ARB (Wave H)
                     ),
                   ),
-                );
-              },
+                ),
+
+                // Divider before list
+                SliverToBoxAdapter(
+                  child: Divider(
+                    color: AppColors.line(context),
+                    height: 1,
+                  ),
+                ),
+
+                // List of recurring expenses in a grouped card
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 24, bottom: 32),
+                    child: CalmCard(
+                      padding: EdgeInsets.zero,
+                      child: Column(
+                        children: [
+                          for (var i = 0; i < _expenses.length; i++) ...[
+                            if (i > 0)
+                              Divider(
+                                color: AppColors.line(context),
+                                height: 1,
+                                indent: 64,
+                              ),
+                            _RecurringRow(
+                              key: i == 0
+                                  ? RecurringExpensesTourKeys.expenseItem
+                                  : null,
+                              expense: _expenses[i],
+                              localizedCategory:
+                                  _localizedCategory(_expenses[i].category, l10n),
+                              l10n: l10n,
+                              onEdit: () => _addOrEdit(_expenses[i]),
+                              onToggle: () => _toggleActive(_expenses[i]),
+                              onDelete: () => _delete(_expenses[i]),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
     );
   }
 }
+
+// ---------------------------------------------------------------------------
+// Row widget for a single recurring expense inside the grouped card.
+// ---------------------------------------------------------------------------
+class _RecurringRow extends StatelessWidget {
+  const _RecurringRow({
+    super.key,
+    required this.expense,
+    required this.localizedCategory,
+    required this.l10n,
+    required this.onEdit,
+    required this.onToggle,
+    required this.onDelete,
+  });
+
+  final RecurringExpense expense;
+  final String localizedCategory;
+  final S l10n;
+  final VoidCallback onEdit;
+  final VoidCallback onToggle;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final catColor = AppColors.categoryColorByName(expense.category);
+    final subtitleParts = <String>[
+      formatCurrency(expense.amount),
+      if (expense.dayOfMonth != null)
+        '${l10n.recurringExpenseDayOfMonth} ${expense.dayOfMonth}',
+      if (expense.description != null && expense.description!.isNotEmpty)
+        expense.description!,
+      if (!expense.isActive) l10n.recurringExpenseInactive,
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        children: [
+          Expanded(
+            child: CalmListTile(
+              leadingIcon: getCategoryIcon(expense.category),
+              leadingColor: catColor,
+              title: localizedCategory,
+              subtitle: subtitleParts.join(' · '),
+              trailing: expense.isActive ? null : l10n.recurringExpenseInactive,
+            ),
+          ),
+          PopupMenuButton<String>(
+            onSelected: (action) {
+              switch (action) {
+                case 'edit':
+                  onEdit();
+                case 'toggle':
+                  onToggle();
+                case 'delete':
+                  onDelete();
+              }
+            },
+            itemBuilder: (_) => [
+              PopupMenuItem(
+                value: 'edit',
+                child: Text(l10n.recurringExpenseEdit),
+              ),
+              PopupMenuItem(
+                value: 'toggle',
+                child: Text(expense.isActive
+                    ? l10n.recurringExpenseInactive
+                    : l10n.recurringExpenseActive),
+              ),
+              PopupMenuItem(
+                value: 'delete',
+                child: Text(l10n.delete,
+                    style: TextStyle(color: AppColors.bad(context))),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public helper — show the recurring expense edit sheet from other screens.
+// ---------------------------------------------------------------------------
 
 /// Public helper to show the recurring expense edit sheet from other screens.
 /// Pass [preselectedCategory] to pre-select the category chip.
@@ -289,10 +326,9 @@ Future<RecurringExpense?> showEditRecurringSheet(
   RecurringExpense? existing,
   String? preselectedCategory,
 }) {
-  return showModalBottomSheet<RecurringExpense>(
-    context: context,
+  return CalmBottomSheet.show<RecurringExpense>(
+    context,
     isScrollControlled: true,
-    backgroundColor: Colors.transparent,
     builder: (_) => _EditRecurringSheet(
       existing: existing,
       preselectedCategory: preselectedCategory,
@@ -300,11 +336,19 @@ Future<RecurringExpense?> showEditRecurringSheet(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Edit / Add sheet
+// ---------------------------------------------------------------------------
+
 class _EditRecurringSheet extends StatefulWidget {
   final RecurringExpense? existing;
   final List<CustomCategory> customCategories;
   final String? preselectedCategory;
-  const _EditRecurringSheet({this.existing, this.customCategories = const [], this.preselectedCategory});
+  const _EditRecurringSheet({
+    this.existing,
+    this.customCategories = const [],
+    this.preselectedCategory,
+  });
 
   @override
   State<_EditRecurringSheet> createState() => _EditRecurringSheetState();
@@ -376,23 +420,25 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
       initialChildSize: 0.7,
       minChildSize: 0.5,
       maxChildSize: 0.95,
+      expand: false,
       builder: (_, scrollController) => Container(
         decoration: BoxDecoration(
-          color: AppColors.surface(context),
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+          color: AppColors.card(context),
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
         ),
         child: Form(
           key: _formKey,
           child: ListView(
             controller: scrollController,
-            padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+            padding: const EdgeInsets.fromLTRB(24, 12, 24, 32),
             children: [
+              // Drag handle
               Center(
                 child: Container(
                   width: 40,
                   height: 4,
                   decoration: BoxDecoration(
-                    color: AppColors.dragHandle(context),
+                    color: AppColors.ink20(context),
                     borderRadius: BorderRadius.circular(2),
                   ),
                 ),
@@ -403,22 +449,17 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                     ? l10n.recurringExpenseEdit
                     : l10n.recurringExpenseAdd,
                 style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.textPrimary(context),
+                  fontSize: 17,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.ink(context),
                 ),
               ),
-              const SizedBox(height: 20),
+              const SizedBox(height: 24),
 
               // Category
               Text(
                 l10n.recurringExpenseCategory,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textSecondary(context),
-                  letterSpacing: 0.8,
-                ),
+                style: CalmText.eyebrow(context),
               ),
               const SizedBox(height: 8),
               Wrap(
@@ -440,14 +481,14 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                       selected: selected,
                       onSelected: (_) =>
                           setState(() => _selectedCategory = cat),
-                      selectedColor: AppColors.primaryLight(context),
+                      selectedColor: AppColors.accentSoft(context),
                       labelStyle: TextStyle(
                         fontSize: 13,
                         fontWeight:
                             selected ? FontWeight.w600 : FontWeight.w400,
                         color: selected
-                            ? AppColors.primary(context)
-                            : AppColors.textSecondary(context),
+                            ? AppColors.accent(context)
+                            : AppColors.ink70(context),
                       ),
                     );
                   }),
@@ -459,14 +500,14 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                       selected: selected,
                       onSelected: (_) =>
                           setState(() => _selectedCategory = cc.name),
-                      selectedColor: AppColors.primaryLight(context),
+                      selectedColor: AppColors.accentSoft(context),
                       labelStyle: TextStyle(
                         fontSize: 13,
                         fontWeight:
                             selected ? FontWeight.w600 : FontWeight.w400,
                         color: selected
-                            ? AppColors.primary(context)
-                            : AppColors.textSecondary(context),
+                            ? AppColors.accent(context)
+                            : AppColors.ink70(context),
                       ),
                     );
                   }),
@@ -477,12 +518,7 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
               // Amount
               Text(
                 l10n.recurringExpenseAmount,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textSecondary(context),
-                  letterSpacing: 0.8,
-                ),
+                style: CalmText.eyebrow(context),
               ),
               const SizedBox(height: 8),
               TextFormField(
@@ -492,7 +528,8 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                 decoration: InputDecoration(
                   prefixText: currencySymbol(),
                   border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(14),
+                    borderSide: BorderSide(color: AppColors.ink20(context)),
                   ),
                   contentPadding: const EdgeInsets.symmetric(
                       horizontal: 12, vertical: 12),
@@ -510,16 +547,11 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
               Row(
                 children: [
                   Icon(Icons.notifications_outlined,
-                      size: 14, color: AppColors.primary(context)),
+                      size: 14, color: AppColors.accent(context)),
                   const SizedBox(width: 6),
                   Text(
                     l10n.recurringExpenseDayOfMonth,
-                    style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.textSecondary(context),
-                      letterSpacing: 0.8,
-                    ),
+                    style: CalmText.eyebrow(context),
                   ),
                 ],
               ),
@@ -530,9 +562,10 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                 decoration: InputDecoration(
                   hintText: l10n.recurringExpenseDayHint,
                   prefixIcon: Icon(Icons.calendar_today,
-                      size: 18, color: AppColors.textMuted(context)),
+                      size: 18, color: AppColors.ink50(context)),
                   border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(14),
+                    borderSide: BorderSide(color: AppColors.ink20(context)),
                   ),
                   contentPadding: const EdgeInsets.symmetric(
                       horizontal: 12, vertical: 12),
@@ -551,12 +584,7 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
               // Description
               Text(
                 l10n.recurringExpenseDescription,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textSecondary(context),
-                  letterSpacing: 0.8,
-                ),
+                style: CalmText.eyebrow(context),
               ),
               const SizedBox(height: 8),
               TextFormField(
@@ -564,7 +592,8 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                 decoration: InputDecoration(
                   hintText: l10n.recurringExpenseDescription,
                   border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(14),
+                    borderSide: BorderSide(color: AppColors.ink20(context)),
                   ),
                   contentPadding: const EdgeInsets.symmetric(
                       horizontal: 12, vertical: 12),
@@ -581,9 +610,9 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
                   _isActive
                       ? l10n.recurringExpenseActive
                       : l10n.recurringExpenseInactive,
-                  style: TextStyle(color: AppColors.textPrimary(context)),
+                  style: TextStyle(color: AppColors.ink(context)),
                 ),
-                activeThumbColor: AppColors.primary(context),
+                activeColor: AppColors.accent(context),
                 contentPadding: EdgeInsets.zero,
               ),
               const SizedBox(height: 24),
@@ -591,14 +620,14 @@ class _EditRecurringSheetState extends State<_EditRecurringSheet> {
               // Save button
               SizedBox(
                 width: double.infinity,
-                height: 48,
-                child: ElevatedButton(
+                height: 52,
+                child: FilledButton(
                   onPressed: _save,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.primary(context),
-                    foregroundColor: AppColors.onPrimary(context),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.ink(context),
+                    foregroundColor: AppColors.bg(context),
                     shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12)),
+                        borderRadius: BorderRadius.circular(14)),
                     elevation: 0,
                   ),
                   child: Text(


### PR DESCRIPTION
## Summary
Automated delivery from branch `issue-867-recurring-expenses-calm`.

## Linked Issue
Fixes #867

## Release Notes
- Automated delivery for branch `issue-867-recurring-expenses-calm`.
- Merge branch 'main' into issue-867-recurring-expenses-calm
- Merge branch 'main' into issue-867-recurring-expenses-calm
- issue-879: fix(onboarding): always show skip + enable overlay tap on all tours #879 (Fixes #879)
- Merge branch 'main' into issue-867-recurring-expenses-calm
- issue-875: fix(shopping-list): preserve original case in CalmEyebrow group header #875 (Fixes #875)
- issue-873: refactor(plan): rewrite plan hub + plan & shop on Calm #873 (Fixes #873)
- Merge branch 'main' into issue-867-recurring-expenses-calm
- issue-868: refactor(savings-goals): rewrite screen + goal card + add sheet on Calm #868 (Fixes #868)
- Merge branch 'main' into issue-867-recurring-expenses-calm
- refactor(trends): rewrite expense trends + trend sheet on Calm widget library (Fixes #866)
- issue-865: refactor(expense-tracker): rewrite on Calm widget library #865 (Fixes #865)
- issue-867: refactor(recurring-expenses): rewrite on Calm widget library #867
- issue-863: test(dashboard): align functional tests with Calm rewrite #863 (Fixes #863)
- issue-861: feat(widgets): add Calm widgets batch 2 (empty state, sheet, tile) #861 (Fixes #861)
- issue-859: feat(widgets): add Calm widgets batch 1 (scaffold, hero, eyebrow, pill, card) #859 (Fixes #859)
- test(command): update set_color_palette validator tests for calm-only enum #857 (Fixes #857)
- issue-854: test(theme): add Calm invariants harness with grandfathered allow-list #854 (Fixes #854)
- chore(theme): adopt Calm default and pre-warm Fraunces #852 (Fixes #852)
- test(theme): update app_theme_test expected colors to Calm tokens #850 (Fixes #850)
- fix(meal-planner): preserve variety when budget is zero or impossibly tight #848 (Fixes #848)
- ci(agent-delivery): dispatch release-tag.yml after auto-versioned merges #846 (Fixes #846)
- fix(meal-planner): multi-course leftovers, weekly reset, hard filters; auto-release on merge #835 (Fixes #838)
- docs: expand root README with full repository overview (#833) (Fixes #833)
- Merge branch 'main' into issue-828-tax-tables-2026 (Fixes #828)
- feat: update ES/FR tax tables to 2026 + fix salary settings rebuild #828 (Fixes #828)
- fix: add ValueKey to salary TextFormFields for reliable rebuild #828 (Fixes #828)
- feat: update ES/FR tax tables to 2026 + comprehensive tax tests #828 (Fixes #828)
- fix(meal-planner): HARD enforce strong protein in all lunch/dinner mains #795 (Fixes #826)
- chore(release): v2026.6.1 (Fixes #824)
- fix(l10n): repair double/triple UTF-8 encoding corruption in all ARB files #820 (Fixes #820)
- chore(release): v2026.6.0 (Fixes #817)
- feat(meal-planner): courseType field, balanced meals, compact UI, full test suite + E2E (Fixes #795)
- fix: replace non-existent avgKcal with overallScore on nutrition chip #808 (Fixes #808)
- fix: replace non-existent avgKcal with overallScore on nutrition chip #809 (Fixes #809)
- fix(meal-planner): fix dessert/soup categorization false positives (Fixes #795)
- fix(ci): omit --target in release create when tag exists (Fixes #795)
- fix(ci): add comment to retrigger CI for release-tag workflow fix #795 (Fixes #795)
- fix(ci): release-tag.yml — create release even when tag already exists (Fixes #795)
- chore(release): v2026.5.0 (Fixes #797)
- feat(meal-planner): multi-course meals, fix ingredient substitution & shopping list (Fixes #795)
- chore(release): v2026.4.6 — downgrade Kotlin to 2.1.0 for stable release builds #789 (#794)
- chore(release): v2026.4.5 — set Kotlin languageVersion to 2.0 for release builds #789 (#793)
- chore(release): v2026.4.4 — fix Gradle build by removing Base64 dart-define parsing #789 (#791)
- chore(release): v2026.4.3 (#790)
- fix: resolve java.util.Base64 in build.gradle.kts for release builds #784 (#787)
- chore(release): v2026.4.2 #784 (#785)
- issue-781: allow release builds without monetization secrets #781 (Fixes #781)
- issue-781: allow release builds without monetization secrets #781 (#782)
- chore(release): v2026.4.1 — Coach & Command Assistant Polish (#780)
- issue-763: migrate coach to SQLite, add tier history, free trial #763 #768 #770 (#778)
- issue-761: extract CoachChatController and EdgeFunctionClient #761 #762 (#777)
- issue-754: surface offline state in coach/command, persist coach mode, add mounted guard #754 #756 #767 (#776)
- issue-764: add security fixes for AI services #764 #765 #766 #769 (#775)
- issue-750: add FR/ES command regex and help command #750 #755 (#774)
- issue-749: fix command assistant critical issues #749 #752 #753 #757 #758 (#773)
- issue-748: localize coach PT strings and fix delimiter regex #748 #751 (#772)
- issue-747: fix coach critical bugs (timeout, double-tap, copyWith) #747 #759 #760 (#771)
- issue-629: revamp meal planner settings UX #629 (#746)
- issue-637: add unit tests for critical financial flows #637 (#745)
- issue-636: add more tests to push coverage past 45% threshold #636 (#744)
- issue-15: add receipt photo display in expense detail sheet #15 (#742)
- issue-636: add critical path tests and raise coverage to 45% #636 (#741)
- issue-14: add yearly summary service, screen, and tests #14 (#740)
- feat: spending anomaly alerts (#739)
- issue-13: add per-category budget rollover #13 (Fixes #13)
- feat: expense search & filter with extracted logic and tests (Fixes #9)
- Add monthly summary CSV export (Fixes #8)
- Make meal wizard re-accessible after setup (#732)
- Fix expense type switch erasing value (Fixes #17)
- Localize 17 hardcoded UI strings (Fixes #75)
- IRS 2026 tax deduction rules with family-type caps (Fixes #20)
- Show IRS deductions outside detailed dashboard (Fixes #43)
- Fix meal prep guide fallback and label feedback buttons (Fixes #70)
- issue-251: surface grocery store freshness and status in the UI #251 (#727)
- fix: add error handling to all Supabase service calls (Fixes #115)
- feat: support filtering stale grocery stores from comparisons (Fixes #253)
- feat: add grocery freshness metadata to service models (Fixes #250)
- feat: add stale-store fallback messaging for degraded grocery data (Fixes #252)
- issue-116: fix .single() crash with safe maybeSingle alternative #116 (Fixes #116)
- issue-718: lower coverage gate to 40% to match actual non-generated coverage #718 (Fixes #718)
- test: add offline sync component tests (Fixes #718)
- issue-647: add tests for offline sync components #647 (Fixes #647)
- issue-647: strip generated code from lcov coverage report #647 (Fixes #647)
- feat: offline shopping local cache and sync queue (Fixes #647)
- ci: raise coverage gating to 50% #636 (Fixes #636)
- test: stabilize savings goals smoke timing #713 (#714)
- test: add savings goals Playwright smoke #709 (Fixes #709)
- test: stabilize Flutter semantic clicks #707 (Fixes #707)
- test: prefer visible semantic matches #705 (Fixes #705)
- test: avoid Playwright click stalls on Flutter semantics #703 (Fixes #703)
- test: stabilize Playwright semantics helper #701 (Fixes #701)
- ci: allow manual Flutter CI execution #699 (Fixes #699)
- ci: run authenticated Playwright smoke in CI #697 (Fixes #697)
- test: add dashboard Playwright smoke #695 (Fixes #695)
- test: add expense tracker Playwright smoke #693 (Fixes #693)
- test: add shopping list Playwright smoke #691 (Fixes #691)
- test: add auth flow Playwright smoke coverage #637 (Fixes #637)
- test: add Playwright meal planner smoke scaffold #688 (Fixes #688)
- issue-686: defer onboarding tour completion state updates #686 (Fixes #686)
- Merge branch 'main' into issue-445-setup-wizard-default (Fixes #445)
- fix: keep setup wizard pending for empty legacy settings #445 (#679)
- feat: show expense location map in detail sheet #504 (#684)
- fix: lazily create simple repository-backed services #635 (Fixes #635)
- issue-635: introduce repository layer over Supabase #635 (#677)
- feat: use in-app camera preview for receipt photo mode #378 (#682)
- fix: persist setup wizard flag on household creation #446 (Fixes #446)
- fix: persist setup wizard flag on household creation #446 (#680)
- test: avoid pumpAndSettle in receipt photo mode test #379 (#678)
- refactor: migrate models to generated serialization #638 (#676)
- ci: validate runtime secrets and document dart-defines #114 (#675)
- test: skip perf budgets during coverage runs #673 (#674)
- feat: add analytics and user telemetry #648 (#672)
- feat: add structured logging and sentry crash reporting #640 (Fixes #640)
- feat: add structured logging and sentry crash reporting #640 (#670)
- refactor: route quick actions and tabs through typed app routes #646 (Fixes #646)
- chore: link benchmark stabilization to #666 (Fixes #666)
- test: stabilize shopping list performance budget #643 (Fixes #643)
- Merge branch 'main' into issue-643-scoped-app-state (Fixes #643)
- feat: replace global ValueNotifiers with scoped app shell state (Fixes #643)
- issue-642: move hardcoded API keys to --dart-define #642 (Fixes #642)
- test: add performance benchmarks in CI (Fixes #649)
- Merge branch 'main' into issue-644-fix-mounted-guards (Fixes #644)
- issue-644: add consistent mounted guards on async callbacks #644 (Fixes #644)
- Merge branch 'main' into issue-650-add-ios-ci-build (Fixes #650)
- issue-650: add iOS build verification to CI pipeline #650 (Fixes #650)
- test: add cross-service integration flows (Fixes #641)
- issue-639: add global error handling, error boundaries, and custom exceptions #639 (Fixes #639)
- issue-651: add Supabase migration tracking and version control #651 (Fixes #651)
- issue-645: replace magic numbers with named constants #645 (Fixes #645)
- issue-645: replace magic numbers with named constants #645 (Fixes #645)
- issue-650: add iOS build verification to CI pipeline #650 (Fixes #650)
- Revamp meals section with card-based layout (Fixes #630)
- issue-627: fix soup over-selection, ingredient swap visibility, low-protein filter #627 (Fixes #627)
- chore(release): v2026.4.0 (Fixes #626)
- fix: release script minor bump same-month collision (Fixes #622)
- issue-615: fix deep links for quick-add, meals, and assistant #615 (Fixes #615)
- issue-615: fix deep links for quick-add, meals, and assistant #615 (Fixes #615)
- issue-616: localize coach mode recommender keywords for PT/EN/ES/FR #616 (Fixes #616)
- issue-614: fix meal plan notifications hardcoded to true #614 (Fixes #614)
- chore(release): v2026.3.41 (Fixes #613)
- issue-548: fix hardcoded Quick Actions string and add Tier 1 card tests #548 (Fixes #548)
- issue-548: fix hardcoded Quick Actions string and add Tier 1 card tests #548 (Fixes #548)
- issue-549: redesign salary settings with visual hierarchy and semantic states #549 (Fixes #549)
- issue-502: redesign budget settings section with dynamic health colors #502 (Fixes #502)
- issue-491: unify budget category dropdown with custom categories #491 (Fixes #491)
- chore(release): v2026.3.40 (Fixes #605)
- issue-583: waste forecasting with excess ingredient detection #583 (Fixes #583)
- issue-583: waste forecasting with excess ingredient detection #583 (Fixes #583)
- issue-574: weekly nutrition dashboard with progress bars and macro breakdown #574 (Fixes #574)
- issue-574: weekly nutrition dashboard with progress bars and macro breakdown #574 (Fixes #574)
- issue-576: pantry inventory tracking with quantities #576 (Fixes #576)
- issue-576: pantry inventory tracking with quantities #576 (Fixes #576)
- issue-577: fix service file to retain main's methods after rebase #577 (Fixes #577)
- issue-577: recipe rating system with 1-5 stars replacing binary feedback #577 (Fixes #577)
- issue-582: add l10n keys for macro optimization lost during rebase #582 (Fixes #582)
- issue-582: add l10n keys for macro optimization lost during rebase #582 (Fixes #582)
- issue-581: add missing L10n keys for cross-meal swap #581 (Fixes #581)
- issue-579: active vs passive prep time with split display #579 (Fixes #579)
- issue-580: seasonal awareness via grocery pricing data #580 (Fixes #580)
- issue-573: unit conversion in shopping list merge #573 (Fixes #573)
- issue-573: unit conversion in shopping list merge #573 (Fixes #573)
- issue-578: meal plan history with undo after regeneration #578 (Fixes #578)
- issue-572: fix extraGuests not propagated to calculations #572 (Fixes #572)
- issue-575: migrate recipe catalog to Supabase with local fallback #575 (Fixes #575)
- issue-571: fix substitutions ignored in shopping list consolidation #571 (Fixes #571)
- release-v2026.3.39: chore(release): v2026.3.39 (Fixes #563) (Fixes #565) (Fixes #566) (Fixes #569)
- issue-565: ingredient substitution, pantry planning, taste profile, fix shopping list merge #565 (Fixes #565)
- Expand meal planner recipe catalog from 48 to 128 recipes (Fixes #566)
- issue-563: fix meal planner dedup collapse causing same recipe for all meals #563 (Fixes #563)
- chore(release): v2026.3.38 (Fixes #557) (Fixes #559) (Fixes #561)
- issue-559: wire receipt scan button to ReceiptScanSheet + ReviewSheet flow #559 (Fixes #559)
- issue-557: fix expense tracker sync, custom category colors, chip colors, attachment feedback, income UX #557 (Fixes #557)
- issue-555: unify dashboard, remove detailed/focused split, integrate quickActions card #555 (Fixes #555)
- chore(release): v2026.3.36 (Fixes #552) (Fixes #553)
- issue-549: redesign income/salary section with summary header and visual grouping #549 (Fixes #549) (Fixes #549)
- issue-548: add tier-1 dashboard cards with reorderable card system #548 (Fixes #548) (Fixes #548)
- issue-536: add unit tests for categoryIconByName custom categories lookup #536 (Fixes #536)
- chore(release): v2026.3.35 (Fixes #543) (Fixes #544)
- issue-538: add location search and manual address input #538 (Fixes #538) (Fixes #538)
- issue-538: add location search and manual address input #538 (Fixes #538) (Fixes #538)
- issue-536: fix custom category icon not displaying in expense list and dashboard #536 (Fixes #536) (Fixes #536)
- issue-537: fix expense attachment persistence and display #537 (Fixes #537)
- issue-533: settings UX redesign for income section and budget input #533 (Fixes #533) (Fixes #533)
- issue-532: add daily expense reminder notification #532 (Fixes #532) (Fixes #532)
- chore(release): v2026.3.34 (Fixes #531)
- issue-527: fix trial to use account creation date instead of install date #527 (Fixes #527) (Fixes #527)
- chore(release): v2026.3.33 (Fixes #526)
- issue-521: add biometric authentication (app lock) #521 (Fixes #521)
- issue-520: fix OpenStreetMap tile access by adding userAgentPackageName #520 (Fixes #520) (Fixes #520)
- chore(release): v2026.3.32 (Fixes #519)
- issue-515: redesign budget settings with expand/collapse cards and summary header #515 (Fixes #515) (Fixes #515)
- issue-513: fix category icons and colors across all screens #513 (Fixes #513) (Fixes #513)
- chore(release): v2026.3.31 (Fixes #512)
- issue-501: unify category system and redesign budget settings UX #501 #502 (Fixes #501)
- chore(release): v2026.3.30 (Fixes #500)
- issue-496: fix settings detail pages not rebuilding on state changes and add predefined categories #496 (Fixes #496)
- chore(release): v2026.3.29 (Fixes #495)
- Fix category system, expense creation, and settings error handling (Fixes #491)
- chore(release): v2026.3.28 (Fixes #490)
- claude/add-multiple-features-TLnHa: make CategoryService lazy to fix test crashes #481 (Fixes #486)
- feat: add expense location/attachments and enhance settings UI (Fixes #483)
- docs: add plan and issue for coach real data + tier differentiation (Fixes #484)
- docs: add plan and issue for coach real data + tier differentiation (#422)
- chore(release): v2026.3.27 (Fixes #480)
- issue-476: align UI with mockup, re-enable CI, rename package (Fixes #476)
- chore(release): v2026.3.26 (Fixes #475)
- issue-467: fix missing l10n key dashboardPreviousMonth → dashboardVsLastMonth #467 (Fixes #467)
- chore(release): v2026.3.25 (Fixes #471)
- issue-467: second-pass design system alignment with UX mockup #467 (Fixes #467) (Fixes #467)
- issue-465: chore(release): v2026.3.24 #465 (Fixes #465) (Fixes #465)
- issue-459: fix ChipThemeData — remove materialTapTargetSize not in Flutter 3.41 #459 (Fixes #459)
- issue-462: chore(release): v2026.3.23 #462 (Fixes #462) (Fixes #462)
- issue-459: align design system with UX mockup — colors, font, radius, FAB, chips #459 (Fixes #459) (Fixes #459)
- issue-457: add validation SnackBar feedback and amount hint in add_expense_sheet #457 (Fixes #457)
- issue-457: fix 31 UX audit issues — l10n, colors, accessibility, clarity #457 (Fixes #457) (Fixes #457)
- chore(release): v2026.3.22 (Fixes #454) (Fixes #454)
- chore(release): v2026.3.21 #452 (Fixes #452)
- Phase 4-6: Complete UX simplification — onboarding, settings, meal planner (Fixes #450)
- issue-448: disable tests and analysis in all CI pipelines #448 (Fixes #448)
- issue-442: fix release-tag workflow — add workflow_dispatch trigger #442 (Fixes #442)
- chore(release): v2026.3.20 (Fixes #441)
- issue-433: add error recovery retry buttons and fix hardcoded error colors #433 (Fixes #433)
- issue-433: add error recovery retry buttons and fix hardcoded error colors #433 (Fixes #433)
- issue-435: centralize category colors and status colors into AppColors #435 (Fixes #435)
- issue-432: fix UI/UX audit issues — localize hardcoded strings, fix colors, text overflow, tap targets #432 (Fixes #432)
- issue-428-429-430: restore full dashboard, collapse all settings, fix meal wizard exit #428 #429 #430 (Fixes #428)
- issue-424: improve coach prompt quality — all categories, more transactions, item names, no hypotheticals #424 (Fixes #424)
- issue-423: add ROI credit purchase sheet, inline micro-action tag, and CreditPack model #423 (Fixes #423)
- chore(release): v2026.3.19 (Fixes #415) (Fixes #415)
- chore(release): v2026.3.18 (Fixes #415) (Fixes #415)
- chore(release): v2026.3.17 (Fixes #415) (Fixes #415)
- chore(release): v2026.3.16 (Fixes #415) (Fixes #415)
- chore(release): v2026.3.15 (Fixes #415) (Fixes #415)
- feat: implement credit monetization features #415 (Fixes #415)
- chore(release): v2026.3.14 (Fixes #414)
- issue-410: auto-resolve bot review threads before merge #410 (Fixes #410)
- chore(release): v2026.3.13 (Fixes #409)
- issue-405: fix release builds to produce APK/AAB artifacts #405 (Fixes #405)
- fix: build APK/AAB in release-tag workflow to fix missing release artifacts (Fixes #403)
- chore(release): v2026.3.12 (Fixes #402)
- issue-393: add release tagging to agent-delivery workflow #393 (Fixes #393)
- issue-393: fix release-tag workflow trigger to use push instead of pull_request #393 (Fixes #393)
- chore(release): v2026.3.12 (Fixes #397)
- issue-393: fix release script to work with protected branches #393 (Fixes #393)
- chore(release): v2026.3.11 (Fixes #391)
- Detect invoice barcodes in product scanner (Fixes #388)
- issue-385: fix em-dash unicode rendering in onboarding tour ARB files #385 (Fixes #385)
- issue-385: fix 5 bugs found during Playwright testing (Fixes #385)
- issue-383: defer non-critical service init to after UI render (Fixes #383)
- Merge branch 'main' into issue-123-localize-hardcoded-strings (Fixes #123)
- Merge remote-tracking branch 'origin/main' into issue-123-localize-hardcoded-strings (Fixes #123)
- issue-380: optimize app lifecycle - debounce resume, batch setState, pause streams (Fixes #380)
- issue-376: inline validate-pr check in agent-delivery workflow (Fixes #376)
- issue-372: trigger validate-pr check (Fixes #374)
- feat(meals): add per-meal preparation guide with offline prep steps (Fixes #372)
- issue-368: chore(release): v2026.3.10 (Fixes #368) (Fixes #369)
- issue-366: wire receipt scanner to UI with camera permissions and review sheet (Fixes #366)
- chore(release): v2026.3.9 (Fixes #364)
- issue-361: fix R8 release build with ML Kit ProGuard rules (Fixes #361)
- chore(release): v2026.3.8 (Fixes #358)
- issue-338: replace sourceMealLabel with sourceMealLabels (N:N) (Fixes #338)
- issue-338: replace sourceMealLabel with sourceMealLabels (N:N) (Fixes #338)
- Merge remote-tracking branch 'origin/main' into issue-326-milestone-5-grocery-rollout (Fixes #326)
- feat(grocery): complete milestone 5 country-aware rollout (#326) (Fixes #326)
- Merge origin/main into issue-331-milestone-6-grocery-workflows (Fixes #331)
- feat(grocery): add reusable country-store scrape workflows (#331) (Fixes #331)
- Merge origin/main into issue-228-pt-country-bundle (Fixes #228)
- feat(grocery): build PT country bundle artifacts (#228) (Fixes #228)
- Merge branch 'main' into issue-340-milestone-8-grocery-freshness (Fixes #340)
- feat(grocery): add freshness and stale-store UX (#340) (Fixes #340)
- Merge origin/main into issue-344-milestone-9-grocery-matching (Fixes #344)
- feat(grocery): add matching diagnostics and overrides (#344) (Fixes #344)
- Merge branch 'main' into issue-346-milestone-10-grocery-scale (Fixes #346)
- docs(grocery): add scale-out preparation guidance (#346) (Fixes #346)
- Merge branch 'main' into issue-337-milestone-7-es-rollout (Fixes #337)
- feat(grocery): add Spain grocery rollout preview (#337) (Fixes #337)
- issue-332: add quantity/unit to ShoppingItem, fix dedup aggregation, hide empty tabs #332 #333 #334 (Fixes #332)
- issue-332: add quantity/unit to ShoppingItem, fix dedup aggregation, hide empty tabs #332 #333 #334 (Fixes #332)
- Merge branch 'main' into issue-231-country-aware-loader (Fixes #231)
- feat(grocery): make asset loading country-aware (#231) (Fixes #231)
- feat(grocery): add PT duplicate and unmatched reporting (#230) (Fixes #230)
- feat(grocery): add PT duplicate and unmatched reporting (#230) (Fixes #230)
- feat(grocery): add PT store freshness summaries (#229) (Fixes #229)
- feat(grocery): add PT store freshness summaries (#229) (Fixes #229)
- feat(grocery): add PT canonical matching pipeline (#227) (Fixes #227)
- feat(grocery): add PT canonical matching pipeline (#227) (Fixes #227)
- feat(grocery): add PT listing normalization pipeline (#226) (Fixes #226)
- feat(grocery): add PT listing normalization pipeline (#226) (Fixes #226)
- test(grocery): add PT scraper smoke validation (#224) (Fixes #224)
- test(grocery): add PT scraper smoke validation (#224) (Fixes #224)
- feat(grocery): emit PT store status artifacts (#223) (Fixes #223)
- feat(grocery): emit PT store status artifacts (#223) (Fixes #223)
- feat(grocery): add Pingo Doce and Auchan scraper adapters (#222) (Fixes #222)
- feat(grocery): add Pingo Doce and Auchan scraper adapters (#222) (Fixes #222)
- issue-285: include receipt scanner l10n keys for post-shopping prompt #285 (Fixes #285)
- issue-284: handle scanReceipt case in app_home switch #284 (Fixes #284)
- issue-284: handle scanReceipt case in app_home switch #284 (Fixes #284)
- Merge branch 'main' into issue-221-continente-adapter (Fixes #221)
- feat(grocery): add Continente store scraper adapter (#221) (Fixes #221)
- Merge pull request #287 from lfrmonteiro99/issue-220-store-scraper-interface
- Merge branch 'main' into issue-220-store-scraper-interface
- trigger: re-run PR checks (Fixes #283)
- issue-285: show scan receipt prompt when all shopping items checked #285 (Fixes #283)
- trigger: re-run PR checks (Fixes #282)
- issue-282: add OCR pipeline and full scan orchestration #282 (Fixes #282)
- issue-281: implement ReceiptScanService QR code pipeline #281 (Fixes #281)
- issue-281: implement ReceiptScanService QR code pipeline #281 (Fixes #281)
- issue-276: fix unnecessary cast in MerchantRegistryService #276 (Fixes #276)
- issue-276: fix unnecessary cast in MerchantRegistryService #276 (Fixes #276)
- issue-280: add AI fallback matching for unmapped receipt items #280 (Fixes #280)
- issue-280: add AI fallback matching for unmapped receipt items #280 (Fixes #280)
- issue-279: implement fuzzy matching for receipt items #279 (Fixes #279)
- issue-279: implement fuzzy matching for receipt items #279 (Fixes #279)
- issue-278: implement receipt text parser for Portuguese receipts #278 (Fixes #278)
- issue-278: implement receipt text parser for Portuguese receipts #278 (Fixes #278)
- issue-274: implement ATCUD QR code parser for Portuguese invoices #274 (Fixes #274)
- issue-274: implement ATCUD QR code parser for Portuguese invoices #274 (Fixes #274)
- issue-277: add google_mlkit_text_recognition and image_picker deps #277 (Fixes #277)
- issue-277: add google_mlkit_text_recognition and image_picker deps #277 (Fixes #277)
- issue-286: add receipt scanner localization strings #286 (Fixes #286)
- issue-286: add receipt scanner localization strings #286 (Fixes #286)
- issue-273: add ParsedReceipt and ReceiptLineItem models #273 (Fixes #273)
- feat(grocery): define reusable store scraper interface (#220)
- Merge branch 'main' into issue-134-fix-arb-utf8-encoding (Fixes #134)
- issue-134: fix UTF-8 encoding issues in Spanish and French ARB files #134 (#255)
- Merge branch 'main' into issue-123-localize-hardcoded-strings (Fixes #123)
- issue-123: replace hardcoded strings with localized equivalents #123 (#259)
- Merge branch 'main' into issue-219-fix-delivery-issue-extraction (Fixes #219)
- issue-219: add Fixes keyword to squash merge commit for auto-close #219 (Fixes #219)
- issue-124: refactor main.dart - split AppHome into separate files #124 (#258)
- issue-124: refactor main.dart - split AppHome into separate files #124 (#256)
- issue-122: add constructor validation for monetary fields #122 (#257)
- issue-122: add constructor validation for monetary fields #122 (#249)
- issue-132: lower coverage threshold to 25% (current ~29%) #132 (#254)
- issue-132: add coverage reporting, l10n validation, and SAST to CI/CD #132 (#248)
- Merge branch 'main' into issue-217-multi-country-grocery-architecture (#247)
- docs(grocery): design multi-country pricing architecture (#217) (#218)
- docs(grocery): add dependency map for multi-country rollout (#217) (#241)
- issue-219: fix agent-delivery extracting wrong issue number from commits (#225)
- fix: show actual errors instead of silently failing, validate all CI secrets (#216)
- fix: show actual errors instead of silently failing, validate all CI secrets (#211)
- fix(android): correct quick shortcut resources (#209) (#210)
- issue-164: trigger CI (#208)
- issue-164: fix review feedback - title rebuild and duplicate slot prevention (#207)
- Freeform Meals (#181)
- issue-167: add quick capture outside the app (#203)
- issue-167: add quick capture outside the app (#180)
- issue-168: add barcode scanning (#201)
- issue-168: add barcode scanning (#179)
- issue-166: add collaboration transparency / household activity (#199)
- issue-166: add collaboration transparency / household activity (#177)
- issue-163: add pantry-light UX (#197)
- issue-163: add pantry-light UX (#176)
- issue-165: add trust center / confidence center (#195)
- issue-165: add trust center / confidence center (#175)
- issue-171: add in-app changelog and roadmap visibility (#193)
- issue-171: add in-app changelog and roadmap visibility (#174)
- issue-170: add import/export for planning artifacts (#191)
- issue-170: add import/export for planning artifacts (#172)
- issue-169: add shopping execution improvements (#182)
- issue-169: add shopping execution improvements (#173)
- issue-162: add budget-aware meal planning UX (#178)
- fix: improve accessibility (touch targets, semantics, drag handles) #133 (#161)
- fix: improve accessibility (touch targets, semantics, drag handles) #133 (#154)
- feat: add rate limiting to AI features (coach, meal planner, commands) #135 (#160)
- feat: add rate limiting to AI features (coach, meal planner, commands) #135 (#152)
- fix: clamp daysLeft/daysRemaining to zero at month boundaries #136 (#159)
- fix: clamp daysLeft/daysRemaining to zero at month boundaries #136 (#151)
- fix: add missing mounted checks after await to prevent setState on disposed widgets #125 (#158)
- fix: add missing mounted checks after await to prevent setState on disposed widgets #125 (#150)
- feat: add undo snackbar for expense deletion #130 (#157)
- feat: add undo snackbar for expense deletion #130 (#149)
- fix: wire up Terms of Service and Privacy Policy buttons in PaywallScreen #131 (#156)
- fix: wire up Terms of Service and Privacy Policy buttons in PaywallScreen #131 (#147)
- fix: add form validation to setup wizard salary step #128 (#155)
- fix: add form validation to setup wizard salary step #128 (#148)
- fix: use Random.secure() for household invite code generation #126 (#146)
- fix: sanitize user input in AI Coach to prevent prompt injection #119 (#145)
- fix: sanitize user input in AI Coach to prevent prompt injection #119 (#140)
- fix: add error boundary around main() service initialization #118 (#144)
- fix: add error boundary around main() service initialization #118 (#139)
- fix: remove push trigger from PR governance to eliminate race condition #137 (#143)
- fix: remove push trigger from PR governance to eliminate race condition #137 (#138)
- fix: remove const from constructor call sites after adding assert() validation #121 #122 (#142)
- fix: gate canUseAI() behind RevenueCat subscription check #120 (#141)
- Resolve merge conflicts with main, keeping trial extension features (#113)
- Improve trial-to-free transition: extend trial, add nudges, pre-expiry reminder, and extension option (#111)
- chore: retrigger CI checks (#109)
- claude/trial-to-free-transition-qqYVE (#105)
- ci: re-trigger governance check after PR body update (#103)
- claude/fix-onboarding-cards-tLcCZ (#100)
- ci: trigger governance re-check after merge conflict resolution (#99)
- claude/improve-savings-goal-explanation-EnjZI (#96)
- fix(ci): use root workflow as single source of truth (#77) (#93)
- fix(ci): use root workflow as single source of truth (#77) (#92)
- issue-86: add onboarding tours for expense tracker, savings goals, recurring expenses, and command assistant (#90)
- issue-86: add onboarding tours for expense tracker, savings goals, recurring expenses, and command assistant (#89)
- chore(release): v2026.3.5 (#88)
- fix(ci): align release build with Supabase dart-defines (#77) (#85)
- issue-77: pass Supabase secrets via --dart-define in CI build (#84)
- fix: restore authError getters dropped during merge (#82)
- claude/new-session-HsuIN (#79)
- issue-77: pass Supabase secrets via --dart-define in CI build (#78)
- issue-72: fix(coach): resolve undefined l10n in _buildComposer and _buildModeCard (#76)
- issue-72-in-app-explanations (#73)
- feat(command): add shopping toggle and expense delete actions (#69) (#74)
- fix(ci): stop relying on ignored supabase config (#71)
- fix(ci): read changelog from build working directory (#66) (#67)
- chore(release): v2026.3.2 (#65)
- fix(ci): enforce validate-pr on push with PR-aware resolution (#60) (#63)
- chore(ci): trigger non-interference pipeline status run (#60) (#62)
- fix(ci): read PR metadata from event payload in governance check (#58) (#61)
- chore(ci): run end-to-end automation smoke test (#58) (#59)
- chore(ci): trigger pr governance synchronize event (#54) (#57)
- fix(ci): harden agent delivery merge flow for stale pipelines (#54) (#56)
- feat(coach): wire eco/plus/pro fallback UX (#53)
- feat(coach): add memory/credits architecture foundation (#52)
- Merge branch 'main' into issue-48-verify-jwt-openai-chat (#50)
- fix(ai): enforce jwt auth for openai-chat invocations (#49)
- fix: add AI coach fallback when edge function returns 404 (#47)
- fix: add AI coach fallback when edge function returns 404 (#46)
- test(settings): ensure invite refresh button is visible before tap (#44)
- fix(ci): make pr-governance regex POSIX-compatible (#42)
- chore(repo): remove legacy root stacks and keep flutter-focused layout (#41)
- chore(ci): enforce issue-first automation and governance (#39)
- ci: run flutter checks on pull_request to unblock auto-merge
- merge: sync main with origin/main before release publication
- chore: setup automated issue workflow and release management
- claude/budget-calculator-app: fix savings UUID mismatch and add atomic contribution RPCs
- claude/budget-calculator-app-TFWgZ (#36)
- claude/budget-calculator-app: add new screens, RevenueCat ads, l10n updates, and expanded tests
- Fix feature switch fallthrough and restore pt locale encoding
- Fix analyzer errors for RevenueCat integration
- Migrate AI calls to Supabase Edge Function and add mobile validation checklist
- Merge pull request #35 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app-TFWgZ (#34)
- claude/budget-calculator-app: unify CI pipeline and fix test trigger
- claude/budget-calculator-app: show savings goals card empty state on dashboard
- claude/budget-calculator-app-TFWgZ (#33)
- claude/budget-calculator-app: fix brittle swap day test assertion
- claude/budget-calculator-app: build both APK and AAB in CI pipeline
- Fix Supabase sync workflow IPv6 issue by forcing IPv4 hostaddr
- claude/budget-calculator-app-TFWgZ (#32)
- Merge branch 'main' into claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app: fix flutter analyze warnings in test files
- claude/budget-calculator-app-TFWgZ (#31)
- Merge branch 'main' into claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app: add AdMob banner ads for free tier after trial
- claude/budget-calculator-app-TFWgZ (#30)
- Merge branch 'main' into claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app: add auto-PR creation and auto-merge on test pass
- claude/budget-calculator-app: update CI to build AAB + add Play Store release guide
- Merge pull request #29 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app: fix PR review issues — category override duplication, scraper unit filtering, test failures
- chore: update grocery prices 2026-03-04
- Merge pull request #28 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app-TFWgZ: fix supabase-price-sync working directory
- Merge pull request #27 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app-TFWgZ: track all untracked test files
- claude/budget-calculator-app-TFWgZ: fix CI flutter analyze errors
- Merge pull request #26 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- fix(l10n): repair arb JSON commas in translation files
- Move supabase price sync workflow to repository root
- Merge pull request #25 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- Merge branch 'main' into claude/budget-calculator-app-TFWgZ
- Restrict Supabase price sync workflow to main branch
- Merge pull request #24 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- Merge pull request #23 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- Add GitHub Actions workflow to scrape prices and apply SQL to Supabase
- Tighten product matching and regenerate strict supermarket SQL updates
- claude/budget-calculator-app-TFWgZ: fix all flutter analyze warnings
- Add PT supermarket scraper and generated Supabase product price updates
- Merge pull request #21 from lfrmonteiro99/claude/budget-calculator-app-TFWgZ
- Merge pull request #22 from lfrmonteiro99/claude/flutter-monetization-planning-fzwge
- claude/budget-calculator-app-TFWgZ: fix PR review bugs + CI supabase config stub
- claude/budget-calculator-app-TFWgZ: add CI/CD and releases documentation
- claude/budget-calculator-app-TFWgZ: add signed APK build + GitHub Releases to CI
- Add tier hierarchy, defaults, name strings, and transition tests
- claude/budget-calculator-app-TFWgZ: meal planner AI enrichment + CI + test fixes
- Add missing tier and subscription edge-case tests
- Add comprehensive tests for subscription service, widgets, and paywall
- Add unit tests for Flutter model classes
- Add 14-day free trial subscription system with feature gating and paywall
- Add comprehensive monetization strategy plan for Flutter app
- claude/budget-calculator-app-TFWgZ: rewrite persona timeline with real pain points and emotional storytelling
- claude/budget-calculator-app-TFWgZ: terminology fix, merge recurring into budget categories, persona timeline on website
- Merge pull request #19 from lfrmonteiro99/claude/add-translations-locale-selector-cURgW
- Add i18n infrastructure for React web app (WIP)
- Add translations and locale selector to docs website
- Merge pull request #18 from lfrmonteiro99/claude/build-budget-app-website-fRwsi
- claude/build-budget-app-website-fRwsi: redesign website UX/UI, add favicon and unified app icon
- claude/budget-calculator-app-TFWgZ: 5 features + onboarding tours with auto-scroll
- feat: add promotional website with privacy policy and terms of use
- claude/budget-calculator-app: fixed vs variable budgets, monthly budget reset, merge food card into budget vs actual, generalized pace alerts, export/search, savings goals, recurring expenses, notifications, expense trends, theme system
- chore: update grocery prices 2026-03-03
- chore: update grocery prices 2026-03-02
- claude/budget-calculator-app-TFWgZ: reorganize settings screen UX
- claude/budget-calculator-app-TFWgZ: expense tracking — budget vs actual per category
- claude/budget-calculator-app-TFWgZ: wave 3 — per-recipe nutrition, calorie/macro targets, medical conditions
- claude/budget-calculator-app-TFWgZ: wave 2 — household profiles, seasonal boost, meal feedback
- claude/budget-calculator-app-TFWgZ: wave 1 — 9 new meal planner settings
- claude/budget-calculator-app-TFWgZ: fix meal plan variety — protein diversity, favorites boost, consecutive dedup
- claude/budget-calculator-app-TFWgZ: fix meal planner audit issues — 3 critical, 7 high/medium bugs
- claude/budget-calculator-app-TFWgZ: meal planner quality overhaul — fix critical bugs, expand catalog, UX improvements
- chore: update grocery prices 2026-03-01
- chore: update grocery prices 2026-02-28
- chore: update grocery prices 2026-02-27
- claude/budget-calculator-app-TFWgZ: fix all flutter analyze warnings
- feat(flutter): comprehensive UX/UI audit - design, usability, accessibility
- Merge remote-tracking branch 'origin/claude/audit-ux-ui-design-yaNeP' into claude/budget-calculator-app-TFWgZ
- Merge remote-tracking branch 'origin/claude/budget-calculator-app-TFWgZ' into claude/budget-calculator-app-TFWgZ
- claude/budget-calculator-app-TFWgZ: add mid-month budget alerts, month review, and minimalist dashboard preset
- feat: add dark mode, skeleton loading, toast, view transitions, expense reorder
- feat: comprehensive UX/UI audit - fix accents, accessibility, and visual polish
- claude/budget-calculator-app-TFWgZ: show exempt-only salaries in dashboard + manual household size in meal settings
- claude/budget-calculator-app-TFWgZ: add expense history, trend charts, and local dashboard config
- claude/budget-calculator-app-TFWgZ: add trend charts and projection simulator
- chore: update grocery prices 2026-02-26
- claude/budget-calculator-app-TFWgZ: sync household data on resume + shared coach insights
- claude/budget-calculator-app-TFWgZ: add duodécimos, exempt income, and N-salary support
- claude/budget-calculator-app-TFWgZ: add 3-part AI analysis and insight history
- claude/budget-calculator-app-TFWgZ: rework AI coach with stress index context
- claude/budget-calculator-app-TFWgZ: add financial tranquility index to dashboard
- claude/budget-calculator-app-TFWgZ: rename app to Gestão Mensal, fix email confirmation deep link
- claude/budget-calculator-app-TFWgZ: add meal settings with wizard, multi-meal generator, and settings UI
- claude/budget-calculator-app-TFWgZ: add meal settings design doc
- chore: update grocery prices 2026-02-25
- claude/budget-calculator-app-TFWgZ: fix joinHousehold via security definer RPC to bypass RLS
- claude/budget-calculator-app-TFWgZ: fix logout navigation and invite code join (remove FK join causing RLS block)
- claude/budget-calculator-app-TFWgZ: add logout button to settings, fix invite code expiry
- claude/budget-calculator-app-TFWgZ: fix finalize shopping - clear checked items optimistically and order history newest first
- claude/budget-calculator-app-TFWgZ: fix shopping list toggle, expandable purchase history
- claude/budget-calculator-app-TFWgZ: add purchase history to shopping list screen
- claude/budget-calculator-app-TFWgZ: fix finalize purchase and add history view
- claude/budget-calculator-app-TFWgZ: products catalog, shopping list flat view, finalize fix
- claude/budget-calculator-app-TFWgZ: fix household creation via security definer RPC
- claude/budget-calculator-app-TFWgZ: make all household members admins
- claude/budget-calculator-app-TFWgZ: fix infinite loading loop in AuthGate after login
- claude/budget-calculator-app-TFWgZ: add Supabase multi-user integration with Auth, households, RLS, and Realtime shopping list
- claude/budget-calculator-app-TFWgZ: fix settings inputs, icon consistency, favorites in meal planner, add shopping spending tracker and food budget card
- claude/budget-calculator-app-TFWgZ: fix locale crash on meal planner screen
- chore: update grocery prices 2026-02-24
- claude/budget-calculator-app-TFWgZ: add meal planner feature with greedy cluster algorithm, OpenAI enrichment, and shopping list integration
- claude/budget-calculator-app-TFWgZ: add meal planner design doc
- claude/budget-calculator-app-TFWgZ: add OpenAI coach screen
- claude/budget-calculator-app-TFWgZ: add shopping list feature with category expansion
- claude/budget-calculator-app-TFWgZ: fix comparisons cache and add favorites feature
- chore: update grocery prices 2026-02-23
- Merge pull request #7 from lfrmonteiro99/claude/add-internet-permission-android-FxhD1
- fix: always prefer bundled asset over stale remote data
- chore: update grocery prices 2026-02-23
- Merge pull request #6 from lfrmonteiro99/claude/add-internet-permission-android-FxhD1
- feat: add product favorites with settings management and priority display
- Merge pull request #5 from lfrmonteiro99/claude/add-internet-permission-android-FxhD1
- Merge branch 'claude/budget-calculator-app-TFWgZ' into claude/add-internet-permission-android-FxhD1
- fix: improve cross-store product matching and populate grocery_prices.json
- chore: ignore Python __pycache__ and .pyc files
- fix: correct remaining Auchan URLs and verify all scrapers return products
- Merge pull request #4 from lfrmonteiro99/claude/add-internet-permission-android-FxhD1
- chore: update grocery prices 2026-02-23
- fix: use correct product parsers for all three store scrapers
- chore: update grocery prices 2026-02-23
- fix: update scraper URLs for Continente, Pingo Doce, and Auchan
- chore: update grocery prices 2026-02-23
- Merge pull request #3 from lfrmonteiro99/claude/grocery-prices-pipeline-hs2vr
- feat: Fetch fresh grocery prices from GitHub Pages for installed apps
- Merge pull request #2 from lfrmonteiro99/claude/flutter-vs-kotlin-evaluation-DyveO
- feat: Add grocery price comparison with daily scraping
- Merge pull request #1 from lfrmonteiro99/claude/flutter-vs-kotlin-evaluation-DyveO
- chore: Add remaining Flutter scaffold files
- feat: Migrate budget calculator app to Flutter
- docs: Add Flutter vs Kotlin Multiplatform evaluation for mobile port
- feat: Add PWA support for mobile install without APK
- feat: Add meal allowance (subsidio de alimentacao) per salary
- feat: Move titulares to per-salary setting
- feat: Complete UI/UX redesign with clean light theme
- feat: Store settings in JSON file via Tauri instead of localStorage
- chore: Normalize Cargo.toml features from tauri init
- chore: Add Cargo.lock from Tauri Rust build
- feat: Create monthly budget calculator app with Tauri v2
