### PR TITLE
issue-1102: refactor(calm): final sweep — residual UI color literals to tokens

### DIFF
--- a/monthy_budget_flutter/lib/screens/settings_screen.dart
+++ b/monthy_budget_flutter/lib/screens/settings_screen.dart
@@ -1023,7 +1023,8 @@ class _EditCustomCategorySheetState extends State<_EditCustomCategorySheet> {
                         ),
                       ),
                       child: selected
-                          ? const Icon(Icons.check, color: Colors.white, size: 20)
+                          ? Icon(Icons.check,
+                              color: AppColors.bg(context), size: 20)
                           : null,
                     ),
                   );

--- a/monthy_budget_flutter/lib/widgets/add_expense_sheet.dart
+++ b/monthy_budget_flutter/lib/widgets/add_expense_sheet.dart
@@ -674,8 +674,8 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                             Marker(
                               point: latlong.LatLng(
                                   _locationLat!, _locationLng!),
-                              child: const Icon(Icons.location_pin,
-                                  color: Colors.red, size: 40),
+                              child: Icon(Icons.location_pin,
+                                  color: AppColors.bad(context), size: 40),
                             ),
                           ]),
                         ],
@@ -829,12 +829,12 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                           child: GestureDetector(
                             onTap: () => _removeExistingAttachment(i),
                             child: Container(
-                              decoration: const BoxDecoration(
-                                  color: Colors.red,
+                              decoration: BoxDecoration(
+                                  color: AppColors.bad(context),
                                   shape: BoxShape.circle),
                               padding: const EdgeInsets.all(2),
-                              child: const Icon(Icons.close,
-                                  size: 14, color: Colors.white),
+                              child: Icon(Icons.close,
+                                  size: 14, color: AppColors.bg(context)),
                             ),
                           ),
                         ),
@@ -863,12 +863,12 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                           child: GestureDetector(
                             onTap: () => _removeNewAttachment(i),
                             child: Container(
-                              decoration: const BoxDecoration(
-                                  color: Colors.red,
+                              decoration: BoxDecoration(
+                                  color: AppColors.bad(context),
                                   shape: BoxShape.circle),
                               padding: const EdgeInsets.all(2),
-                              child: const Icon(Icons.close,
-                                  size: 14, color: Colors.white),
+                              child: Icon(Icons.close,
+                                  size: 14, color: AppColors.bg(context)),
                             ),
                           ),
                         ),

--- a/monthy_budget_flutter/lib/widgets/expense_detail_sheet.dart
+++ b/monthy_budget_flutter/lib/widgets/expense_detail_sheet.dart
@@ -173,9 +173,9 @@ class ExpenseDetailSheet extends StatelessWidget {
                                 expense.locationLat!,
                                 expense.locationLng!,
                               ),
-                              child: const Icon(
+                              child: Icon(
                                 Icons.location_pin,
-                                color: Colors.red,
+                                color: AppColors.bad(context),
                                 size: 40,
                               ),
                             ),

--- a/monthy_budget_flutter/lib/widgets/nutrition_dashboard_card.dart
+++ b/monthy_budget_flutter/lib/widgets/nutrition_dashboard_card.dart
@@ -166,7 +166,7 @@ class NutritionDashboardCard extends StatelessWidget {
                   current: stats.avgProteinG,
                   target: settings.dailyProteinTargetG!.toDouble(),
                   unit: 'g',
-                  color: Colors.blue,
+                  color: AppColors.chartIndigo(context),
                 ),
               ],
               if (settings.dailyFiberTargetG != null) ...[
@@ -275,9 +275,9 @@ class _MacroRow extends StatelessWidget {
     return Wrap(
       spacing: 8,
       children: [
-        _MacroChip(label: '${l10n.nutritionProtein} ${stats.proteinPct}%', color: Colors.blue),
+        _MacroChip(label: '${l10n.nutritionProtein} ${stats.proteinPct}%', color: AppColors.chartIndigo(context)),
         _MacroChip(label: '${l10n.nutritionCarbs} ${stats.carbsPct}%', color: AppColors.warning(context)),
-        _MacroChip(label: '${l10n.nutritionFat} ${stats.fatPct}%', color: Colors.purple),
+        _MacroChip(label: '${l10n.nutritionFat} ${stats.fatPct}%', color: AppColors.chartRed(context)),
       ],
     );
   }

--- a/monthy_budget_flutter/lib/widgets/offline_banner.dart
+++ b/monthy_budget_flutter/lib/widgets/offline_banner.dart
@@ -23,17 +23,17 @@ class OfflineBanner extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           child: Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.cloud_off_outlined,
-                color: Colors.white,
+                color: AppColors.bg(context),
                 size: 20,
               ),
               const SizedBox(width: 10),
               Expanded(
                 child: Text(
                   message,
-                  style: const TextStyle(
-                    color: Colors.white,
+                  style: TextStyle(
+                    color: AppColors.bg(context),
                     fontSize: 13,
                     fontWeight: FontWeight.w600,
                   ),
@@ -49,13 +49,13 @@ class OfflineBanner extends StatelessWidget {
                     vertical: 4,
                   ),
                   decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.2),
+                    color: AppColors.bg(context).withValues(alpha: 0.2),
                     borderRadius: BorderRadius.circular(999),
                   ),
                   child: Text(
                     '$pendingCount',
-                    style: const TextStyle(
-                      color: Colors.white,
+                    style: TextStyle(
+                      color: AppColors.bg(context),
                       fontSize: 12,
                       fontWeight: FontWeight.w700,
                     ),

--- a/monthy_budget_flutter/lib/widgets/star_rating_row.dart
+++ b/monthy_budget_flutter/lib/widgets/star_rating_row.dart
@@ -32,7 +32,7 @@ class StarRatingRow extends StatelessWidget {
                 isFilled ? Icons.star_rounded : Icons.star_border_rounded,
                 size: starSize,
                 color: isFilled
-                    ? Colors.amber
+                    ? AppColors.chartAmber(context)
                     : AppColors.borderMuted(context),
               ),
             ),

--- a/monthy_budget_flutter/lib/widgets/trial_banner.dart
+++ b/monthy_budget_flutter/lib/widgets/trial_banner.dart
@@ -158,7 +158,7 @@ class TrialBanner extends StatelessWidget {
                   backgroundColor: isUrgent
                       ? AppColors.error(context)
                       : AppColors.primary(context),
-                  foregroundColor: Colors.white,
+                  foregroundColor: AppColors.bg(context),
                   padding: const EdgeInsets.symmetric(vertical: 12),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),


### PR DESCRIPTION
## Linked Issue
Fixes #1102

## Release Notes
Final Calm sweep: replaced the last residual hard-coded UI color literals with Calm tokens across 7 files — offline_banner (white→bg on warn fill), trial_banner (white→bg), settings_screen swatch check (white→bg), add_expense_sheet + expense_detail_sheet (delete red→bad, close white→bg), nutrition_dashboard_card (macro blue/purple→chartIndigo/chartRed), star_rating_row (amber→chartAmber). No behaviour change.

## Left as-is (defensible, noted)
add_savings_goal_sheet `_goalColors` (user-pickable palette = data, not theme), receipt_scan_sheet camera-overlay white (viewfinder), command_chat shadowColor. `Colors.transparent` and app_theme token definitions are not literals-in-UI.

## Verification
flutter analyze: no errors/warnings in changed files (pre-existing info lints untouched). Repo-wide genuine-literal count in changed files → 0.