### PR TITLE
fix(l10n): move hardcoded strings in confidence_center_screen to ARB

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -2150,6 +2150,20 @@
     "confidenceRecommendedActions": "Recommended Actions",
     "confidenceCenterSubtitle": "Data freshness and system health",
     "confidenceCenterTile": "Confidence Center",
+    "alertSeverityCritical": "critical",
+    "@alertSeverityCritical": {},
+    "alertSeverityWarning": "warning",
+    "@alertSeverityWarning": {},
+    "alertSeverityInfo": "info",
+    "@alertSeverityInfo": {},
+    "criticalAlertBannerMessage": "{count, plural, =1{1 critical alert — tap to view} other{{count} critical alerts — tap to view}}",
+    "@criticalAlertBannerMessage": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "pantryPickerTitle": "Pantry Picker",
     "pantrySearchHint": "Search ingredients...",
     "pantryTabAlwaysHave": "Always Have",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -2092,6 +2092,20 @@
     "confidenceRecommendedActions": "Acciones Recomendadas",
     "confidenceCenterSubtitle": "Frescura de datos y salud del sistema",
     "confidenceCenterTile": "Centro de Confianza",
+    "alertSeverityCritical": "crítico",
+    "@alertSeverityCritical": {},
+    "alertSeverityWarning": "aviso",
+    "@alertSeverityWarning": {},
+    "alertSeverityInfo": "info",
+    "@alertSeverityInfo": {},
+    "criticalAlertBannerMessage": "{count, plural, =1{1 alerta crítica — tocar para ver} other{{count} alertas críticas — tocar para ver}}",
+    "@criticalAlertBannerMessage": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "pantryPickerTitle": "Selector de Despensa",
     "pantrySearchHint": "Buscar ingredientes...",
     "pantryTabAlwaysHave": "Siempre Tengo",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -2092,6 +2092,20 @@
     "confidenceRecommendedActions": "Actions Recommandées",
     "confidenceCenterSubtitle": "Fraîcheur des données et santé du système",
     "confidenceCenterTile": "Centre de Confiance",
+    "alertSeverityCritical": "critique",
+    "@alertSeverityCritical": {},
+    "alertSeverityWarning": "avertissement",
+    "@alertSeverityWarning": {},
+    "alertSeverityInfo": "info",
+    "@alertSeverityInfo": {},
+    "criticalAlertBannerMessage": "{count, plural, =1{1 alerte critique — appuyer pour voir} other{{count} alertes critiques — appuyer pour voir}}",
+    "@criticalAlertBannerMessage": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "pantryPickerTitle": "Sélecteur de Garde-Manger",
     "pantrySearchHint": "Rechercher des ingrédients...",
     "pantryTabAlwaysHave": "Toujours en Stock",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -4436,6 +4436,20 @@
     "confidenceRecommendedActions": "Ações Recomendadas",
     "confidenceCenterSubtitle": "Frescura dos dados e saúde do sistema",
     "confidenceCenterTile": "Centro de Confiança",
