### PR TITLE
fix(ui): 4 high-severity dead taps (dashboard chevron, grocery empty, Ementa paywall, notification save) #984

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -2134,6 +2134,7 @@ class _AppHomeState extends State<AppHome> with WidgetsBindingObserver {
           showMealsTour: !_onboardingState.isTourDone('meals'),
           onMealsTourComplete: () => _markTourDone('meals'),
           canAccessMeals: _subscription.hasPremiumAccess,
+          onUpgrade: () => _openPaywall(blockedFeature: PremiumFeature.mealPlanner),
         ),
       ),
       AppTab.more: ErrorBoundary(

--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -34,6 +34,7 @@ import '../widgets/info_icon_button.dart';
 import '../utils/savings_projections.dart';
 import '../onboarding/dashboard_tour.dart';
 import '../models/notification_preferences.dart';
+import '../services/local_config_service.dart';
 import 'notification_settings_screen.dart';
 import 'tax_deduction_detail_screen.dart';
 import 'tax_simulator_screen.dart';
@@ -246,8 +247,6 @@ class _DashboardScreenState extends State<DashboardScreen> {
     return CalmHeader(
       eyebrow: eyebrow,
       title: monthLabel,
-      // Chevron is decoration-only in M1; picker wired in M1b.
-      onTitleTap: () {},
       actions: [
         Tooltip(
           message: l10n.notificationSettings,
@@ -273,12 +272,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
     );
   }
 
-  void _openNotificationSettings(BuildContext context) {
-    Navigator.of(context).push(
+  Future<void> _openNotificationSettings(BuildContext context) async {
+    final config = LocalConfigService();
+    final prefs = await config.loadNotificationPreferences();
+    if (!context.mounted) return;
+    await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => NotificationSettingsScreen(
-          preferences: NotificationPreferences(),
-          onSave: (_) {},
+          preferences: prefs,
+          onSave: (updated) => config.saveNotificationPreferences(updated),
         ),
       ),
     );

--- a/monthy_budget_flutter/lib/screens/grocery_screen.dart
+++ b/monthy_budget_flutter/lib/screens/grocery_screen.dart
@@ -444,6 +444,10 @@ class _GroceryScreenState extends State<GroceryScreen> {
       icon: Icons.shopping_cart_outlined,
       title: l10n.groceryEmptyStateTitle,
       body: l10n.groceryEmptyStateMessage,
+      action: CalmEmptyStateAction(
+        label: l10n.barcodeScanTooltip,
+        onPressed: _onScanBarcode,
+      ),
     );
   }
 

--- a/monthy_budget_flutter/lib/screens/plan_and_shop_screen.dart
+++ b/monthy_budget_flutter/lib/screens/plan_and_shop_screen.dart
@@ -62,6 +62,7 @@ class PlanAndShopScreen extends StatefulWidget {
 
   // Premium gate
   final bool canAccessMeals;
+  final VoidCallback? onUpgrade;
 
   const PlanAndShopScreen({
     super.key,
@@ -92,6 +93,7 @@ class PlanAndShopScreen extends StatefulWidget {
     this.showMealsTour = false,
     this.onMealsTourComplete,
     this.canAccessMeals = true,
+    this.onUpgrade,
   });
 
   @override
@@ -406,12 +408,18 @@ class _PlanAndShopScreenState extends State<PlanAndShopScreen> {
         const SizedBox(width: 12),
         Expanded(
           child: CalmTile(
-            icon: Icons.restaurant_menu_outlined,
+            icon: widget.canAccessMeals
+                ? Icons.restaurant_menu_outlined
+                : Icons.lock_outlined,
             label: 'Ementa',
-            count: _plan != null
-                ? '${_plan!.days.length} refeições'
-                : 'sem plano',
-            onTap: widget.canAccessMeals ? () => _openEmenta(context) : null,
+            count: widget.canAccessMeals
+                ? (_plan != null
+                    ? '${_plan!.days.length} refeições'
+                    : 'sem plano')
+                : 'Premium',
+            onTap: widget.canAccessMeals
+                ? () => _openEmenta(context)
+                : (widget.onUpgrade ?? () => _openEmenta(context)),
           ),
         ),
         const SizedBox(width: 12),


### PR DESCRIPTION
## Summary
Automated delivery from branch `issue-983-dead-taps-fixes`.

## Linked Issue
Fixes #985
