### PR TITLE
feat(tax-sim): add subsidyMode (duodécimos) control

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -3103,6 +3103,7 @@
     "settingsDisabilityLabel": "PERSON WITH DISABILITY",
     "helperDisability": "Applies the disability-specific withholding tables (IV–VII).",
     "taxSimIrsJovem": "IRS Jovem (year)",
+    "taxSimSubsidyMode": "Subsidies (duodécimos)",
     "taxSimDisability": "Disability",
     "irsJovemLegalNote": "IRS Jovem: the withholding rate for the total income is applied only to the non-exempt part (Despacho no. 236-A/2025). The exempt part is capped at 55×IAS (≈ €29,542/year). Monthly withholding is an estimate — the final amount is settled in the annual tax return (Modelo 3), and the annual cap is spread across months approximately.",
     "@irsJovemLegalNote": {

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -3038,6 +3038,7 @@
     "settingsDisabilityLabel": "PERSONA CON DISCAPACIDAD",
     "helperDisability": "Aplica las tablas de retención específicas para discapacidad (IV–VII).",
     "taxSimIrsJovem": "IRS Jovem (año)",
+    "taxSimSubsidyMode": "Subsidios (duodécimos)",
     "taxSimDisability": "Discapacidad",
     "irsJovemLegalNote": "IRS Jovem: el tipo de retención del rendimiento total se aplica solo a la parte no exenta (Despacho n.º 236-A/2025). La parte exenta está limitada a 55×IAS (≈ 29.542€/año). La retención mensual es una estimación — el importe final se ajusta en la declaración anual (Modelo 3) y el tope anual se reparte entre los meses de forma aproximada.",
     "@irsJovemLegalNote": {

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -3038,6 +3038,7 @@
     "settingsDisabilityLabel": "PERSONNE EN SITUATION DE HANDICAP",
     "helperDisability": "Applique les tables de retenue spécifiques au handicap (IV–VII).",
     "taxSimIrsJovem": "IRS Jovem (année)",
+    "taxSimSubsidyMode": "Subsidies (duodécimos)",
     "taxSimDisability": "Handicap",
     "irsJovemLegalNote": "IRS Jovem : le taux de retenue du revenu total s'applique uniquement à la partie non exonérée (Despacho n.º 236-A/2025). La partie exonérée est plafonnée à 55×IAS (≈ 29 542€/an). La retenue mensuelle est une estimation — le montant final est régularisé dans la déclaration annuelle (Modelo 3) et le plafond annuel est réparti sur les mois de façon approximative.",
     "@irsJovemLegalNote": {

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -5832,6 +5832,7 @@
     },
     "helperDisability": "Aplica as tabelas de retenção específicas para deficiência (IV–VII).",
     "taxSimIrsJovem": "IRS Jovem (ano)",
+    "taxSimSubsidyMode": "Subsidios (duodécimos)",
     "taxSimDisability": "Deficiência",
     "irsJovemLegalNote": "IRS Jovem: aplica-se a taxa de retenção do rendimento total apenas à parte não isenta (Despacho n.º 236-A/2025). A parte isenta está limitada a 55×IAS (≈ 29.542€/ano). A retenção mensal é uma estimativa — o valor final é acertado no IRS anual (Modelo 3) e o tecto anual é repartido pelos meses de forma aproximada.",
     "@irsJovemLegalNote": {

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -10757,6 +10757,12 @@ abstract class S {
   /// **'IRS Jovem (ano)'**
   String get taxSimIrsJovem;
 
+  /// No description provided for @taxSimSubsidyMode.
+  ///
+  /// In pt, this message translates to:
+  /// **'Subsidios (duodécimos)'**
+  String get taxSimSubsidyMode;
+
   /// No description provided for @taxSimDisability.
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -6013,6 +6013,9 @@ class SEn extends S {
   String get taxSimIrsJovem => 'IRS Jovem (year)';
 
   @override
+  String get taxSimSubsidyMode => 'Subsidies (duodécimos)';
+
+  @override
   String get taxSimDisability => 'Disability';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -6060,6 +6060,9 @@ class SEs extends S {
   String get taxSimIrsJovem => 'IRS Jovem (año)';
 
   @override
+  String get taxSimSubsidyMode => 'Subsidios (duodécimos)';
+
+  @override
   String get taxSimDisability => 'Discapacidad';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -6073,6 +6073,9 @@ class SFr extends S {
   String get taxSimIrsJovem => 'IRS Jovem (année)';
 
   @override
+  String get taxSimSubsidyMode => 'Subsidies (duodécimos)';
+
+  @override
   String get taxSimDisability => 'Handicap';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -6056,6 +6056,9 @@ class SPt extends S {
   String get taxSimIrsJovem => 'IRS Jovem (ano)';
 
   @override
+  String get taxSimSubsidyMode => 'Subsidios (duodécimos)';
+
+  @override
   String get taxSimDisability => 'Deficiência';
 
   @override

--- a/monthy_budget_flutter/lib/screens/tax_simulator_screen.dart
+++ b/monthy_budget_flutter/lib/screens/tax_simulator_screen.dart
@@ -24,6 +24,7 @@ class TaxSimulatorScreen extends StatefulWidget {
 
 class _TaxSimulatorScreenState extends State<TaxSimulatorScreen> {
   late double _grossAmount;
+  late SubsidyMode _subsidyMode;
   late MaritalStatus _maritalStatus;
   late int _titulares;
   late int _dependentes;
@@ -43,6 +44,7 @@ class _TaxSimulatorScreenState extends State<TaxSimulatorScreen> {
       orElse: () => const SalaryInfo(),
     );
     _grossAmount = salary.grossAmount;
+    _subsidyMode = salary.subsidyMode;
     _maritalStatus = widget.settings.personalInfo.maritalStatus;
     _titulares = salary.titulares;
     _dependentes = widget.settings.personalInfo.dependentes;
@@ -71,6 +73,7 @@ class _TaxSimulatorScreenState extends State<TaxSimulatorScreen> {
     // Simulated
     final simSalary = currentSalary.copyWith(
       grossAmount: _grossAmount,
+      subsidyMode: _subsidyMode,
       titulares: _titulares,
       mealAllowanceType: _mealType,
       mealAllowancePerDay: _mealPerDay,
@@ -250,6 +253,20 @@ class _TaxSimulatorScreenState extends State<TaxSimulatorScreen> {
                   _recalculate();
                 }),
               ),
+              if (country.hasSubsidies) ...[
+                const SizedBox(height: 16),
+                _SegmentedRow(
+                  label: l10n.taxSimSubsidyMode,
+                  options: SubsidyMode.values
+                      .map((m) => m.localizedShortLabel(l10n))
+                      .toList(),
+                  selected: _subsidyMode.index,
+                  onSelected: (i) => setState(() {
+                    _subsidyMode = SubsidyMode.values[i];
+                    _recalculate();
+                  }),
+                ),
+              ],
               if (country.maritalStatusAffectsTax) ...[
                 const SizedBox(height: 16),
                 _SegmentedRow(

--- a/monthy_budget_flutter/test/tax_sim_subsidy_mode_test.dart
+++ b/monthy_budget_flutter/test/tax_sim_subsidy_mode_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/data/tax/tax_factory.dart';
+import 'package:monthly_management/data/tax/tax_system.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/utils/calculations.dart';
+
+void main() {
+  final ptSystem = getTaxSystem(Country.pt);
+
+  const personal = PersonalInfo(
+    maritalStatus: MaritalStatus.solteiro,
+    dependentes: 0,
+  );
+
+  SalaryInfo salaryWith(SubsidyMode mode) => SalaryInfo(
+        label: 'Test',
+        grossAmount: 1500,
+        enabled: true,
+        subsidyMode: mode,
+      );
+
+  group('subsidyMode in calculateNetSalary', () {
+    test('SubsidyMode.none: effectiveGross equals grossAmount', () {
+      final result = calculateNetSalary(salaryWith(SubsidyMode.none), personal, ptSystem);
+      expect(result.effectiveGrossAmount, closeTo(1500.0, 0.01));
+      expect(result.subsidyMonthlyBonus, closeTo(0.0, 0.01));
+    });
+
+    test('SubsidyMode.full: effectiveGross = grossAmount × 14/12', () {
+      final result = calculateNetSalary(salaryWith(SubsidyMode.full), personal, ptSystem);
+      expect(result.effectiveGrossAmount, closeTo(1500.0 * 14 / 12, 0.02));
+      expect(result.subsidyMonthlyBonus, greaterThan(0.0));
+    });
+
+    test('SubsidyMode.half: effectiveGross = grossAmount × 13/12', () {
+      final result = calculateNetSalary(salaryWith(SubsidyMode.half), personal, ptSystem);
+      expect(result.effectiveGrossAmount, closeTo(1500.0 * 13 / 12, 0.02));
+    });
+
+    test('full-mode net is higher than none-mode net', () {
+      final none = calculateNetSalary(salaryWith(SubsidyMode.none), personal, ptSystem);
+      final full = calculateNetSalary(salaryWith(SubsidyMode.full), personal, ptSystem);
+      expect(full.totalNetWithMeal, greaterThan(none.totalNetWithMeal),
+          reason: 'duodécimos should increase total monthly net');
+    });
+
+    test('half-mode net is between none and full', () {
+      final none = calculateNetSalary(salaryWith(SubsidyMode.none), personal, ptSystem);
+      final half = calculateNetSalary(salaryWith(SubsidyMode.half), personal, ptSystem);
+      final full = calculateNetSalary(salaryWith(SubsidyMode.full), personal, ptSystem);
+      expect(half.totalNetWithMeal, greaterThan(none.totalNetWithMeal));
+      expect(half.totalNetWithMeal, lessThan(full.totalNetWithMeal));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1111

## Release Notes
- **Tax simulator now exposes a subsidyMode (duodécimos) control** — the biggest net-pay lever was silently inherited from stored settings and invisible to the user. The new 3-segment control (Sem / Com / 50%) is shown for PT and ES and immediately reflects in the simulated net take-home.
- The simulated scenario uses the user's chosen subsidyMode, not the stored one. Switching between none/full/half shows a ±16.7% / ±8.3% difference in effective gross, exactly what a user would want to model before contract negotiation.

## Changes
- `lib/screens/tax_simulator_screen.dart` — add `_subsidyMode` late field; init from `salary.subsidyMode`; pass in `copyWith` in `_recalculate()`; render `_SegmentedRow` gated on `country.hasSubsidies`
- `lib/l10n/app_{en,pt,es,fr}.arb` — add `taxSimSubsidyMode` key (all 4 locales)
- `lib/l10n/generated/` — regenerated localizations
- `test/tax_sim_subsidy_mode_test.dart` — 5 tests: effectiveGross and net ordering across all 3 modes