### PR TITLE
fix(notifications): wire scheduleTrialExpiryReminder — dead code, never called

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -678,6 +678,7 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
 
   void _refreshNotificationSchedules() {
     final topCategory = _topCategoryUsage();
+    final sub = _subscription;
     unawaited(
       NotificationService().refreshAllSchedules(
         prefs: _notificationPrefs,
@@ -686,6 +687,11 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
         hasMealPlan: _hasMealPlan,
         topCategoryName: topCategory?.category,
         topCategoryUsagePercent: topCategory?.percent,
+        trialEndDate: sub.isTrialActive
+            ? sub.trialStartDate.add(Duration(days: sub.effectiveTrialDays))
+            : null,
+        activeCategories: _recurringExpenses.where((e) => e.isActive).length,
+        activeSavingsGoals: _savingsGoals.where((g) => g.isActive).length,
       ),
     );
   }

--- a/monthy_budget_flutter/lib/services/notification_service.dart
+++ b/monthy_budget_flutter/lib/services/notification_service.dart
@@ -5,6 +5,7 @@ import 'package:timezone/timezone.dart' as tz;
 import '../constants/app_constants.dart';
 import '../models/notification_preferences.dart';
 import '../models/recurring_expense.dart';
+import 'downgrade_service.dart';
 import 'log_service.dart';
 
 class NotificationRefreshDecision {
@@ -96,6 +97,9 @@ class NotificationService {
     required bool hasMealPlan,
     String? topCategoryName,
     double? topCategoryUsagePercent,
+    DateTime? trialEndDate,
+    int activeCategories = 0,
+    int activeSavingsGoals = 0,
   }) async {
     if (!_initialized) {
       if (_initFuture != null) {
@@ -113,6 +117,9 @@ class NotificationService {
             hasMealPlan: hasMealPlan,
             topCategoryName: topCategoryName,
             topCategoryUsagePercent: topCategoryUsagePercent,
+            trialEndDate: trialEndDate,
+            activeCategories: activeCategories,
+            activeSavingsGoals: activeSavingsGoals,
           );
         })
         .catchError((e) {
@@ -132,6 +139,9 @@ class NotificationService {
     required bool hasMealPlan,
     String? topCategoryName,
     double? topCategoryUsagePercent,
+    DateTime? trialEndDate,
+    int activeCategories = 0,
+    int activeSavingsGoals = 0,
   }) async {
     await cancelAll();
 
@@ -177,6 +187,18 @@ class NotificationService {
 
     for (int i = 0; i < decision.customReminderCount; i++) {
       await _scheduleCustomReminder(prefs.customReminders[i], i);
+    }
+
+    if (trialEndDate != null) {
+      await scheduleTrialExpiryReminder(
+        trialEndDate: trialEndDate,
+        activeCategories: activeCategories,
+        activeSavingsGoals: activeSavingsGoals,
+        maxFreeCategories: DowngradeService.maxFreeCategories,
+        maxFreeSavingsGoals: DowngradeService.maxFreeSavingsGoals,
+        preferredHour: prefs.preferredHour,
+        preferredMinute: prefs.preferredMinute,
+      );
     }
   }
 
@@ -457,6 +479,20 @@ class NotificationService {
         category: 'service.notifications',
       );
     }
+  }
+
+  /// Returns true when the trial expiry reminder would fire — i.e. the reminder
+  /// date (trialEndDate minus daysBeforeExpiry) is still in the future.
+  ///
+  /// Exposed for testing; mirrors the guard inside [scheduleTrialExpiryReminder].
+  @visibleForTesting
+  static bool trialReminderWouldFire(
+    DateTime? trialEndDate, {
+    int daysBeforeExpiry = 10,
+  }) {
+    if (trialEndDate == null) return false;
+    final reminderDate = trialEndDate.subtract(Duration(days: daysBeforeExpiry));
+    return reminderDate.isAfter(DateTime.now());
   }
 
   /// Build the body text for the trial expiry reminder notification.

--- a/monthy_budget_flutter/test/services/trial_expiry_notification_test.dart
+++ b/monthy_budget_flutter/test/services/trial_expiry_notification_test.dart
@@ -2,6 +2,47 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monthly_management/services/notification_service.dart';
 
 void main() {
+  group('NotificationService.trialReminderWouldFire', () {
+    test('returns false when trialEndDate is null', () {
+      expect(
+        NotificationService.trialReminderWouldFire(null),
+        isFalse,
+      );
+    });
+
+    test('returns true when reminder date is in the future', () {
+      final endDate = DateTime.now().add(const Duration(days: 15));
+      expect(
+        NotificationService.trialReminderWouldFire(endDate),
+        isTrue,
+      );
+    });
+
+    test('returns false when trial ends before daysBeforeExpiry threshold', () {
+      final endDate = DateTime.now().add(const Duration(days: 5));
+      expect(
+        NotificationService.trialReminderWouldFire(endDate, daysBeforeExpiry: 10),
+        isFalse,
+      );
+    });
+
+    test('returns false when trial has already ended', () {
+      final endDate = DateTime.now().subtract(const Duration(days: 2));
+      expect(
+        NotificationService.trialReminderWouldFire(endDate),
+        isFalse,
+      );
+    });
+
+    test('threshold is configurable via daysBeforeExpiry', () {
+      final endDate = DateTime.now().add(const Duration(days: 2));
+      expect(
+        NotificationService.trialReminderWouldFire(endDate, daysBeforeExpiry: 1),
+        isTrue,
+      );
+    });
+  });
+
   group('NotificationService.buildTrialExpiryBody', () {
     test('shows excess categories and goals', () {
       final body = NotificationService.buildTrialExpiryBody(


### PR DESCRIPTION
## Linked Issue
Fixes #1109

## Summary
`scheduleTrialExpiryReminder` was fully implemented but had zero callers — trial users never received the pre-expiry warning. This PR wires it into the existing `refreshAllSchedules` refresh cycle.

**Changes:**
- `notification_service.dart`: add optional `trialEndDate`, `activeCategories`, `activeSavingsGoals` to `refreshAllSchedules` and `_refreshAllSchedulesImpl`; call `scheduleTrialExpiryReminder` at the end of each refresh when `trialEndDate` is provided; add `@visibleForTesting` static `trialReminderWouldFire` for unit testing the scheduling guard
- `app_home.dart`: pass trial end date (computed from `trialStartDate + effectiveTrialDays`) and active counts in `_refreshNotificationSchedules()`; `trialEndDate` is `null` when trial is not active, so no reminder is scheduled for non-trial users
- **Cancellation is automatic**: `cancelAll()` runs at the top of every `_refreshAllSchedulesImpl` invocation, so the trial reminder is cancelled on the next refresh whenever the trial ends or is converted

## Release Notes
Trial users now receive a pre-expiry notification 10 days before their trial ends, showing how many categories/goals will be paused on the free plan. The reminder is automatically cancelled if the trial is upgraded or expires.

## Test plan
- [x] 5 new unit tests for `trialReminderWouldFire` (null, future, near-expiry < threshold, past, custom threshold)
- [x] All 2146 existing tests pass
- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` clean on changed files

release:patch