### PR TITLE
issue-1129: refactor(meal-planner): replace legacy AppColors aliases with Calm tokens

### DIFF
--- a/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
+++ b/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
@@ -211,7 +211,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                 child: SizedBox(
                   width: 40,
                   height: 4,
-                  child: ColoredBox(color: AppColors.borderMuted(ctx)),
+                  child: ColoredBox(color: AppColors.ink20(ctx)),
                 ),
               ),
             ),
@@ -570,7 +570,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                 child: SizedBox(
                   width: 40,
                   height: 4,
-                  child: ColoredBox(color: AppColors.borderMuted(context)),
+                  child: ColoredBox(color: AppColors.ink20(context)),
                 ),
               ),
             ),
@@ -592,7 +592,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                       l10n.mealBatchTotalTime(plan.totalTimeEstimate),
                       style: TextStyle(
                         fontSize: 13,
-                        color: AppColors.textSecondary(context),
+                        color: AppColors.ink70(context),
                       ),
                     ),
                   ],
@@ -610,7 +610,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                       padding: const EdgeInsets.only(bottom: 8),
                       child: CalmListTile(
                         leadingIcon: Icons.circle,
-                        leadingColor: AppColors.primary(context),
+                        leadingColor: AppColors.ink(context),
                         title: '${e.key + 1}. ${e.value}',
                       ),
                     ),
@@ -670,7 +670,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                 child: SizedBox(
                   width: 40,
                   height: 4,
-                  child: ColoredBox(color: AppColors.borderMuted(ctx)),
+                  child: ColoredBox(color: AppColors.ink20(ctx)),
                 ),
               ),
             ),
@@ -691,7 +691,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                     recipe.name,
                     style: TextStyle(
                       fontSize: 14,
-                      color: AppColors.textSecondary(ctx),
+                      color: AppColors.ink70(ctx),
                     ),
                   ),
                   const SizedBox(height: 2),
@@ -699,7 +699,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                     l10n.mealPrepTime(recipe.prepMinutes.toString()),
                     style: TextStyle(
                       fontSize: 12,
-                      color: AppColors.textMuted(ctx),
+                      color: AppColors.ink50(ctx),
                     ),
                   ),
                 ],
@@ -714,7 +714,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                   ...steps.asMap().entries.map(
                     (e) => CalmListTile(
                       leadingIcon: Icons.circle,
-                      leadingColor: AppColors.primary(ctx),
+                      leadingColor: AppColors.ink(ctx),
                       title: '${e.key + 1}. ${e.value}',
                     ),
                   ),
@@ -729,14 +729,14 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                     if (aiContent.variation.isNotEmpty)
                       CalmListTile(
                         leadingIcon: Icons.shuffle,
-                        leadingColor: AppColors.primary(ctx),
+                        leadingColor: AppColors.ink(ctx),
                         title: l10n.mealVariation,
                         subtitle: aiContent.variation,
                       ),
                     if (aiContent.storageInfo.isNotEmpty)
                       CalmListTile(
                         leadingIcon: Icons.kitchen,
-                        leadingColor: AppColors.textSecondary(ctx),
+                        leadingColor: AppColors.ink70(ctx),
                         title: l10n.mealStorage,
                         subtitle: aiContent.storageInfo,
                       ),
@@ -820,7 +820,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                   child: SizedBox(
                     width: 40,
                     height: 4,
-                    child: ColoredBox(color: AppColors.borderMuted(ctx)),
+                    child: ColoredBox(color: AppColors.ink20(ctx)),
                   ),
                 ),
               ),
@@ -841,7 +841,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                       l10n.mealPantrySelectHint,
                       style: TextStyle(
                         fontSize: 13,
-                        color: AppColors.textSecondary(ctx),
+                        color: AppColors.ink70(ctx),
                       ),
                     ),
                     const SizedBox(height: 4),
@@ -850,7 +850,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                       style: TextStyle(
                         fontSize: 12,
                         fontWeight: FontWeight.w600,
-                        color: AppColors.primary(ctx),
+                        color: AppColors.ink(ctx),
                       ),
                     ),
                   ],
