### PR TITLE
issue-1131: refactor(auth): replace legacy AppColors aliases with Calm tokens in auth screens

### DIFF
--- a/monthy_budget_flutter/lib/screens/auth/auth_gate.dart
+++ b/monthy_budget_flutter/lib/screens/auth/auth_gate.dart
@@ -218,7 +218,7 @@ class _ErrorScreen extends StatelessWidget {
                 error,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  color: AppColors.textSecondary(context),
+                  color: AppColors.ink70(context),
                   fontSize: 13,
                 ),
               ),

--- a/monthy_budget_flutter/lib/screens/auth/biometric_lock_screen.dart
+++ b/monthy_budget_flutter/lib/screens/auth/biometric_lock_screen.dart
@@ -53,7 +53,7 @@ class _BiometricLockScreenState extends State<BiometricLockScreen> {
               Icon(
                 Icons.lock_outline,
                 size: 64,
-                color: AppColors.primary(context),
+                color: AppColors.ink(context),
               ),
               const SizedBox(height: 24),
               Text(
@@ -69,12 +69,12 @@ class _BiometricLockScreenState extends State<BiometricLockScreen> {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 15,
-                  color: AppColors.textSecondary(context),
+                  color: AppColors.ink70(context),
                 ),
               ),
               const SizedBox(height: 32),
               if (_authenticating)
-                CircularProgressIndicator(color: AppColors.primary(context))
+                CircularProgressIndicator(color: AppColors.ink(context))
               else
                 FilledButton.icon(
                   onPressed: _triggerAuth,

--- a/monthy_budget_flutter/test/screens/auth_calm_tokens_test.dart
+++ b/monthy_budget_flutter/test/screens/auth_calm_tokens_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/screens/auth/biometric_lock_screen.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  group('#1131 Auth screens — Calm token migration', () {
+    testWidgets('BiometricLockScreen renders without error', (tester) async {
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          BiometricLockScreen(onUnlocked: () {}),
+        ),
+      );
+      await tester.pump();
+      expect(find.byType(BiometricLockScreen), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1131

## Summary

Replaces 4 legacy `AppColors` alias calls in auth screens:

| File | Changes |
|---|---|
| `lib/screens/auth/auth_gate.dart` | `textSecondary` → `ink70` (1 occurrence) |
| `lib/screens/auth/biometric_lock_screen.dart` | `primary` → `ink` (2), `textSecondary` → `ink70` (1) |

## Release Notes

Auth screens (biometric lock and auth gate) now use only explicit Calm tokens, completing the token migration for the login/auth flow (umbrella #1030, item #20).

## Checklist

- [x] 4 alias occurrences replaced
- [x] `flutter test` — 2190 passed
- [x] No features removed