### PR TITLE
fix(notifications): persist budget-alert dedup guard across cold starts

### DIFF
--- a/monthy_budget_flutter/lib/services/local_config_service.dart
+++ b/monthy_budget_flutter/lib/services/local_config_service.dart
@@ -107,4 +107,24 @@ class LocalConfigService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_notifKey, config.toJsonString());
   }
+
+  static const _budgetAlertMonthKey = 'budget_alert_fired_month';
+
+  /// Returns the `"YYYY-M"` string stored when the budget alert last fired,
+  /// or `null` if it has never fired or was cleared (spend dropped).
+  Future<String?> loadBudgetAlertFiredMonth() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_budgetAlertMonthKey);
+  }
+
+  /// Persists [month] as `"YYYY-M"` when the alert fires; pass `null` to
+  /// clear (i.e. when spending drops back below the threshold).
+  Future<void> saveBudgetAlertFiredMonth(String? month) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (month == null) {
+      await prefs.remove(_budgetAlertMonthKey);
+    } else {
+      await prefs.setString(_budgetAlertMonthKey, month);
+    }
+  }
 }

--- a/monthy_budget_flutter/lib/services/notification_service.dart
+++ b/monthy_budget_flutter/lib/services/notification_service.dart
@@ -6,6 +6,7 @@ import '../constants/app_constants.dart';
 import '../models/notification_preferences.dart';
 import '../models/recurring_expense.dart';
 import 'downgrade_service.dart';
+import 'local_config_service.dart';
 import 'log_service.dart';
 
 class NotificationRefreshDecision {
@@ -36,6 +37,7 @@ class NotificationService {
   NotificationService._();
 
   final _plugin = FlutterLocalNotificationsPlugin();
+  final _localConfig = LocalConfigService();
   bool _initialized = false;
   Future<void>? _initFuture;
   Future<void> _refreshChain = Future.value();
@@ -145,6 +147,11 @@ class NotificationService {
   }) async {
     await cancelAll();
 
+    final now = DateTime.now();
+    final currentMonth = '${now.year}-${now.month}';
+    final firedMonth = await _localConfig.loadBudgetAlertFiredMonth();
+    _budgetAlertTriggered = firedMonth == currentMonth;
+
     final decision = buildRefreshDecision(
       prefs: prefs,
       budgetUsagePercent: budgetUsagePercent,
@@ -165,6 +172,7 @@ class NotificationService {
 
     if (decision.shouldResetBudgetAlertTrigger) {
       _budgetAlertTriggered = false;
+      await _localConfig.saveBudgetAlertFiredMonth(null);
     } else if (decision.shouldShowBudgetAlert &&
         decision.budgetAlertUsagePercent != null) {
       await _showBudgetAlert(
@@ -172,6 +180,7 @@ class NotificationService {
         categoryName: decision.budgetAlertCategoryName,
       );
       _budgetAlertTriggered = true;
+      await _localConfig.saveBudgetAlertFiredMonth(currentMonth);
     }
 
     if (decision.scheduleDailyExpenseReminder) {

--- a/monthy_budget_flutter/test/integration/notification_preferences_refresh_flow_test.dart
+++ b/monthy_budget_flutter/test/integration/notification_preferences_refresh_flow_test.dart
@@ -13,6 +13,33 @@ void main() {
     localConfigService = LocalConfigService();
   });
 
+  group('budget-alert dedup guard — persistence', () {
+    test('no month stored initially', () async {
+      final month = await localConfigService.loadBudgetAlertFiredMonth();
+      expect(month, isNull);
+    });
+
+    test('save and reload the fired month', () async {
+      await localConfigService.saveBudgetAlertFiredMonth('2026-7');
+      final month = await localConfigService.loadBudgetAlertFiredMonth();
+      expect(month, '2026-7');
+    });
+
+    test('saving null clears the stored month', () async {
+      await localConfigService.saveBudgetAlertFiredMonth('2026-7');
+      await localConfigService.saveBudgetAlertFiredMonth(null);
+      final month = await localConfigService.loadBudgetAlertFiredMonth();
+      expect(month, isNull);
+    });
+
+    test('different month means guard resets', () async {
+      await localConfigService.saveBudgetAlertFiredMonth('2026-6');
+      final stored = await localConfigService.loadBudgetAlertFiredMonth();
+      // Simulates cold-start in a new month: stored != current
+      expect(stored, isNot('2026-7'));
+    });
+  });
+
   group('notification preferences refresh flow', () {
     test('saved preferences produce the expected refresh decision', () async {
       final prefs = NotificationPreferences(


### PR DESCRIPTION
## Linked Issue
Fixes #1108

## What changed
- `LocalConfigService`: added `loadBudgetAlertFiredMonth()` / `saveBudgetAlertFiredMonth(String?)` backed by SharedPreferences key `budget_alert_fired_month`.
- `NotificationService._refreshAllSchedulesImpl`: on every refresh, loads the persisted fired-month and sets `_budgetAlertTriggered` accordingly. Saves the current month when the alert fires; clears it when spend drops below the threshold (reset path).

## Why
`_budgetAlertTriggered` was an in-memory field — reset to `false` on every cold start, causing the budget alert to re-fire each time the app launched mid-month.

## Tests
`test/integration/notification_preferences_refresh_flow_test.dart` — 4 new tests covering: initial null, save/reload, null-clear, and cross-month mismatch.

## Release Notes
Fixed a bug where the monthly budget-exceeded notification would fire again every time the app was restarted instead of only once per calendar month.