### PR TITLE
feat(calm): convert meal section cards to CalmCard in settings

### DIFF
--- a/monthy_budget_flutter/lib/screens/settings_screen_sections.dart
+++ b/monthy_budget_flutter/lib/screens/settings_screen_sections.dart
@@ -1958,14 +1958,9 @@ extension _SettingsSections on _SettingsScreenState {
   static int _nearestComplexity(int v) => v <= 2 ? 1 : (v <= 4 ? 3 : 5);
 
   Widget _mealCard({required IconData icon, required String title, required List<Widget> children, String? subtitle}) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: BorderSide(color: AppColors.border(context)),
-      ),
-      child: Padding(
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: CalmCard(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -1988,22 +1983,19 @@ extension _SettingsSections on _SettingsScreenState {
   }
 
   Widget _mealExpansionCard({required IconData icon, required String title, required List<Widget> children, String? subtitle, bool initiallyExpanded = false}) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: BorderSide(color: AppColors.border(context)),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: ExpansionTile(
-        initiallyExpanded: initiallyExpanded,
-        tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        leading: Icon(icon, size: 18, color: AppColors.primary(context)),
-        title: Text(title, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700)),
-        subtitle: subtitle != null ? Text(subtitle, style: TextStyle(fontSize: 12, color: AppColors.textMuted(context))) : null,
-        children: children,
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: CalmCard(
+        padding: EdgeInsets.zero,
+        child: ExpansionTile(
+          initiallyExpanded: initiallyExpanded,
+          tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          leading: Icon(icon, size: 18, color: AppColors.primary(context)),
+          title: Text(title, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700)),
+          subtitle: subtitle != null ? Text(subtitle, style: TextStyle(fontSize: 12, color: AppColors.textMuted(context))) : null,
+          children: children,
+        ),
       ),
     );
   }

--- a/monthy_budget_flutter/test/screens/settings_meal_calmcard_test.dart
+++ b/monthy_budget_flutter/test/screens/settings_meal_calmcard_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/models/meal_settings.dart';
+import 'package:monthly_management/screens/settings_screen.dart';
+import 'package:monthly_management/widgets/calm/calm_card.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  Widget buildMealSettings() {
+    final settings = AppSettings().copyWith(
+      mealSettings: const MealSettings(wizardCompleted: true),
+    );
+    return wrapWithTestApp(
+      SettingsScreen(
+        settings: settings,
+        onSave: (_) {},
+        favorites: const [],
+        onSaveFavorites: (_) {},
+        apiKey: '',
+        onSaveApiKey: (_) {},
+        isAdmin: false,
+        householdId: 'hh_1',
+        initialSection: 'meals',
+        loadAssociatedMembers: (_) async => const [],
+      ),
+    );
+  }
+
+  group('#1072 meal cards use CalmCard', () {
+    testWidgets('meals section renders CalmCard widgets', (tester) async {
+      await tester.pumpWidget(buildMealSettings());
+      await tester.pumpAndSettle();
+
+      // _mealCard and _mealExpansionCard now wrap in CalmCard.
+      // 6 static cards + 4 expansion cards = at least 4 visible CalmCards.
+      expect(find.byType(CalmCard), findsAtLeastNWidgets(4));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1072

## What changed

Converted `_mealCard` and `_mealExpansionCard` helper methods in `settings_screen_sections.dart` from raw Material `Card` widgets to `CalmCard`:

- `_mealCard`: `Card(margin, elevation, shape, child: Padding(all:16, …))` → `Padding(bottom:12, child: CalmCard(padding:all(16), …))`
- `_mealExpansionCard`: `Card(margin, elevation, shape, clipBehavior, child: ExpansionTile(…))` → `Padding(bottom:12, child: CalmCard(padding:zero, child: ExpansionTile(…)))`

Manual `elevation`, `shape`, `RoundedRectangleBorder`, and `BorderSide` removed — all inherited from `CardTheme`.

## Release Notes

Settings screen meal cards now use the Calm design system `CalmCard` component, inheriting shared theme tokens (radius, border, elevation) instead of hardcoded values.