### PR TITLE
fix(l10n): move hardcoded PT strings in shopping_list_screen to ARB

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -563,6 +563,34 @@
             }
         }
     },
+    "shoppingFinalizing": "FINALIZING",
+    "@shoppingFinalizing": {},
+    "shoppingListEyebrow": "LIST",
+    "@shoppingListEyebrow": {},
+    "shoppingHeroItemCount": "{count} to buy",
+    "@shoppingHeroItemCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingSummaryEyebrow": "SUMMARY",
+    "@shoppingSummaryEyebrow": {},
+    "shoppingCheckedCountLabel": "{count} ✓",
+    "@shoppingCheckedCountLabel": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingToBuyEyebrow": "TO BUY",
+    "@shoppingToBuyEyebrow": {},
+    "shoppingInBasketEyebrow": "IN BASKET",
+    "@shoppingInBasketEyebrow": {},
+    "shoppingHistoryEyebrow": "HISTORY",
+    "@shoppingHistoryEyebrow": {},
     "authLogin": "Sign in",
     "authRegister": "Create account",
     "authEmail": "Email",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -521,6 +521,34 @@
             }
         }
     },
+    "shoppingFinalizing": "FINALIZANDO",
+    "@shoppingFinalizing": {},
+    "shoppingListEyebrow": "LISTA",
+    "@shoppingListEyebrow": {},
+    "shoppingHeroItemCount": "{count} por comprar",
+    "@shoppingHeroItemCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingSummaryEyebrow": "RESUMEN",
+    "@shoppingSummaryEyebrow": {},
+    "shoppingCheckedCountLabel": "{count} ✓",
+    "@shoppingCheckedCountLabel": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingToBuyEyebrow": "POR COMPRAR",
+    "@shoppingToBuyEyebrow": {},
+    "shoppingInBasketEyebrow": "EN EL CARRO",
+    "@shoppingInBasketEyebrow": {},
+    "shoppingHistoryEyebrow": "HISTORIAL",
+    "@shoppingHistoryEyebrow": {},
     "authLogin": "Iniciar sesión",
     "authRegister": "Crear cuenta",
     "authEmail": "Email",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -521,6 +521,34 @@
             }
         }
     },
+    "shoppingFinalizing": "EN COURS",
+    "@shoppingFinalizing": {},
+    "shoppingListEyebrow": "LISTE",
+    "@shoppingListEyebrow": {},
+    "shoppingHeroItemCount": "{count} à acheter",
+    "@shoppingHeroItemCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingSummaryEyebrow": "RÉSUMÉ",
+    "@shoppingSummaryEyebrow": {},
+    "shoppingCheckedCountLabel": "{count} ✓",
+    "@shoppingCheckedCountLabel": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingToBuyEyebrow": "À ACHETER",
+    "@shoppingToBuyEyebrow": {},
+    "shoppingInBasketEyebrow": "DANS LE PANIER",
+    "@shoppingInBasketEyebrow": {},
+    "shoppingHistoryEyebrow": "HISTORIQUE",
+    "@shoppingHistoryEyebrow": {},
     "authLogin": "Se connecter",
     "authRegister": "Créer un compte",
     "authEmail": "Email",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -1111,6 +1111,34 @@
             }
         }
     },
