### PR TITLE
fix(recurring): backfill skipped months + idempotent expense generation

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -560,8 +560,8 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
         _refreshNotificationSchedules();
       }
       _dataHealthService.recordLoad(SyncDomain.recurringExpenses);
-      // Auto-populate recurring expenses for the current month
-      final created = await _recurringExpenseService.populateMonthIfNeeded(
+      // Backfill any months missed since last launch, then populate current
+      final created = await _recurringExpenseService.backfillToMonth(
         widget.householdId,
         _currentMonthKey,
       );

--- a/monthy_budget_flutter/lib/repositories/expense_repository.dart
+++ b/monthy_budget_flutter/lib/repositories/expense_repository.dart
@@ -13,6 +13,9 @@ abstract class ExpenseRepository {
   Future<List<ActualExpense>> loadMonth(String householdId, String monthKey);
   Future<void> add(ActualExpense expense, String householdId);
   Future<void> addAll(List<ActualExpense> expenses, String householdId);
+  /// Upsert-ignore for recurring-generated expenses — idempotent on PK conflict.
+  Future<void> addAllFromRecurring(
+      List<ActualExpense> expenses, String householdId);
   Future<void> update(ActualExpense expense);
   Future<List<String>> uploadAttachments(
     List<File> files,
@@ -56,6 +59,17 @@ class SupabaseExpenseRepository implements ExpenseRepository {
     if (expenses.isEmpty) return;
     await _client.from('actual_expenses').insert(
       expenses.map((expense) => expense.toSupabase(householdId)).toList(),
+    );
+  }
+
+  @override
+  Future<void> addAllFromRecurring(
+      List<ActualExpense> expenses, String householdId) async {
+    if (expenses.isEmpty) return;
+    await _client.from('actual_expenses').upsert(
+      expenses.map((expense) => expense.toSupabase(householdId)).toList(),
+      onConflict: 'id',
+      ignoreDuplicates: true,
     );
   }
 
@@ -196,6 +210,7 @@ abstract class RecurringExpenseRepository {
   Future<void> delete(String id);
   Future<bool> hasRunForMonth(String householdId, String monthKey);
   Future<void> markRunForMonth(String householdId, String monthKey);
+  Future<List<String>> loadRunMonths(String householdId);
 }
 
 class SupabaseRecurringExpenseRepository implements RecurringExpenseRepository {
@@ -242,10 +257,23 @@ class SupabaseRecurringExpenseRepository implements RecurringExpenseRepository {
 
   @override
   Future<void> markRunForMonth(String householdId, String monthKey) {
-    return _client.from('recurring_expense_runs').insert({
-      'household_id': householdId,
-      'month_key': monthKey,
-    });
+    // upsert so concurrent calls don't throw PK violation
+    return _client.from('recurring_expense_runs').upsert(
+      {'household_id': householdId, 'month_key': monthKey},
+      onConflict: 'household_id,month_key',
+      ignoreDuplicates: true,
+    );
+  }
+
+  @override
+  Future<List<String>> loadRunMonths(String householdId) async {
+    final rows = await _client
+        .from('recurring_expense_runs')
+        .select('month_key')
+        .eq('household_id', householdId);
+    return (rows as List<dynamic>)
+        .map((r) => r['month_key'] as String)
+        .toList();
   }
 }
 

--- a/monthy_budget_flutter/lib/services/recurring_expense_service.dart
+++ b/monthy_budget_flutter/lib/services/recurring_expense_service.dart
@@ -76,7 +76,11 @@ class RecurringExpenseService {
 
       final recurring = await _resolvedRecurringRepository.load(householdId);
       final active = recurring.where((expense) => expense.isActive).toList();
-      if (active.isEmpty) return [];
+      if (active.isEmpty) {
+        // Mark run even if empty so we don't query again next month
+        await _resolvedRecurringRepository.markRunForMonth(householdId, monthKey);
+        return [];
+      }
 
       final parts = monthKey.split('-');
       final year = int.parse(parts[0]);
@@ -91,7 +95,8 @@ class RecurringExpenseService {
 
         created.add(
           ActualExpense(
-            id: 'exp_rec_${recurringExpense.id}_${DateTime.now().millisecondsSinceEpoch}',
+            // Deterministic ID: collision on re-run = idempotent upsert-ignore
+            id: 'exp_rec_${recurringExpense.id}_$monthKey',
             category: recurringExpense.category,
             amount: recurringExpense.amount,
             date: date,
@@ -104,10 +109,10 @@ class RecurringExpenseService {
       }
 
       if (created.isNotEmpty) {
-        await _resolvedExpenseRepository.addAll(created, householdId);
+        await _resolvedExpenseRepository.addAllFromRecurring(
+            created, householdId);
       }
-      await _resolvedRecurringRepository.markRunForMonth(
-          householdId, monthKey);
+      await _resolvedRecurringRepository.markRunForMonth(householdId, monthKey);
 
       return created;
     } catch (e, stack) {
@@ -120,5 +125,67 @@ class RecurringExpenseService {
       );
       throw DataException('Failed to populate month $monthKey', e, stack);
     }
+  }
+
+  /// Populates all gap months from the last run through [currentMonthKey].
+  /// Safe to call on every app launch — already-run months are skipped.
+  Future<List<ActualExpense>> backfillToMonth(
+    String householdId,
+    String currentMonthKey,
+  ) async {
+    try {
+      final runMonths =
+          await _resolvedRecurringRepository.loadRunMonths(householdId);
+
+      final List<String> gaps;
+      if (runMonths.isEmpty) {
+        gaps = [currentMonthKey];
+      } else {
+        final sorted = runMonths.toList()..sort();
+        final lastRun = sorted.last;
+        if (lastRun == currentMonthKey) return [];
+        // All months after lastRun up to and including currentMonthKey
+        gaps = _monthsBetween(lastRun, currentMonthKey).skip(1).toList();
+      }
+
+      final all = <ActualExpense>[];
+      for (final month in gaps) {
+        final created = await populateMonthIfNeeded(householdId, month);
+        all.addAll(created);
+      }
+      return all;
+    } catch (e, stack) {
+      if (e is DataException) rethrow;
+      LogService.error(
+        'Failed to backfill recurring expenses to $currentMonthKey',
+        error: e,
+        stackTrace: stack,
+        category: 'service.recurring_expense',
+      );
+      throw DataException(
+          'Failed to backfill recurring expenses to $currentMonthKey', e, stack);
+    }
+  }
+
+  /// Returns all month keys from [fromMonthKey] to [toMonthKey] inclusive,
+  /// in ascending order. Format: "YYYY-MM".
+  static List<String> _monthsBetween(String fromMonthKey, String toMonthKey) {
+    final fp = fromMonthKey.split('-');
+    var year = int.parse(fp[0]);
+    var month = int.parse(fp[1]);
+    final tp = toMonthKey.split('-');
+    final toYear = int.parse(tp[0]);
+    final toMonth = int.parse(tp[1]);
+
+    final months = <String>[];
+    while (year < toYear || (year == toYear && month <= toMonth)) {
+      months.add('$year-${month.toString().padLeft(2, '0')}');
+      month++;
+      if (month > 12) {
+        month = 1;
+        year++;
+      }
+    }
+    return months;
   }
 }

--- a/monthy_budget_flutter/test/services/recurring_backfill_test.dart
+++ b/monthy_budget_flutter/test/services/recurring_backfill_test.dart
@@ -1,0 +1,210 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/actual_expense.dart';
+import 'package:monthly_management/models/recurring_expense.dart';
+import 'package:monthly_management/repositories/expense_repository.dart';
+import 'package:monthly_management/services/recurring_expense_service.dart';
+
+// ---------- fake repositories ----------
+
+class FakeRecurringRepository implements RecurringExpenseRepository {
+  final List<RecurringExpense> _expenses;
+  final Set<String> _runMonths;
+
+  FakeRecurringRepository({
+    List<RecurringExpense>? expenses,
+    Set<String>? runMonths,
+  })  : _expenses = expenses ?? [],
+        _runMonths = runMonths ?? {};
+
+  @override
+  Future<List<RecurringExpense>> load(String householdId) async => _expenses;
+
+  @override
+  Future<void> save(RecurringExpense expense, String householdId) async {}
+
+  @override
+  Future<void> delete(String id) async {}
+
+  @override
+  Future<bool> hasRunForMonth(String householdId, String monthKey) async =>
+      _runMonths.contains(monthKey);
+
+  @override
+  Future<void> markRunForMonth(String householdId, String monthKey) async =>
+      _runMonths.add(monthKey);
+
+  @override
+  Future<List<String>> loadRunMonths(String householdId) async =>
+      _runMonths.toList();
+}
+
+class FakeExpenseRepository implements ExpenseRepository {
+  final List<ActualExpense> inserted = [];
+  int addAllFromRecurringCalls = 0;
+
+  @override
+  Future<List<ActualExpense>> loadMonth(String householdId, String monthKey) async => [];
+
+  @override
+  Future<void> add(ActualExpense expense, String householdId) async =>
+      inserted.add(expense);
+
+  @override
+  Future<void> addAll(List<ActualExpense> expenses, String householdId) async =>
+      inserted.addAll(expenses);
+
+  @override
+  Future<void> addAllFromRecurring(
+      List<ActualExpense> expenses, String householdId) async {
+    addAllFromRecurringCalls++;
+    // Idempotent: only insert if ID not already present
+    for (final e in expenses) {
+      if (!inserted.any((i) => i.id == e.id)) {
+        inserted.add(e);
+      }
+    }
+  }
+
+  @override
+  Future<void> update(ActualExpense expense) async {}
+
+  @override
+  Future<void> delete(String id) async {}
+
+  @override
+  Future<List<String>> uploadAttachments(
+      List<File> files, String householdId, String expenseId) async =>
+      [];
+
+  @override
+  Future<Map<String, List<ActualExpense>>> loadHistory(String householdId,
+          {int months = 12}) async =>
+      {};
+}
+
+// ---------- helpers ----------
+
+RecurringExpense _rent({String id = 'r1', int dayOfMonth = 1}) =>
+    RecurringExpense(
+      id: id,
+      category: 'Housing',
+      amount: 800.0,
+      description: 'Rent',
+      dayOfMonth: dayOfMonth,
+      isActive: true,
+    );
+
+// ---------- tests ----------
+
+void main() {
+  group('RecurringExpenseService — backfill', () {
+    test('no prior runs: only current month is populated', () async {
+      final recRepo = FakeRecurringRepository(expenses: [_rent()]);
+      final expRepo = FakeExpenseRepository();
+      final service = RecurringExpenseService(
+        recurringRepository: recRepo,
+        expenseRepository: expRepo,
+      );
+
+      final created = await service.backfillToMonth('hh1', '2026-03');
+
+      expect(created.length, 1);
+      expect(created.first.monthKey, '2026-03');
+      expect(recRepo._runMonths, contains('2026-03'));
+    });
+
+    test('one skipped month: both gap and current are populated', () async {
+      final recRepo = FakeRecurringRepository(
+        expenses: [_rent()],
+        runMonths: {'2026-01'},
+      );
+      final expRepo = FakeExpenseRepository();
+      final service = RecurringExpenseService(
+        recurringRepository: recRepo,
+        expenseRepository: expRepo,
+      );
+
+      // Current is 2026-03; last run was 2026-01 → gap is 2026-02 and 2026-03
+      final created = await service.backfillToMonth('hh1', '2026-03');
+
+      expect(created.length, 2, reason: 'Feb + Mar should be populated');
+      final months = created.map((e) => e.monthKey).toSet();
+      expect(months, containsAll(['2026-02', '2026-03']));
+      expect(recRepo._runMonths, containsAll(['2026-01', '2026-02', '2026-03']));
+    });
+
+    test('two skipped months: all three gap months populated', () async {
+      final recRepo = FakeRecurringRepository(
+        expenses: [_rent()],
+        runMonths: {'2026-01'},
+      );
+      final expRepo = FakeExpenseRepository();
+      final service = RecurringExpenseService(
+        recurringRepository: recRepo,
+        expenseRepository: expRepo,
+      );
+
+      final created = await service.backfillToMonth('hh1', '2026-04');
+
+      expect(created.length, 3,
+          reason: 'Feb, Mar, Apr must all be populated');
+      final months = created.map((e) => e.monthKey).toSet();
+      expect(months, containsAll(['2026-02', '2026-03', '2026-04']));
+    });
+
+    test('already up to date: no new expenses created', () async {
+      final recRepo = FakeRecurringRepository(
+        expenses: [_rent()],
+        runMonths: {'2026-03'},
+      );
+      final expRepo = FakeExpenseRepository();
+      final service = RecurringExpenseService(
+        recurringRepository: recRepo,
+        expenseRepository: expRepo,
+      );
+
+      final created = await service.backfillToMonth('hh1', '2026-03');
+
+      expect(created, isEmpty);
+    });
+  });
+
+  group('RecurringExpenseService — idempotent IDs', () {
+    test('expense ID includes monthKey, not a timestamp', () async {
+      final recRepo = FakeRecurringRepository(expenses: [_rent(id: 'rent42')]);
+      final expRepo = FakeExpenseRepository();
+      final service = RecurringExpenseService(
+        recurringRepository: recRepo,
+        expenseRepository: expRepo,
+      );
+
+      final created = await service.populateMonthIfNeeded('hh1', '2026-03');
+
+      expect(created.first.id, 'exp_rec_rent42_2026-03');
+    });
+
+    test('concurrent populate calls produce no duplicates (idempotent)', () async {
+      final recRepo = FakeRecurringRepository(expenses: [_rent(id: 'r1')]);
+      final expRepo = FakeExpenseRepository();
+      final service = RecurringExpenseService(
+        recurringRepository: recRepo,
+        expenseRepository: expRepo,
+      );
+
+      // Simulate race: call twice in parallel (both see hasRunForMonth=false
+      // before either marks it). addAllFromRecurring must be idempotent.
+      await Future.wait([
+        service.populateMonthIfNeeded('hh1', '2026-03'),
+        service.populateMonthIfNeeded('hh1', '2026-03'),
+      ]);
+
+      final ids = expRepo.inserted.map((e) => e.id).toList();
+      expect(ids.toSet().length, ids.length,
+          reason: 'No duplicate expense IDs after concurrent populate');
+      expect(expRepo.inserted.length, 1,
+          reason: 'Only one expense inserted despite concurrent calls');
+    });
+  });
+}

--- a/monthy_budget_flutter/test/services/repository_backed_service_test.dart
+++ b/monthy_budget_flutter/test/services/repository_backed_service_test.dart
@@ -171,6 +171,15 @@ class InMemoryExpenseRepository implements ExpenseRepository {
   }
 
   @override
+  Future<void> addAllFromRecurring(
+      List<ActualExpense> expenses, String householdId) async {
+    addedBatches.add(List<ActualExpense>.from(expenses));
+    for (final e in expenses) {
+      if (!_expenses.any((i) => i.id == e.id)) _expenses.add(e);
+    }
+  }
+
+  @override
   Future<void> delete(String id) async {
     _expenses.removeWhere((expense) => expense.id == id);
   }
@@ -270,6 +279,14 @@ class InMemoryRecurringExpenseRepository implements RecurringExpenseRepository {
   @override
   Future<void> save(RecurringExpense expense, String householdId) async {
     _expenses.add(expense);
+  }
+
+  @override
+  Future<List<String>> loadRunMonths(String householdId) async {
+    return _alreadyRanMonths
+        .where((k) => k.startsWith('$householdId|'))
+        .map((k) => k.split('|').last)
+        .toList();
   }
 }
 

--- a/monthy_budget_flutter/test/services/service_coverage_test.dart
+++ b/monthy_budget_flutter/test/services/service_coverage_test.dart
@@ -48,6 +48,14 @@ class _MemExpenseRepo implements ExpenseRepository {
   }
 
   @override
+  Future<void> addAllFromRecurring(
+      List<ActualExpense> expenses, String hid) async {
+    for (final e in expenses) {
+      if (!_items.any((i) => i.id == e.id)) _items.add(e);
+    }
+  }
+
+  @override
   Future<void> update(ActualExpense expense) async {
     if (shouldThrow) throw StateError('update failed');
     final idx = _items.indexWhere((e) => e.id == expense.id);
@@ -142,6 +150,14 @@ class _MemRecurringRepo implements RecurringExpenseRepository {
   @override
   Future<void> markRunForMonth(String hid, String mk) async {
     _ran.add('$hid|$mk');
+  }
+
+  @override
+  Future<List<String>> loadRunMonths(String hid) async {
+    return _ran
+        .where((k) => k.startsWith('$hid|'))
+        .map((k) => k.split('|').last)
+        .toList();
   }
 }
 

--- a/monthy_budget_flutter/test/services/supabase_error_handling_test.dart
+++ b/monthy_budget_flutter/test/services/supabase_error_handling_test.dart
@@ -40,6 +40,8 @@ class ThrowingExpenseRepository implements ExpenseRepository {
   @override
   Future<void> addAll(List<ActualExpense> e, String h) => throw error;
   @override
+  Future<void> addAllFromRecurring(List<ActualExpense> e, String h) => throw error;
+  @override
   Future<void> update(ActualExpense e) => throw error;
   @override
   Future<List<String>> uploadAttachments(
@@ -68,6 +70,8 @@ class ThrowingRecurringExpenseRepository implements RecurringExpenseRepository {
   Future<bool> hasRunForMonth(String h, String m) => throw error;
   @override
   Future<void> markRunForMonth(String h, String m) => throw error;
+  @override
+  Future<List<String>> loadRunMonths(String h) => throw error;
 }
 
 class ThrowingSavingsRepository implements SavingsRepository {


### PR DESCRIPTION
## Linked Issue
Fixes #1104

## What changed

**Backfill (silent data loss fix)**
- Added `RecurringExpenseService.backfillToMonth(householdId, currentMonthKey)`: on every app launch, queries `recurring_expense_runs` to find all months since the last run that haven't been populated, and populates each gap in order. Users who miss one or more months now get all missed recurring expenses generated when they next open the app.
- `_loadRecurringExpenses` in `app_home.dart` now calls `backfillToMonth` instead of `populateMonthIfNeeded`.

**Idempotent IDs (race + duplicate fix)**
- Expense ID changed from `exp_rec_{id}_{millisecond}` → `exp_rec_{id}_{monthKey}`: deterministic, so re-runs collide on PK instead of creating duplicates.
- New `addAllFromRecurring()` on `ExpenseRepository` uses Supabase `upsert` with `ignoreDuplicates: true` — concurrent populate calls can't insert duplicates.
- `markRunForMonth()` changed to upsert-ignore so concurrent second mark doesn't throw PK violation.

**New repository method**
- `RecurringExpenseRepository.loadRunMonths(householdId)` returns all month keys that have already been marked as run.

## Release Notes
Fixed a data loss bug where recurring expenses (rent, subscriptions, etc.) were silently skipped for any month the app wasn't opened. The app now backfills all missed months on the next launch. Also fixed a race condition that could generate duplicate recurring expenses on fast back-to-back app loads.