### PR TITLE
issue-1133: fix(l10n): move hardcoded PT strings in dashboard_screen to ARB

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -178,6 +178,7 @@
         }
     },
     "dashboardConfigureData": "Set up your data to see the summary.",
+    "dashboardEmptyStateBody": "Set up your income and expenses to get started.",
     "dashboardOpenSettingsButton": "Open Settings",
     "dashboardGrossIncome": "Gross Income",
     "dashboardNetIncome": "Net Income",
@@ -2743,6 +2744,7 @@
     "dashboardBurnRateSubtitle": "Daily average vs available budget",
     "dashboardBurnRateOnTrack": "On track",
     "dashboardBurnRateOver": "Over pace",
+    "dashboardBurnRateAttention": "attention",
     "dashboardBurnRateDailyAvg": "AVG/DAY",
     "dashboardBurnRateAllowance": "ALLOW./DAY",
     "dashboardBurnRateDaysLeft": "DAYS LEFT",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -178,6 +178,7 @@
         }
     },
     "dashboardConfigureData": "Configure sus datos para ver el resumen.",
+    "dashboardEmptyStateBody": "Configure sus ingresos y gastos para comenzar.",
     "dashboardOpenSettingsButton": "Abrir Configuración",
     "dashboardGrossIncome": "Ingreso Bruto",
     "dashboardNetIncome": "Ingreso Neto",
@@ -2685,6 +2686,7 @@
     "dashboardBurnRateSubtitle": "Promedio diario vs presupuesto disponible",
     "dashboardBurnRateOnTrack": "En camino",
     "dashboardBurnRateOver": "Sobre el ritmo",
+    "dashboardBurnRateAttention": "atención",
     "dashboardBurnRateDailyAvg": "MEDIA/DÍA",
     "dashboardBurnRateAllowance": "DISP./DÍA",
     "dashboardBurnRateDaysLeft": "DÍAS RESTANTES",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -178,6 +178,7 @@
         }
     },
     "dashboardConfigureData": "Configurez vos données pour voir le résumé.",
+    "dashboardEmptyStateBody": "Configurez vos revenus et dépenses pour commencer.",
     "dashboardOpenSettingsButton": "Ouvrir les Paramètres",
     "dashboardGrossIncome": "Revenu Brut",
     "dashboardNetIncome": "Revenu Net",
@@ -2685,6 +2686,7 @@
     "dashboardBurnRateSubtitle": "Moyenne quotidienne vs budget disponible",
     "dashboardBurnRateOnTrack": "En bonne voie",
     "dashboardBurnRateOver": "Au-dessus du rythme",
+    "dashboardBurnRateAttention": "attention",
     "dashboardBurnRateDailyAvg": "MOY./JOUR",
     "dashboardBurnRateAllowance": "DISP./JOUR",
     "dashboardBurnRateDaysLeft": "JOURS RESTANTS",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -516,6 +516,7 @@
     "@dashboardConfigureData": {
         "description": "Empty state message"
     },
