### PR TITLE
fix(subscription): guard paying users against offline/error RevenueCat downgrade

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -507,7 +507,10 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
       final user = Supabase.instance.client.auth.currentUser;
       final previousTier = _subscription.tier;
       await RevenueCatService.login(user?.id);
-      final remoteTier = await RevenueCatService.getCurrentTier();
+      // getRemoteTier() returns null on error/offline — syncFromRemoteTier
+      // treats null as "unknown, keep local tier" so paying users are never
+      // downgraded by a network blip.
+      final remoteTier = await RevenueCatService.getRemoteTier();
       final updated = await _subscriptionService.syncFromRemoteTier(
         _subscription,
         remoteTier,

--- a/monthy_budget_flutter/lib/services/revenuecat_service.dart
+++ b/monthy_budget_flutter/lib/services/revenuecat_service.dart
@@ -20,14 +20,15 @@ class RevenueCatService {
   static Future<void> initialize() async {
     if (revenueCatSimulateMode) return;
     if (_initialized) return;
-    _initialized = true;
-
+    // _initialized is set to true ONLY after configure succeeds, so that a
+    // failed init is retried on next launch instead of silently being a no-op.
     try {
       await Purchases.setLogLevel(
         revenueCatDebugLogsEnabled ? LogLevel.debug : LogLevel.info,
       );
       final config = PurchasesConfiguration(revenueCatApiKey);
       await Purchases.configure(config);
+      _initialized = true;
       _available = true;
     } on MissingPluginException {
       _available = false;
@@ -82,6 +83,24 @@ class RevenueCatService {
         category: 'service.revenuecat',
       );
       return SubscriptionTier.free;
+    }
+  }
+
+  /// Like [getCurrentTier] but returns `null` when the result is uncertain
+  /// (simulate mode, SDK unavailable, or network/SDK error). Callers that use
+  /// this must treat `null` as "keep local tier" and skip any downgrade logic.
+  static Future<SubscriptionTier?> getRemoteTier() async {
+    if (revenueCatSimulateMode || !_initialized || !_available) return null;
+    try {
+      final info = await Purchases.getCustomerInfo();
+      return _tierFromCustomerInfo(info);
+    } catch (e) {
+      LogService.error(
+        'RevenueCat getRemoteTier failed',
+        error: e,
+        category: 'service.revenuecat',
+      );
+      return null;
     }
   }
 

--- a/monthy_budget_flutter/lib/services/subscription_service.dart
+++ b/monthy_budget_flutter/lib/services/subscription_service.dart
@@ -116,11 +116,27 @@ class SubscriptionService {
     return updated;
   }
 
+  /// Sync the local tier with a confirmed remote result.
+  ///
+  /// Pass `null` as [remoteTier] when the RC result is uncertain (offline,
+  /// error, simulate mode). A null value is a no-op — the local tier is kept
+  /// and nothing is persisted, so a network blip never downgrades a paying user.
   Future<SubscriptionState> syncFromRemoteTier(
     SubscriptionState current,
-    SubscriptionTier remoteTier,
+    SubscriptionTier? remoteTier,
   ) async {
+    if (remoteTier == null) return current; // unknown — keep local tier
     if (current.tier == remoteTier) return current;
+
+    // Re-upgrade path: RC confirms premium after a (possibly false) downgrade.
+    // Clear the downgrade latch so categories/goals are restored.
+    final wasDowngraded = current.tier == SubscriptionTier.free &&
+        current.trialUsed &&
+        remoteTier != SubscriptionTier.free;
+    if (wasDowngraded) {
+      await resetDowngradeTracking();
+    }
+
     final updated = current.copyWith(
       tier: remoteTier,
       trialUsed: remoteTier != SubscriptionTier.free

--- a/monthy_budget_flutter/test/services/subscription_offline_guard_test.dart
+++ b/monthy_budget_flutter/test/services/subscription_offline_guard_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:monthly_management/models/subscription_state.dart';
+import 'package:monthly_management/services/revenuecat_service.dart';
+import 'package:monthly_management/services/subscription_service.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('RevenueCatService.getRemoteTier — offline / unavailable guard', () {
+    test('returns null in simulate mode (unknown, not free)', () async {
+      // revenueCatSimulateMode is true in tests — must yield null, not free.
+      final tier = await RevenueCatService.getRemoteTier();
+      expect(tier, isNull,
+          reason:
+              'unavailable RC must return null so callers skip the sync, '
+              'not downgrade to free');
+    });
+  });
+
+  group('SubscriptionService.syncFromRemoteTier — downgrade guard', () {
+    late SubscriptionService service;
+
+    setUp(() => service = SubscriptionService());
+
+    test('does NOT downgrade when remoteTier is null (unknown / offline)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final premium = SubscriptionState(
+        tier: SubscriptionTier.family,
+        trialUsed: true,
+        trialStartDate: DateTime(2026, 1, 1),
+      );
+
+      final result = await service.syncFromRemoteTier(premium, null);
+
+      expect(result.tier, SubscriptionTier.family,
+          reason: 'null remote tier = unknown; must keep existing premium tier');
+      expect(result, same(premium),
+          reason: 'no state change and no persistence should happen');
+    });
+
+    test('applies upgrade when remoteTier is non-free', () async {
+      SharedPreferences.setMockInitialValues({});
+      final freeTrial = SubscriptionState(
+        tier: SubscriptionTier.free,
+        trialUsed: false,
+        trialStartDate: DateTime(2026, 1, 1),
+      );
+
+      final result = await service.syncFromRemoteTier(freeTrial, SubscriptionTier.family);
+
+      expect(result.tier, SubscriptionTier.family);
+      expect(result.trialUsed, isTrue);
+    });
+
+    test('applies downgrade when remoteTier is explicitly free', () async {
+      SharedPreferences.setMockInitialValues({});
+      final premium = SubscriptionState(
+        tier: SubscriptionTier.family,
+        trialUsed: true,
+        trialStartDate: DateTime(2026, 1, 1),
+      );
+
+      final result = await service.syncFromRemoteTier(premium, SubscriptionTier.free);
+
+      expect(result.tier, SubscriptionTier.free,
+          reason: 'explicit confirmed free = real downgrade, must apply');
+    });
+
+    test('clears downgrade latch when syncing from free back to premium', () async {
+      SharedPreferences.setMockInitialValues({
+        'downgrade_applied': true, // latch set by a previous (possibly false) downgrade
+      });
+      final freeState = SubscriptionState(
+        tier: SubscriptionTier.free,
+        trialUsed: true,
+        trialStartDate: DateTime(2026, 1, 1),
+      );
+
+      await service.syncFromRemoteTier(freeState, SubscriptionTier.family);
+
+      final latchStillSet = await service.isDowngradeApplied();
+      expect(latchStillSet, isFalse,
+          reason:
+              'when RC confirms premium, the downgrade latch must be cleared '
+              'so categories/goals are re-enabled');
+    });
+
+    test('no-op when tier is already equal to remoteTier', () async {
+      SharedPreferences.setMockInitialValues({});
+      final premium = SubscriptionState(
+        tier: SubscriptionTier.family,
+        trialUsed: true,
+        trialStartDate: DateTime(2026, 1, 1),
+      );
+
+      final result = await service.syncFromRemoteTier(premium, SubscriptionTier.family);
+
+      expect(result, same(premium));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1105

## What changed

**Root cause**: `getCurrentTier()` returned `SubscriptionTier.free` on any error (offline, SDK unavailable, init failed), which `syncFromRemoteTier` applied unconditionally — downgrading paying users and irreversibly deactivating their categories/goals.

**Fix — 4 targeted changes:**

1. **`RevenueCatService.getRemoteTier()`** (new method): returns `SubscriptionTier?` — `null` when unavailable/error (simulate mode, SDK not init'd, network throw). Distinct from "we know the user is free".

2. **`SubscriptionService.syncFromRemoteTier()`**: parameter type changed to `SubscriptionTier?`. A `null` value is an explicit no-op — returns the existing state unchanged without persisting anything. Paying users stay paying when RC is unreachable.

3. **`app_home._syncRevenueCat()`**: switched from `getCurrentTier()` to `getRemoteTier()` so an RC failure silently keeps the local tier instead of overwriting it with free.

4. **Re-upgrade latch clear**: `syncFromRemoteTier` now calls `resetDowngradeTracking()` when it detects a free→premium transition, so a false downgrade followed by a successful RC sync restores categories/goals automatically.

**Bonus — init latch fix**: `_initialized = true` moved to after `Purchases.configure()` succeeds. A failed init no longer permanently kills the subscription system for the session.

## Release Notes
Fixed a critical bug where paying subscribers could be silently downgraded to the free plan (with categories and savings goals deactivated) if the app was opened while offline or during a RevenueCat network error. The app now keeps the user's last known subscription tier when the remote check is inconclusive.