### PR TITLE
fix(tax-sim): meal-allowance marginal rate + gate titulares control

### DIFF
--- a/monthy_budget_flutter/lib/data/tax/pt_tax_system.dart
+++ b/monthy_budget_flutter/lib/data/tax/pt_tax_system.dart
@@ -72,6 +72,7 @@ class PtTaxSystem extends TaxSystem {
     return TaxResult(
       incomeTax: retention,
       incomeTaxRate: rate,
+      marginalRate: bracket?.rate ?? 0.0,
       socialContribution: ss,
       socialContributionRate: socialSecurityRate,
       netSalary: net,

--- a/monthy_budget_flutter/lib/data/tax/tax_system.dart
+++ b/monthy_budget_flutter/lib/data/tax/tax_system.dart
@@ -70,6 +70,11 @@ enum Country {
 class TaxResult {
   final double incomeTax;
   final double incomeTaxRate;
+  /// The marginal bracket rate (e.g. 0.241 for 24.1%). Used to tax income
+  /// components (such as meal allowance excess) that are legally subject to
+  /// the marginal rate, not the effective average rate. Defaults to 0.0 for
+  /// tax systems that don't expose bracket-level detail.
+  final double marginalRate;
   final double socialContribution;
   final double socialContributionRate;
   final double netSalary;
@@ -77,6 +82,7 @@ class TaxResult {
   const TaxResult({
     required this.incomeTax,
     required this.incomeTaxRate,
+    this.marginalRate = 0.0,
     required this.socialContribution,
     required this.socialContributionRate,
     required this.netSalary,

--- a/monthy_budget_flutter/lib/screens/tax_simulator_screen.dart
+++ b/monthy_budget_flutter/lib/screens/tax_simulator_screen.dart
@@ -270,11 +270,16 @@ class _TaxSimulatorScreenState extends State<TaxSimulatorScreen> {
                         : i == 1
                             ? MaritalStatus.casado
                             : MaritalStatus.uniaoFacto;
+                    if (_maritalStatus == MaritalStatus.solteiro) {
+                      _titulares = 1;
+                    }
                     _recalculate();
                   }),
                 ),
               ],
-              if (country.hasTitulares) ...[
+              if (country.hasTitulares &&
+                  (_maritalStatus == MaritalStatus.casado ||
+                      _maritalStatus == MaritalStatus.uniaoFacto)) ...[
                 const SizedBox(height: 16),
                 _SegmentedRow(
                   label: l10n.taxSimTitulares,

--- a/monthy_budget_flutter/lib/utils/calculations.dart
+++ b/monthy_budget_flutter/lib/utils/calculations.dart
@@ -86,6 +86,7 @@ SalaryCalculation calculateNetSalary(
   // A Segurança Social incide sobre o total pago no mês (base + duodécimos).
   final double irsRetention;
   final double irsRate;
+  final double irsMarginalRate;
   final double socialSecurity;
 
   if (country == Country.pt && subsidyBonus > 0) {
@@ -100,6 +101,7 @@ SalaryCalculation calculateNetSalary(
     final baseRate = baseGross > 0 ? baseTax.incomeTax / baseGross : 0.0;
     irsRetention = _round2(baseTax.incomeTax + baseRate * subsidyBonus);
     irsRate = baseTax.incomeTaxRate;
+    irsMarginalRate = baseTax.marginalRate;
     socialSecurity = taxSystem.calculateSocialContribution(effectiveGross);
   } else {
     final taxResult = taxSystem.calculateTax(
@@ -112,6 +114,7 @@ SalaryCalculation calculateNetSalary(
     );
     irsRetention = taxResult.incomeTax;
     irsRate = taxResult.incomeTaxRate;
+    irsMarginalRate = taxResult.marginalRate;
     socialSecurity = taxResult.socialContribution;
   }
 
@@ -122,7 +125,7 @@ SalaryCalculation calculateNetSalary(
           salary.mealAllowanceType,
           salary.mealAllowancePerDay,
           salary.workingDaysPerMonth,
-          irsRate,
+          irsMarginalRate,
           taxSystem.socialContributionRate,
         )
       : const MealAllowanceCalculation();

--- a/monthy_budget_flutter/test/tax_sim_polish_test.dart
+++ b/monthy_budget_flutter/test/tax_sim_polish_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/data/tax/tax_factory.dart';
+import 'package:monthly_management/data/tax/tax_system.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/utils/calculations.dart';
+
+void main() {
+  final ptSystem = getTaxSystem(Country.pt);
+
+  group('Task A — meal allowance taxed at marginal rate, not effective', () {
+    // €1500 solteiro: bracket upTo 1819, rate 0.241 (24.1%)
+    // Effective rate = (1500×0.241 - 193.33) / 1500 ≈ 11.21%
+    // Meal card €12/day × 22 days:
+    //   taxable = (12 - 10.20) × 22 = 39.60
+    //   IRS at marginal 24.1%  → 9.55
+    //   IRS at effective 11.2% → 4.44  ← wrong (old behaviour)
+
+    test('PT calculateTax exposes marginalRate = bracket rate', () {
+      final result = ptSystem.calculateTax(
+        grossSalary: 1500,
+        maritalStatus: 'solteiro',
+        titulares: 1,
+        dependentes: 0,
+      );
+
+      // Marginal rate for this bracket is 24.1%
+      expect(result.marginalRate, closeTo(0.241, 0.001),
+          reason: 'TaxResult must expose the bracket marginal rate, '
+              'not the effective rate');
+    });
+
+    test('calculateNetSalary uses marginal rate for meal allowance tax', () {
+      final salary = SalaryInfo(
+        label: 'Test',
+        grossAmount: 1500,
+        enabled: true,
+        subsidyMode: SubsidyMode.none,
+        mealAllowanceType: MealAllowanceType.card,
+        mealAllowancePerDay: 12.0,
+        workingDaysPerMonth: 22,
+      );
+      final personal = const PersonalInfo(
+        maritalStatus: MaritalStatus.solteiro,
+        dependentes: 0,
+      );
+
+      final result = calculateNetSalary(salary, personal, ptSystem);
+
+      // taxable = (12-10.20) × 22 = 39.60
+      // IRS at marginal 24.1% = 9.55 (allow ±0.10 for rounding)
+      expect(
+        result.mealAllowance.irsTaxOnMeal,
+        greaterThan(8.0),
+        reason:
+            'meal allowance excess must be taxed at the marginal rate (~9.55), '
+            'not the lower effective rate (~4.44)',
+      );
+    });
+
+    test('no meal allowance → marginalRate has no effect on net', () {
+      final salary = const SalaryInfo(
+        label: 'Test',
+        grossAmount: 1500,
+        enabled: true,
+        subsidyMode: SubsidyMode.none,
+      );
+      final personal = const PersonalInfo(
+        maritalStatus: MaritalStatus.solteiro,
+        dependentes: 0,
+      );
+
+      final result = calculateNetSalary(salary, personal, ptSystem);
+
+      expect(result.mealAllowance.irsTaxOnMeal, 0.0);
+      expect(result.mealAllowance.taxablePortion, 0.0);
+    });
+
+    test('meal allowance within exempt limit → no tax regardless of rate', () {
+      // €10/day is below the card exempt limit of €10.20 → taxable = 0
+      final salary = SalaryInfo(
+        label: 'Test',
+        grossAmount: 1500,
+        enabled: true,
+        subsidyMode: SubsidyMode.none,
+        mealAllowanceType: MealAllowanceType.card,
+        mealAllowancePerDay: 10.0,
+        workingDaysPerMonth: 22,
+      );
+      final personal = const PersonalInfo(
+        maritalStatus: MaritalStatus.solteiro,
+        dependentes: 0,
+      );
+
+      final result = calculateNetSalary(salary, personal, ptSystem);
+
+      expect(result.mealAllowance.taxablePortion, 0.0);
+      expect(result.mealAllowance.irsTaxOnMeal, 0.0);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1112

## Release Notes
- **Meal allowance IRS deduction now uses the marginal bracket rate** (e.g. 24.1% for €1500/month) instead of the lower effective rate. This is the legally correct treatment: excess meal allowance above the exempt limit is subject to the marginal rate, not the average effective rate.
- **Titulares control is now gated on marital status**: the 1/2 titulares toggle only appears for casado/união de facto, and resets to 1 when switching to solteiro.

## Changes
- `lib/data/tax/tax_system.dart` — added `marginalRate` field to `TaxResult` (backward-compatible, default `0.0`)
- `lib/data/tax/pt_tax_system.dart` — set `marginalRate: bracket?.rate ?? 0.0` in `TaxResult` constructor
- `lib/utils/calculations.dart` — capture `irsMarginalRate` from both tax paths; pass it to `calculateMealAllowance` instead of `irsRate`
- `lib/screens/tax_simulator_screen.dart` — gate titulares row on `casado || uniaoFacto`; reset `_titulares = 1` on solteiro selection
- `test/tax_sim_polish_test.dart` — 4 tests covering marginal rate exposure and meal allowance tax correctness