+    "dashboardEmptyStateBody": "Configure os seus rendimentos e despesas para começar.",
     "dashboardOpenSettingsButton": "Abrir Definições",
     "@dashboardOpenSettingsButton": {
         "description": "Empty state settings button label"
@@ -5190,6 +5191,7 @@
     "@dashboardBurnRateOnTrack": {"description": "On track pace label"},
     "dashboardBurnRateOver": "Acima do ritmo",
     "@dashboardBurnRateOver": {"description": "Over pace label"},
+    "dashboardBurnRateAttention": "atenção",
     "dashboardBurnRateDailyAvg": "MÉDIA/DIA",
     "@dashboardBurnRateDailyAvg": {"description": "Daily average label"},
     "dashboardBurnRateAllowance": "DISP./DIA",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -815,6 +815,12 @@ abstract class S {
   /// **'Configure os seus dados para ver o resumo.'**
   String get dashboardConfigureData;
 
+  /// No description provided for @dashboardEmptyStateBody.
+  ///
+  /// In pt, this message translates to:
+  /// **'Configure os seus rendimentos e despesas para começar.'**
+  String get dashboardEmptyStateBody;
+
   /// Empty state settings button label
   ///
   /// In pt, this message translates to:
@@ -9238,6 +9244,12 @@ abstract class S {
   /// In pt, this message translates to:
   /// **'Acima do ritmo'**
   String get dashboardBurnRateOver;
+
+  /// No description provided for @dashboardBurnRateAttention.
+  ///
+  /// In pt, this message translates to:
+  /// **'atenção'**
+  String get dashboardBurnRateAttention;
 
   /// Daily average label
   ///

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -383,6 +383,10 @@ class SEn extends S {
   String get dashboardConfigureData => 'Set up your data to see the summary.';
 
   @override
+  String get dashboardEmptyStateBody =>
+      'Set up your income and expenses to get started.';
+
+  @override
   String get dashboardOpenSettingsButton => 'Open Settings';
 
   @override
@@ -5108,6 +5112,9 @@ class SEn extends S {
 
   @override
   String get dashboardBurnRateOver => 'Over pace';
+
+  @override
+  String get dashboardBurnRateAttention => 'attention';
 
   @override
   String get dashboardBurnRateDailyAvg => 'AVG/DAY';

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -384,6 +384,10 @@ class SEs extends S {
       'Configure sus datos para ver el resumen.';
 
   @override
+  String get dashboardEmptyStateBody =>
+      'Configure sus ingresos y gastos para comenzar.';
+
+  @override
   String get dashboardOpenSettingsButton => 'Abrir Configuración';
 
   @override
@@ -5153,6 +5157,9 @@ class SEs extends S {
 
   @override
   String get dashboardBurnRateOver => 'Sobre el ritmo';
+
+  @override
+  String get dashboardBurnRateAttention => 'atención';
 
   @override
   String get dashboardBurnRateDailyAvg => 'MEDIA/DÍA';

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -384,6 +384,10 @@ class SFr extends S {
       'Configurez vos données pour voir le résumé.';
 
   @override
+  String get dashboardEmptyStateBody =>
+      'Configurez vos revenus et dépenses pour commencer.';
+
+  @override
   String get dashboardOpenSettingsButton => 'Ouvrir les Paramètres';
 
   @override
@@ -5161,6 +5165,9 @@ class SFr extends S {
 
   @override
   String get dashboardBurnRateOver => 'Au-dessus du rythme';
+
+  @override
+  String get dashboardBurnRateAttention => 'attention';
 
   @override
   String get dashboardBurnRateDailyAvg => 'MOY./JOUR';

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -384,6 +384,10 @@ class SPt extends S {
       'Configure os seus dados para ver o resumo.';
 
   @override
+  String get dashboardEmptyStateBody =>
+      'Configure os seus rendimentos e despesas para começar.';
+
+  @override
   String get dashboardOpenSettingsButton => 'Abrir Definições';
 
   @override
@@ -5148,6 +5152,9 @@ class SPt extends S {
 
   @override
   String get dashboardBurnRateOver => 'Acima do ritmo';
+
+  @override
+  String get dashboardBurnRateAttention => 'atenção';
 
   @override
   String get dashboardBurnRateDailyAvg => 'MÉDIA/DIA';

--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -440,8 +440,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       child: CalmEmptyState(
         icon: Icons.account_balance_wallet_outlined,
         title: l10n.dashboardConfigureData,
-        // TODO(l10n): move to ARB (Wave H)
-        body: 'Configure os seus rendimentos e despesas para começar.',
+        body: l10n.dashboardEmptyStateBody,
         action: CalmEmptyStateAction(
           label: l10n.dashboardOpenSettingsButton,
           onPressed: onOpenSettings,
@@ -1916,8 +1915,7 @@ class _StressIndexCardState extends State<_StressIndexCard> {
 
   String _statusLabel(BuildContext context, int score, S l10n) {
     if (score >= 60) return l10n.dashboardBurnRateOnTrack;
-    // TODO(l10n): move to ARB (Wave H)
-    if (score >= 40) return 'atenção';
+    if (score >= 40) return l10n.dashboardBurnRateAttention;
     return l10n.dashboardBurnRateOver;
   }
 

--- a/monthy_budget_flutter/test/screens/dashboard_l10n_1133_test.dart
+++ b/monthy_budget_flutter/test/screens/dashboard_l10n_1133_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/models/budget_summary.dart';
+import 'package:monthly_management/models/local_dashboard_config.dart';
+import 'package:monthly_management/models/purchase_record.dart';
+import 'package:monthly_management/screens/dashboard_screen.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  Widget buildEmpty() => wrapWithTestApp(
+        DashboardScreen(
+          settings: const AppSettings(),
+          summary: const BudgetSummary(),
+          purchaseHistory: const PurchaseHistory(),
+          dashboardConfig: const LocalDashboardConfig(),
+          expenseHistory: const {},
+          actualExpenses: const [],
+          monthlyBudgets: const {},
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: () {},
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+        ),
+      );
+
+  group('#1133 dashboard l10n — hardcoded strings replaced', () {
+    testWidgets('empty state body uses l10n key, not hardcoded PT', (tester) async {
+      await tester.pumpWidget(buildEmpty());
+      await tester.pumpAndSettle();
+
+      // Verify the hardcoded PT string is gone
+      expect(
+        find.text('Configure os seus rendimentos e despesas para começar.'),
+        findsNothing,
+      );
+
+      // Verify the EN translation from the ARB key is shown instead
+      final l10n = await S.delegate.load(const Locale('en'));
+      expect(find.text(l10n.dashboardEmptyStateBody), findsOneWidget);
+    });
+
+    testWidgets('burn rate attention label uses l10n key, not hardcoded', (tester) async {
+      // The l10n key must exist in the generated class — compile check.
+      final l10n = await S.delegate.load(const Locale('en'));
+      expect(l10n.dashboardBurnRateAttention, isNotEmpty);
+      expect(l10n.dashboardBurnRateAttention, isNot('atenção'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1133

## Summary

Two hardcoded Portuguese strings in `dashboard_screen.dart` that were marked `TODO(l10n)` are now sourced from ARB keys:

| Hardcoded | New key | Context |
|---|---|---|
| `'Configure os seus rendimentos e despesas para começar.'` | `dashboardEmptyStateBody` | Empty state card body |
| `'atenção'` | `dashboardBurnRateAttention` | Burn rate mid-range label |

Keys added to all 4 locale files (PT / EN / ES / FR) and `flutter gen-l10n` regenerated.

## Release Notes

Dashboard empty state and burn rate labels are now fully localized — EN, ES and FR users no longer see Portuguese text in these two spots.

## Checklist

- [x] 2 keys added to all 4 ARB files
- [x] `flutter gen-l10n` clean
- [x] `dashboard_screen.dart` uses `l10n.*` — no hardcoded strings remain
- [x] TDD: 2 tests added, passing
- [x] `flutter test` — 2194 passed