@@ -875,11 +875,11 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                         ing.category.name,
                         style: TextStyle(
                           fontSize: 12,
-                          color: AppColors.textMuted(ctx),
+                          color: AppColors.ink50(ctx),
                         ),
                       ),
                       value: isSelected,
-                      activeColor: AppColors.primary(ctx),
+                      activeColor: AppColors.ink(ctx),
                       onChanged: (v) {
                         setSheetState(() {
                           if (v == true) {
@@ -913,7 +913,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                     icon: const Icon(Icons.auto_awesome),
                     label: Text(l10n.mealPantryApply),
                     style: FilledButton.styleFrom(
-                      backgroundColor: AppColors.primary(ctx),
+                      backgroundColor: AppColors.ink(ctx),
                       padding: const EdgeInsets.symmetric(vertical: 14),
                     ),
                   ),
@@ -971,7 +971,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                 child: SizedBox(
                   width: 40,
                   height: 4,
-                  child: ColoredBox(color: AppColors.borderMuted(ctx)),
+                  child: ColoredBox(color: AppColors.ink20(ctx)),
                 ),
               ),
             ),
@@ -997,7 +997,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                   l10n.mealSubstituteHint,
                   style: TextStyle(
                     fontSize: 12,
-                    color: AppColors.textSecondary(ctx),
+                    color: AppColors.ink70(ctx),
                   ),
                 ),
               ),