+    "alertSeverityCritical": "crítico",
+    "@alertSeverityCritical": {},
+    "alertSeverityWarning": "aviso",
+    "@alertSeverityWarning": {},
+    "alertSeverityInfo": "info",
+    "@alertSeverityInfo": {},
+    "criticalAlertBannerMessage": "{count, plural, =1{1 alerta crítico — toque para ver} other{{count} alertas críticos — toque para ver}}",
+    "@criticalAlertBannerMessage": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "pantryPickerTitle": "Selecionar Despensa",
     "pantrySearchHint": "Pesquisar ingredientes...",
     "pantryTabAlwaysHave": "Sempre Tenho",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -7301,6 +7301,30 @@ abstract class S {
   /// **'Centro de Confiança'**
   String get confidenceCenterTile;
 
+  /// No description provided for @alertSeverityCritical.
+  ///
+  /// In pt, this message translates to:
+  /// **'crítico'**
+  String get alertSeverityCritical;
+
+  /// No description provided for @alertSeverityWarning.
+  ///
+  /// In pt, this message translates to:
+  /// **'aviso'**
+  String get alertSeverityWarning;
+
+  /// No description provided for @alertSeverityInfo.
+  ///
+  /// In pt, this message translates to:
+  /// **'info'**
+  String get alertSeverityInfo;
+
+  /// No description provided for @criticalAlertBannerMessage.
+  ///
+  /// In pt, this message translates to:
+  /// **'{count, plural, =1{1 alerta crítico — toque para ver} other{{count} alertas críticos — toque para ver}}'**
+  String criticalAlertBannerMessage(int count);
+
   /// No description provided for @pantryPickerTitle.
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -4009,6 +4009,26 @@ class SEn extends S {
   String get confidenceCenterTile => 'Confidence Center';
 
   @override
+  String get alertSeverityCritical => 'critical';
+
+  @override
+  String get alertSeverityWarning => 'warning';
+
+  @override
+  String get alertSeverityInfo => 'info';
+
+  @override
+  String criticalAlertBannerMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count critical alerts — tap to view',
+      one: '1 critical alert — tap to view',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get pantryPickerTitle => 'Pantry Picker';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -4044,6 +4044,26 @@ class SEs extends S {
   String get confidenceCenterTile => 'Centro de Confianza';
 
   @override
+  String get alertSeverityCritical => 'crítico';
+
+  @override
+  String get alertSeverityWarning => 'aviso';
+
+  @override
+  String get alertSeverityInfo => 'info';
+
+  @override
+  String criticalAlertBannerMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count alertas críticas — tocar para ver',
+      one: '1 alerta crítica — tocar para ver',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get pantryPickerTitle => 'Selector de Despensa';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -4053,6 +4053,26 @@ class SFr extends S {
   String get confidenceCenterTile => 'Centre de Confiance';
 
   @override
+  String get alertSeverityCritical => 'critique';
+
+  @override
+  String get alertSeverityWarning => 'avertissement';
+
+  @override
+  String get alertSeverityInfo => 'info';
+
+  @override
+  String criticalAlertBannerMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count alertes critiques — appuyer pour voir',
+      one: '1 alerte critique — appuyer pour voir',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get pantryPickerTitle => 'Sélecteur de Garde-Manger';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -4040,6 +4040,26 @@ class SPt extends S {
   String get confidenceCenterTile => 'Centro de Confiança';
 
   @override
+  String get alertSeverityCritical => 'crítico';
+
+  @override
+  String get alertSeverityWarning => 'aviso';
+
+  @override
+  String get alertSeverityInfo => 'info';
+
+  @override
+  String criticalAlertBannerMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count alertas críticos — toque para ver',
+      one: '1 alerta crítico — toque para ver',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get pantryPickerTitle => 'Selecionar Despensa';
 
   @override

--- a/monthy_budget_flutter/lib/screens/confidence_center_screen.dart
+++ b/monthy_budget_flutter/lib/screens/confidence_center_screen.dart
@@ -130,10 +130,11 @@ class _AlertCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = S.of(context);
     final (Color leadColor, String severityLabel) = switch (alert.severity) {
-      AlertSeverity.critical => (AppColors.bad(context), 'crítico'), // TODO(l10n):
-      AlertSeverity.warning => (AppColors.warn(context), 'aviso'), // TODO(l10n):
-      AlertSeverity.info => (AppColors.accent(context), 'info'), // TODO(l10n):
+      AlertSeverity.critical => (AppColors.bad(context), l10n.alertSeverityCritical),
+      AlertSeverity.warning => (AppColors.warn(context), l10n.alertSeverityWarning),
+      AlertSeverity.info => (AppColors.accent(context), l10n.alertSeverityInfo),
     };
 
     final icon = switch (alert.severity) {
@@ -169,6 +170,7 @@ class CriticalAlertBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (criticalCount <= 0) return const SizedBox.shrink();
+    final l10n = S.of(context);
     return GestureDetector(
       onTap: onTap,
       child: Container(
@@ -181,7 +183,7 @@ class CriticalAlertBanner extends StatelessWidget {
             const SizedBox(width: 8),
             Expanded(
               child: Text(
-                '$criticalCount critical alert${criticalCount == 1 ? '' : 's'} — tap to view', // TODO(l10n):
+                l10n.criticalAlertBannerMessage(criticalCount),
                 style: TextStyle(
                   color: AppColors.bg(context),
                   fontWeight: FontWeight.w600,

--- a/monthy_budget_flutter/test/screens/confidence_center_l10n_1143_test.dart
+++ b/monthy_budget_flutter/test/screens/confidence_center_l10n_1143_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
+
+void main() {
+  group('#1143 confidence_center_screen — l10n keys', () {
+    late S l10n;
+
+    setUpAll(() async {
+      l10n = await S.delegate.load(const Locale('en'));
+    });
+
+    test('alertSeverityCritical non-empty, not hardcoded PT', () {
+      expect(l10n.alertSeverityCritical, isNotEmpty);
+      expect(l10n.alertSeverityCritical, isNot('crítico'));
+    });
+
+    test('alertSeverityWarning non-empty, not hardcoded PT', () {
+      expect(l10n.alertSeverityWarning, isNotEmpty);
+      expect(l10n.alertSeverityWarning, isNot('aviso'));
+    });
+
+    test('alertSeverityInfo non-empty', () {
+      expect(l10n.alertSeverityInfo, isNotEmpty);
+    });
+
+    test('criticalAlertBannerMessage singular contains count', () {
+      final result = l10n.criticalAlertBannerMessage(1);
+      expect(result, isNotEmpty);
+      expect(result, contains('1'));
+    });
+
+    test('criticalAlertBannerMessage plural contains count', () {
+      final result = l10n.criticalAlertBannerMessage(3);
+      expect(result, isNotEmpty);
+      expect(result, contains('3'));
+    });
+
+    test('criticalAlertBannerMessage singular and plural differ', () {
+      expect(
+        l10n.criticalAlertBannerMessage(1),
+        isNot(l10n.criticalAlertBannerMessage(3)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1143

## Summary

Moves 4 hardcoded strings in `confidence_center_screen.dart` to ARB — 3 severity labels and a critical-alert banner with proper ICU pluralization (replacing the inline Dart ternary).

**Keys added:** `alertSeverityCritical`, `alertSeverityWarning`, `alertSeverityInfo`, `criticalAlertBannerMessage` (ICU plural `{count}`).

## Files changed

- `lib/l10n/app_en.arb`, `app_pt.arb`, `app_es.arb`, `app_fr.arb` — 4 new keys
- `lib/l10n/generated/` — regenerated via `flutter gen-l10n`
- `lib/screens/confidence_center_screen.dart` — severity labels + banner message replaced with `l10n.*`; added `l10n = S.of(context)` in both widget build methods
- `test/screens/confidence_center_l10n_1143_test.dart` — 6 TDD tests (singular/plural behaviour verified, all green)

## Release Notes

Alert severity labels (critical/warning/info) and the critical-alert dashboard banner are now properly translated in all supported locales; plural handling is now correct via ICU instead of a Dart ternary.