+    "shoppingFinalizing": "A FINALIZAR",
+    "@shoppingFinalizing": {},
+    "shoppingListEyebrow": "LISTA",
+    "@shoppingListEyebrow": {},
+    "shoppingHeroItemCount": "{count} por comprar",
+    "@shoppingHeroItemCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingSummaryEyebrow": "RESUMO",
+    "@shoppingSummaryEyebrow": {},
+    "shoppingCheckedCountLabel": "{count} ✓",
+    "@shoppingCheckedCountLabel": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "shoppingToBuyEyebrow": "POR COMPRAR",
+    "@shoppingToBuyEyebrow": {},
+    "shoppingInBasketEyebrow": "NO CESTO",
+    "@shoppingInBasketEyebrow": {},
+    "shoppingHistoryEyebrow": "HISTÓRICO",
+    "@shoppingHistoryEyebrow": {},
     "authLogin": "Entrar na conta",
     "@authLogin": {
         "description": "Auth login screen title"

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -1727,6 +1727,54 @@ abstract class S {
   /// **'Mais barato em {store} ({price})'**
   String shoppingCheapestAt(String store, String price);
 
+  /// No description provided for @shoppingFinalizing.
+  ///
+  /// In pt, this message translates to:
+  /// **'A FINALIZAR'**
+  String get shoppingFinalizing;
+
+  /// No description provided for @shoppingListEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'LISTA'**
+  String get shoppingListEyebrow;
+
+  /// No description provided for @shoppingHeroItemCount.
+  ///
+  /// In pt, this message translates to:
+  /// **'{count} por comprar'**
+  String shoppingHeroItemCount(int count);
+
+  /// No description provided for @shoppingSummaryEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'RESUMO'**
+  String get shoppingSummaryEyebrow;
+
+  /// No description provided for @shoppingCheckedCountLabel.
+  ///
+  /// In pt, this message translates to:
+  /// **'{count} ✓'**
+  String shoppingCheckedCountLabel(int count);
+
+  /// No description provided for @shoppingToBuyEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'POR COMPRAR'**
+  String get shoppingToBuyEyebrow;
+
+  /// No description provided for @shoppingInBasketEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'NO CESTO'**
+  String get shoppingInBasketEyebrow;
+
+  /// No description provided for @shoppingHistoryEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'HISTÓRICO'**
+  String get shoppingHistoryEyebrow;
+
   /// Auth login screen title
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -926,6 +926,34 @@ class SEn extends S {
   }
 
   @override
+  String get shoppingFinalizing => 'FINALIZING';
+
+  @override
+  String get shoppingListEyebrow => 'LIST';
+
+  @override
+  String shoppingHeroItemCount(int count) {
+    return '$count to buy';
+  }
+
+  @override
+  String get shoppingSummaryEyebrow => 'SUMMARY';
+
+  @override
+  String shoppingCheckedCountLabel(int count) {
+    return '$count ✓';
+  }
+
+  @override
+  String get shoppingToBuyEyebrow => 'TO BUY';
+
+  @override
+  String get shoppingInBasketEyebrow => 'IN BASKET';
+
+  @override
+  String get shoppingHistoryEyebrow => 'HISTORY';
+
+  @override
   String get authLogin => 'Sign in';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -933,6 +933,34 @@ class SEs extends S {
   }
 
   @override
+  String get shoppingFinalizing => 'FINALIZANDO';
+
+  @override
+  String get shoppingListEyebrow => 'LISTA';
+
+  @override
+  String shoppingHeroItemCount(int count) {
+    return '$count por comprar';
+  }
+
+  @override
+  String get shoppingSummaryEyebrow => 'RESUMEN';
+
+  @override
+  String shoppingCheckedCountLabel(int count) {
+    return '$count ✓';
+  }
+
+  @override
+  String get shoppingToBuyEyebrow => 'POR COMPRAR';
+
+  @override
+  String get shoppingInBasketEyebrow => 'EN EL CARRO';
+
+  @override
+  String get shoppingHistoryEyebrow => 'HISTORIAL';
+
+  @override
   String get authLogin => 'Iniciar sesión';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -936,6 +936,34 @@ class SFr extends S {
   }
 
   @override
+  String get shoppingFinalizing => 'EN COURS';
+
+  @override
+  String get shoppingListEyebrow => 'LISTE';
+
+  @override
+  String shoppingHeroItemCount(int count) {
+    return '$count à acheter';
+  }
+
+  @override
+  String get shoppingSummaryEyebrow => 'RÉSUMÉ';
+
+  @override
+  String shoppingCheckedCountLabel(int count) {
+    return '$count ✓';
+  }
+
+  @override
+  String get shoppingToBuyEyebrow => 'À ACHETER';
+
+  @override
+  String get shoppingInBasketEyebrow => 'DANS LE PANIER';
+
+  @override
+  String get shoppingHistoryEyebrow => 'HISTORIQUE';
+
+  @override
   String get authLogin => 'Se connecter';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -931,6 +931,34 @@ class SPt extends S {
   }
 
   @override
+  String get shoppingFinalizing => 'A FINALIZAR';
+
+  @override
+  String get shoppingListEyebrow => 'LISTA';
+
+  @override
+  String shoppingHeroItemCount(int count) {
+    return '$count por comprar';
+  }
+
+  @override
+  String get shoppingSummaryEyebrow => 'RESUMO';
+
+  @override
+  String shoppingCheckedCountLabel(int count) {
+    return '$count ✓';
+  }
+
+  @override
+  String get shoppingToBuyEyebrow => 'POR COMPRAR';
+
+  @override
+  String get shoppingInBasketEyebrow => 'NO CESTO';
+
+  @override
+  String get shoppingHistoryEyebrow => 'HISTÓRICO';
+
+  @override
   String get authLogin => 'Entrar na conta';
 
   @override

--- a/monthy_budget_flutter/lib/screens/shopping_list_screen.dart
+++ b/monthy_budget_flutter/lib/screens/shopping_list_screen.dart
@@ -110,7 +110,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              CalmEyebrow('A FINALIZAR'), // TODO(l10n): extract to ARB
+              CalmEyebrow(l10n.shoppingFinalizing),
               const SizedBox(height: 8),
               ConstrainedBox(
                 constraints: const BoxConstraints(maxHeight: 200),
@@ -285,10 +285,9 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
     final heroBlock = Padding(
       padding: const EdgeInsets.only(top: 20, bottom: 16),
       child: CalmHero(
-        eyebrow: 'LISTA', // TODO(l10n): extract to ARB
+        eyebrow: l10n.shoppingListEyebrow,
         amount: formatCurrency(uncheckedTotal),
-        subtitle:
-            '${uncheckedItems.length} por comprar', // TODO(l10n): extract to ARB
+        subtitle: l10n.shoppingHeroItemCount(uncheckedItems.length),
       ),
     );
 
@@ -301,7 +300,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                CalmEyebrow('RESUMO'), // TODO(l10n): extract to ARB
+                CalmEyebrow(l10n.shoppingSummaryEyebrow),
                 const SizedBox(height: 4),
                 Text(
                   l10n.shoppingItemsRemaining(
@@ -320,7 +319,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
           const SizedBox(width: 8),
           // Status pill: shows how many items checked
           CalmPill(
-            label: '${checkedItems.length} ✓', // TODO(l10n): extract to ARB
+            label: l10n.shoppingCheckedCountLabel(checkedItems.length),
             color: hasChecked
                 ? AppColors.ok(context)
                 : AppColors.ink50(context),
@@ -558,7 +557,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
           padding: const EdgeInsets.fromLTRB(0, 8, 0, 80),
           children: [
             if (unchecked.isNotEmpty) ...[
-              CalmEyebrow('POR COMPRAR'), // TODO(l10n): extract to ARB
+              CalmEyebrow(l10n.shoppingToBuyEyebrow),
               const SizedBox(height: 6),
               ...unchecked.asMap().entries.map(
                 (e) => _buildItemRow(
@@ -570,7 +569,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
             ],
             if (checked.isNotEmpty) ...[
               const SizedBox(height: 8),
-              CalmEyebrow('NO CESTO'), // TODO(l10n): extract to ARB
+              CalmEyebrow(l10n.shoppingInBasketEyebrow),
               const SizedBox(height: 6),
               ...checked.asMap().entries.map(
                 (e) => _buildItemRow(e.value, index: 1000 + e.key),
@@ -632,7 +631,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                CalmEyebrow('HISTÓRICO'), // TODO(l10n): extract to ARB
+                CalmEyebrow(l10n.shoppingHistoryEyebrow),
                 const SizedBox(height: 4),
                 Text(
                   l10n.shoppingHistoryTitle,

--- a/monthy_budget_flutter/test/screens/shopping_list_l10n_1135_test.dart
+++ b/monthy_budget_flutter/test/screens/shopping_list_l10n_1135_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
+
+void main() {
+  group('#1135 shopping_list_screen — l10n keys', () {
+    late S l10n;
+
+    setUpAll(() async {
+      l10n = await S.delegate.load(const Locale('en'));
+    });
+
+    test('shoppingFinalizing is non-empty and not hardcoded PT', () {
+      expect(l10n.shoppingFinalizing, isNotEmpty);
+      expect(l10n.shoppingFinalizing, isNot('A FINALIZAR'));
+    });
+
+    test('shoppingListEyebrow is non-empty and not hardcoded PT', () {
+      expect(l10n.shoppingListEyebrow, isNotEmpty);
+      expect(l10n.shoppingListEyebrow, isNot('LISTA'));
+    });
+
+    test('shoppingHeroItemCount returns a string containing the count', () {
+      final result = l10n.shoppingHeroItemCount(3);
+      expect(result, isNotEmpty);
+      expect(result, contains('3'));
+    });
+
+    test('shoppingSummaryEyebrow is non-empty and not hardcoded PT', () {
+      expect(l10n.shoppingSummaryEyebrow, isNotEmpty);
+      expect(l10n.shoppingSummaryEyebrow, isNot('RESUMO'));
+    });
+
+    test('shoppingCheckedCountLabel returns a string containing the count', () {
+      final result = l10n.shoppingCheckedCountLabel(2);
+      expect(result, isNotEmpty);
+      expect(result, contains('2'));
+    });
+
+    test('shoppingToBuyEyebrow is non-empty and not hardcoded PT', () {
+      expect(l10n.shoppingToBuyEyebrow, isNotEmpty);
+      expect(l10n.shoppingToBuyEyebrow, isNot('POR COMPRAR'));
+    });
+
+    test('shoppingInBasketEyebrow is non-empty and not hardcoded PT', () {
+      expect(l10n.shoppingInBasketEyebrow, isNotEmpty);
+      expect(l10n.shoppingInBasketEyebrow, isNot('NO CESTO'));
+    });
+
+    test('shoppingHistoryEyebrow is non-empty and not hardcoded PT', () {
+      expect(l10n.shoppingHistoryEyebrow, isNotEmpty);
+      expect(l10n.shoppingHistoryEyebrow, isNot('HISTÓRICO'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1135

## Summary

Moves 8 hardcoded Portuguese strings in `shopping_list_screen.dart` to ARB localization keys, giving them proper EN/PT/ES/FR translations.

**Strings replaced:**

| Old | New key | EN |
|-----|---------|-----|
| `'A FINALIZAR'` | `shoppingFinalizing` | `FINALIZING` |
| `'LISTA'` | `shoppingListEyebrow` | `LIST` |
| `'${uncheckedItems.length} por comprar'` | `shoppingHeroItemCount(count)` | `{count} to buy` |
| `'RESUMO'` | `shoppingSummaryEyebrow` | `SUMMARY` |
| `'${checkedItems.length} ✓'` | `shoppingCheckedCountLabel(count)` | `{count} ✓` |
| `'POR COMPRAR'` | `shoppingToBuyEyebrow` | `TO BUY` |
| `'NO CESTO'` | `shoppingInBasketEyebrow` | `IN BASKET` |
| `'HISTÓRICO'` | `shoppingHistoryEyebrow` | `HISTORY` |

## Files changed

- `lib/l10n/app_en.arb`, `app_pt.arb`, `app_es.arb`, `app_fr.arb` — 8 new keys added
- `lib/l10n/generated/` — regenerated via `flutter gen-l10n`
- `lib/screens/shopping_list_screen.dart` — all 8 hardcoded strings replaced with `l10n.*`
- `test/screens/shopping_list_l10n_1135_test.dart` — 8 new TDD tests (written before implementation, all green)

## Release Notes

Shopping list labels (LISTA, RESUMO, HISTÓRICO, POR COMPRAR, NO CESTO, A FINALIZAR) are now properly translated in all supported locales instead of always showing Portuguese.