### PR TITLE
fix(ai-coach): allow trial users through canUseAI() gate

### DIFF
--- a/monthy_budget_flutter/lib/screens/coach_screen.dart
+++ b/monthy_budget_flutter/lib/screens/coach_screen.dart
@@ -223,9 +223,9 @@ class _CoachScreenState extends State<CoachScreen> with WidgetsBindingObserver {
     final text = _composerController.text.trim();
     if (text.isEmpty || _loading) return;
 
-    // Pre-flight: if no API key is configured, route the user to settings
-    // instead of letting the request fail with a vague server error.
-    if (widget.apiKey.trim().isEmpty) {
+    // Pre-flight: free-tier users without a local API key can't reach the
+    // edge function; trial/premium users use server-side auth and don't need one.
+    if (!AiCoachService.canUseAI(_subscription, apiKey: widget.apiKey)) {
       final l10n = S.of(context);
       CalmSnack.show(
         context,

--- a/monthy_budget_flutter/lib/services/ai_coach_service.dart
+++ b/monthy_budget_flutter/lib/services/ai_coach_service.dart
@@ -15,7 +15,6 @@ import '../repositories/local/coach_message_storage.dart';
 import '../utils/category_helpers.dart';
 import '../utils/stress_index.dart';
 import 'edge_function_client.dart';
-import 'revenuecat_service.dart';
 import '../models/subscription_state.dart';
 
 /// Delegates to [EdgeFunctionClient.isFunctionNotFoundError].
@@ -139,17 +138,15 @@ class AiCoachService {
 
   /// Gate for AI features.
   ///
-  /// Returns `true` if the user has an active trial or a premium/family
-  /// subscription via RevenueCat. Free-tier users without a trial are blocked.
-  Future<bool> canUseAI() async {
-    final tier = await RevenueCatService.getCurrentTier();
-    if (tier == SubscriptionTier.premium || tier == SubscriptionTier.family) {
-      return true;
-    }
-    // Free tier — allow only if the user has a local API key configured
-    final key = await loadApiKey();
-    return key.trim().isNotEmpty;
-  }
+  /// Returns `true` when [subscription] grants premium access (including active
+  /// trial) or the user has a local [apiKey] configured. Uses
+  /// [SubscriptionState.hasPremiumAccess] as the single source of truth,
+  /// consistent with every other feature gate in the app.
+  static bool canUseAI(
+    SubscriptionState subscription, {
+    required String apiKey,
+  }) =>
+      subscription.hasPremiumAccess || apiKey.trim().isNotEmpty;
 
   // ── Insight history (household-shared via Supabase) ────────────────────────
 

--- a/monthy_budget_flutter/test/services/ai_coach_service_test.dart
+++ b/monthy_budget_flutter/test/services/ai_coach_service_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/constants/app_constants.dart';
+import 'package:monthly_management/models/subscription_state.dart';
 import 'package:monthly_management/services/ai_coach_service.dart';
 
 void main() {
@@ -52,6 +54,48 @@ void main() {
       );
       expect(message, contains('Sessao expirada'));
       expect(message, contains('Inicie sessao novamente'));
+    });
+  });
+
+  group('canUseAI — subscription-based gate', () {
+    final trialState = SubscriptionState(
+      trialStartDate: DateTime.now().subtract(const Duration(days: 5)),
+    );
+    final premiumState = SubscriptionState(
+      trialStartDate: AppConstants.farPastDate,
+      tier: SubscriptionTier.premium,
+    );
+    final freeState = SubscriptionState(
+      trialStartDate: AppConstants.farPastDate,
+      trialUsed: true,
+    );
+
+    test('free tier without API key is blocked', () {
+      expect(
+        AiCoachService.canUseAI(freeState, apiKey: ''),
+        isFalse,
+      );
+    });
+
+    test('trial-active user is allowed without API key', () {
+      expect(
+        AiCoachService.canUseAI(trialState, apiKey: ''),
+        isTrue,
+      );
+    });
+
+    test('premium user is allowed without API key', () {
+      expect(
+        AiCoachService.canUseAI(premiumState, apiKey: ''),
+        isTrue,
+      );
+    });
+
+    test('free tier with local API key is allowed', () {
+      expect(
+        AiCoachService.canUseAI(freeState, apiKey: 'sk-abc123'),
+        isTrue,
+      );
     });
   });
 


### PR DESCRIPTION
## Linked Issue
Fixes #1106

## Summary
`canUseAI()` was an async instance method that performed a second RevenueCat call and did not check `isTrialActive`, contradicting the docstring and every other feature gate in the app.

**`ai_coach_service.dart`:**
- Replaced with a synchronous `static` method that takes `SubscriptionState` directly
- Returns `subscription.hasPremiumAccess || apiKey.isNotEmpty` — single source of truth, consistent with `canAccess(aiCoach)`
- Removed the now-unused `revenuecat_service.dart` import

**`coach_screen.dart:228`:**
- The pre-flight gate was `widget.apiKey.trim().isEmpty` — this blocked all users without a local OpenAI key, including trial/premium users who reach the AI through the server-side edge function (no local key needed)
- Changed to `!AiCoachService.canUseAI(_subscription, apiKey: widget.apiKey)` — trial and premium users proceed to the edge function; only free-tier users without a local key see the "configure API key" message

## Release Notes
Trial users can now use the AI Coach without configuring a personal OpenAI API key. The access gate is now consistent with how every other premium feature is gated in the app.

## Test plan
- [x] 4 new unit tests: free+no key (blocked), trial+no key (allowed), premium+no key (allowed), free+key (allowed)
- [x] All 2150 tests pass
- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` clean on changed files

release:patch