@@ -1019,7 +1019,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                             .map(
                               (alt) => CalmListTile(
                                 leadingIcon: Icons.swap_horiz,
-                                leadingColor: AppColors.primary(ctx),
+                                leadingColor: AppColors.ink(ctx),
                                 title: alt.name,
                                 subtitle:
                                     '${alt.avgPricePerUnit.toStringAsFixed(2)}${currencySymbol()}/${alt.unit}',
@@ -1047,7 +1047,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                             .map(
                               (alt) => CalmListTile(
                                 leadingIcon: Icons.swap_horiz,
-                                leadingColor: AppColors.textMuted(ctx),
+                                leadingColor: AppColors.ink50(ctx),
                                 title: alt.name,
                                 subtitle:
                                     '${alt.category.name} · ${alt.avgPricePerUnit.toStringAsFixed(2)}${currencySymbol()}/${alt.unit}',
@@ -1733,9 +1733,9 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                               style: const TextStyle(fontSize: 11),
                             ),
                             style: OutlinedButton.styleFrom(
-                              foregroundColor: AppColors.primary(context),
+                              foregroundColor: AppColors.ink(context),
                               side: BorderSide(
-                                color: AppColors.primary(context),
+                                color: AppColors.ink(context),
                               ),
                               shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(8),
@@ -1764,13 +1764,13 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                                       height: 14,
                                       child: CircularProgressIndicator(
                                         strokeWidth: 2,
-                                        color: AppColors.primary(context),
+                                        color: AppColors.ink(context),
                                       ),
                                     )
                                   : Icon(
                                       Icons.kitchen,
                                       size: 18,
-                                      color: AppColors.primary(context),
+                                      color: AppColors.ink(context),
                                     ),
                               padding: EdgeInsets.zero,
                               tooltip: l10n.mealBatchPrepGuide,
@@ -2028,10 +2028,10 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                     FloatingActionButton.small(
                       heroTag: 'addFreeform',
                       onPressed: () => _showFreeformDayPicker(plan),
-                      backgroundColor: AppColors.primary(context),
+                      backgroundColor: AppColors.ink(context),
                       child: Icon(
                         Icons.edit_note,
-                        color: AppColors.onPrimary(context),
+                        color: AppColors.bg(context),
                       ),
                     ),
                   ],

--- a/monthy_budget_flutter/lib/widgets/nutrition_dashboard_card.dart
+++ b/monthy_budget_flutter/lib/widgets/nutrition_dashboard_card.dart
@@ -128,10 +128,10 @@ class NutritionDashboardCard extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
       child: Card(
         elevation: 0,
-        color: AppColors.surface(context),
+        color: AppColors.card(context),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: AppColors.border(context)),
+          side: BorderSide(color: AppColors.line(context)),
         ),
         child: Padding(
           padding: const EdgeInsets.all(12),
@@ -141,7 +141,7 @@ class NutritionDashboardCard extends StatelessWidget {
               // Header
               Row(
                 children: [
-                  Icon(Icons.bar_chart_rounded, size: 18, color: AppColors.textSecondary(context)),
+                  Icon(Icons.bar_chart_rounded, size: 18, color: AppColors.ink70(context)),
                   const SizedBox(width: 8),
                   Text(
                     l10n.nutritionDashboardTitle,
@@ -187,7 +187,7 @@ class NutritionDashboardCard extends StatelessWidget {
                 const SizedBox(height: 8),
                 Text(
                   '${l10n.nutritionTopProteins}: ${stats.topProteins.entries.take(3).map((e) => '${_resolveProteinName(e.key)} ${e.value}x').join(', ')}',
-                  style: TextStyle(fontSize: 11, color: AppColors.textSecondary(context)),
+                  style: TextStyle(fontSize: 11, color: AppColors.ink70(context)),
                 ),
               ],
             ],
@@ -240,7 +240,7 @@ class _NutrientBar extends StatelessWidget {
             borderRadius: BorderRadius.circular(4),
             child: LinearProgressIndicator(
               value: barRatio,
-              backgroundColor: AppColors.border(context),
+              backgroundColor: AppColors.line(context),
               color: progressColor,
               minHeight: 8,
             ),

--- a/monthy_budget_flutter/lib/widgets/star_rating_row.dart
+++ b/monthy_budget_flutter/lib/widgets/star_rating_row.dart
@@ -33,7 +33,7 @@ class StarRatingRow extends StatelessWidget {
                 size: starSize,
                 color: isFilled
                     ? AppColors.chartAmber(context)
-                    : AppColors.borderMuted(context),
+                    : AppColors.ink20(context),
               ),
             ),
           ),

--- a/monthy_budget_flutter/test/screens/meal_planner_calm_tokens_test.dart
+++ b/monthy_budget_flutter/test/screens/meal_planner_calm_tokens_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/widgets/star_rating_row.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  group('#1129 Calm token migration — meal planner widgets', () {
+    testWidgets('StarRatingRow renders filled and empty stars', (tester) async {
+      var rated = 0;
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          StarRatingRow(currentRating: 3, onRate: (v) => rated = v),
+        ),
+      );
+      await tester.pump();
+
+      // 5 stars rendered
+      expect(find.byType(Icon), findsNWidgets(5));
+      // Tap the 5th star
+      await tester.tap(find.byType(GestureDetector).last);
+      await tester.pump();
+      expect(rated, 5);
+    });
+
+    testWidgets('StarRatingRow with no rating shows only unfilled stars', (tester) async {
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          StarRatingRow(currentRating: null, onRate: (_) {}),
+        ),
+      );
+      await tester.pump();
+
+      final icons = tester.widgetList<Icon>(find.byType(Icon)).toList();
+      expect(icons.every((i) => i.icon == Icons.star_border_rounded), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1129

## Summary

Replaces 32 legacy `AppColors` alias calls across three files with explicit Calm tokens:

| File | Aliases fixed |
|---|---|
| `lib/screens/meal_planner_screen.dart` | 26 |
| `lib/widgets/star_rating_row.dart` | 1 |
| `lib/widgets/nutrition_dashboard_card.dart` | 5 |

Mapping: `primary→ink`, `textSecondary→ink70`, `textMuted→ink50`, `borderMuted→ink20`, `border→line`, `surface→card`, `onPrimary→bg`.

## Release Notes

Meal planner screen and its satellite widgets now use only explicit Calm design tokens — no legacy aliases remain in the meal planner code path.

## Checklist

- [x] All 32 alias occurrences replaced across 3 files
- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` clean
- [x] `flutter test` — 2190 passed
- [x] No features removed