### PR TITLE
fix(l10n): move hardcoded PT strings in setup_wizard_screen to ARB

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -1220,6 +1220,20 @@
     "setupWizardReassurance": "You can change everything later in settings.",
     "setupWizardStart": "Get started",
     "setupWizardSkipAll": "Skip setup",
+    "setupWizardBack": "Back",
+    "@setupWizardBack": {},
+    "setupWizardStepEyebrow": "STEP {step} · 3",
+    "@setupWizardStepEyebrow": {
+        "placeholders": {
+            "step": {
+                "type": "int"
+            }
+        }
+    },
+    "setupWizardIncomeEyebrow": "INCOME",
+    "@setupWizardIncomeEyebrow": {},
+    "setupWizardExpensesEyebrow": "MONTHLY EXPENSES",
+    "@setupWizardExpensesEyebrow": {},
     "setupWizardStepOf": "Step {step} of {total}",
     "@setupWizardStepOf": {
         "placeholders": {

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -1178,6 +1178,20 @@
     "setupWizardReassurance": "Puedes cambiarlo todo más tarde en ajustes.",
     "setupWizardStart": "Empezar",
     "setupWizardSkipAll": "Saltar configuración",
+    "setupWizardBack": "Anterior",
+    "@setupWizardBack": {},
+    "setupWizardStepEyebrow": "PASO {step} · 3",
+    "@setupWizardStepEyebrow": {
+        "placeholders": {
+            "step": {
+                "type": "int"
+            }
+        }
+    },
+    "setupWizardIncomeEyebrow": "INGRESOS",
+    "@setupWizardIncomeEyebrow": {},
+    "setupWizardExpensesEyebrow": "GASTOS MENSUALES",
+    "@setupWizardExpensesEyebrow": {},
     "setupWizardStepOf": "Paso {step} de {total}",
     "@setupWizardStepOf": {
         "placeholders": {

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -1178,6 +1178,20 @@
     "setupWizardReassurance": "Vous pouvez tout modifier plus tard dans les paramètres.",
     "setupWizardStart": "Commencer",
     "setupWizardSkipAll": "Passer la configuration",
+    "setupWizardBack": "Précédent",
+    "@setupWizardBack": {},
+    "setupWizardStepEyebrow": "ÉTAPE {step} · 3",
+    "@setupWizardStepEyebrow": {
+        "placeholders": {
+            "step": {
+                "type": "int"
+            }
+        }
+    },
+    "setupWizardIncomeEyebrow": "REVENUS",
+    "@setupWizardIncomeEyebrow": {},
+    "setupWizardExpensesEyebrow": "DÉPENSES MENSUELLES",
+    "@setupWizardExpensesEyebrow": {},
     "setupWizardStepOf": "Étape {step} sur {total}",
     "@setupWizardStepOf": {
         "placeholders": {

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -2801,6 +2801,20 @@
     "@setupWizardSkipAll": {
         "description": "Skip all button on welcome screen"
     },
+    "setupWizardBack": "Anterior",
+    "@setupWizardBack": {},
+    "setupWizardStepEyebrow": "PASSO {step} · 3",
+    "@setupWizardStepEyebrow": {
+        "placeholders": {
+            "step": {
+                "type": "int"
+            }
+        }
+    },
+    "setupWizardIncomeEyebrow": "RENDIMENTO",
+    "@setupWizardIncomeEyebrow": {},
+    "setupWizardExpensesEyebrow": "DESPESAS MENSAIS",
+    "@setupWizardExpensesEyebrow": {},
     "setupWizardStepOf": "Passo {step} de {total}",
     "@setupWizardStepOf": {
         "description": "Step progress indicator",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -4091,6 +4091,30 @@ abstract class S {
   /// **'Saltar configuração'**
   String get setupWizardSkipAll;
 
+  /// No description provided for @setupWizardBack.
+  ///
+  /// In pt, this message translates to:
+  /// **'Anterior'**
+  String get setupWizardBack;
+
+  /// No description provided for @setupWizardStepEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'PASSO {step} · 3'**
+  String setupWizardStepEyebrow(int step);
+
+  /// No description provided for @setupWizardIncomeEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'RENDIMENTO'**
+  String get setupWizardIncomeEyebrow;
+
+  /// No description provided for @setupWizardExpensesEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'DESPESAS MENSAIS'**
+  String get setupWizardExpensesEyebrow;
+
   /// Step progress indicator
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -2199,6 +2199,20 @@ class SEn extends S {
   String get setupWizardSkipAll => 'Skip setup';
 
   @override
+  String get setupWizardBack => 'Back';
+
+  @override
+  String setupWizardStepEyebrow(int step) {
+    return 'STEP $step · 3';
+  }
+
+  @override
+  String get setupWizardIncomeEyebrow => 'INCOME';
+
+  @override
+  String get setupWizardExpensesEyebrow => 'MONTHLY EXPENSES';
+
+  @override
   String setupWizardStepOf(int step, int total) {
     return 'Step $step of $total';
   }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -2210,6 +2210,20 @@ class SEs extends S {
   String get setupWizardSkipAll => 'Saltar configuración';
 
   @override
+  String get setupWizardBack => 'Anterior';
+
+  @override
+  String setupWizardStepEyebrow(int step) {
+    return 'PASO $step · 3';
+  }
+
+  @override
+  String get setupWizardIncomeEyebrow => 'INGRESOS';
+
+  @override
+  String get setupWizardExpensesEyebrow => 'GASTOS MENSUALES';
+
+  @override
   String setupWizardStepOf(int step, int total) {
     return 'Paso $step de $total';
   }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -2215,6 +2215,20 @@ class SFr extends S {
   String get setupWizardSkipAll => 'Passer la configuration';
 
   @override
+  String get setupWizardBack => 'Précédent';
+
+  @override
+  String setupWizardStepEyebrow(int step) {
+    return 'ÉTAPE $step · 3';
+  }
+
+  @override
+  String get setupWizardIncomeEyebrow => 'REVENUS';
+
+  @override
+  String get setupWizardExpensesEyebrow => 'DÉPENSES MENSUELLES';
+
+  @override
   String setupWizardStepOf(int step, int total) {
     return 'Étape $step sur $total';
   }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -2207,6 +2207,20 @@ class SPt extends S {
   String get setupWizardSkipAll => 'Saltar configuração';
 
   @override
+  String get setupWizardBack => 'Anterior';
+
+  @override
+  String setupWizardStepEyebrow(int step) {
+    return 'PASSO $step · 3';
+  }
+
+  @override
+  String get setupWizardIncomeEyebrow => 'RENDIMENTO';
+
+  @override
+  String get setupWizardExpensesEyebrow => 'DESPESAS MENSAIS';
+
+  @override
   String setupWizardStepOf(int step, int total) {
     return 'Passo $step de $total';
   }

--- a/monthy_budget_flutter/lib/screens/setup_wizard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/setup_wizard_screen.dart
@@ -64,7 +64,7 @@ class _WizardBottomRow extends StatelessWidget {
                         borderRadius: BorderRadius.circular(14),
                       ),
                     ),
-                    child: const Text('Anterior'), // TODO(l10n):
+                    child: Text(S.of(context).setupWizardBack),
                   ),
                 ),
               ),
@@ -396,7 +396,7 @@ class _WelcomeAndCountryStep extends StatelessWidget {
         // Progress bar: step 0 of 2
         _WizardProgress(current: 0, total: 2),
         CalmPageHeader(
-          eyebrow: 'PASSO 1 · 3', // TODO(l10n):
+          eyebrow: l10n.setupWizardStepEyebrow(1),
           title: l10n.setupWizardWelcomeTitle,
           showBack: false,
         ),
@@ -555,7 +555,7 @@ class _SalaryAndExpensesStep extends StatelessWidget {
           // Progress bar: step 1 of 2
           _WizardProgress(current: 1, total: 2),
           CalmPageHeader(
-            eyebrow: 'PASSO 2 · 3', // TODO(l10n):
+            eyebrow: l10n.setupWizardStepEyebrow(2),
             title: l10n.setupWizardSalaryTitle,
             showBack: false,
           ),
@@ -568,7 +568,7 @@ class _SalaryAndExpensesStep extends StatelessWidget {
                         fontSize: 14, color: AppColors.ink70(context))),
                 const SizedBox(height: 16),
                 // ── Salary card ──────────────────────────────────────
-                CalmEyebrow('RENDIMENTO'), // TODO(l10n):
+                CalmEyebrow(l10n.setupWizardIncomeEyebrow),
                 const SizedBox(height: 8),
                 CalmCard(
                   padding: const EdgeInsets.all(16),
@@ -599,7 +599,7 @@ class _SalaryAndExpensesStep extends StatelessWidget {
                 ),
                 const SizedBox(height: 20),
                 // ── Expenses card ────────────────────────────────────
-                CalmEyebrow('DESPESAS MENSAIS'), // TODO(l10n):
+                CalmEyebrow(l10n.setupWizardExpensesEyebrow),
                 const SizedBox(height: 8),
                 CalmCard(
                   padding: const EdgeInsets.all(16),
@@ -756,7 +756,7 @@ class _CompletionStepState extends State<_CompletionStep>
         // Progress bar: step 2 of 2 (complete)
         _WizardProgress(current: 2, total: 2),
         CalmPageHeader(
-          eyebrow: 'PASSO 3 · 3', // TODO(l10n):
+          eyebrow: l10n.setupWizardStepEyebrow(3),
           title: l10n.setupWizardCompleteTitle,
           showBack: false,
         ),

--- a/monthy_budget_flutter/test/screens/setup_wizard_l10n_1145_test.dart
+++ b/monthy_budget_flutter/test/screens/setup_wizard_l10n_1145_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
+
+void main() {
+  group('#1145 setup_wizard_screen — l10n keys', () {
+    late S l10n;
+
+    setUpAll(() async {
+      l10n = await S.delegate.load(const Locale('en'));
+    });
+
+    test('setupWizardBack non-empty, not hardcoded PT', () {
+      expect(l10n.setupWizardBack, isNotEmpty);
+      expect(l10n.setupWizardBack, isNot('Anterior'));
+    });
+
+    test('setupWizardStepEyebrow contains step number', () {
+      expect(l10n.setupWizardStepEyebrow(1), contains('1'));
+      expect(l10n.setupWizardStepEyebrow(2), contains('2'));
+      expect(l10n.setupWizardStepEyebrow(3), contains('3'));
+    });
+
+    test('setupWizardStepEyebrow not hardcoded PT prefix', () {
+      expect(l10n.setupWizardStepEyebrow(1), isNot(startsWith('PASSO')));
+    });
+
+    test('setupWizardIncomeEyebrow non-empty, not hardcoded PT', () {
+      expect(l10n.setupWizardIncomeEyebrow, isNotEmpty);
+      expect(l10n.setupWizardIncomeEyebrow, isNot('RENDIMENTO'));
+    });
+
+    test('setupWizardExpensesEyebrow non-empty, not hardcoded PT', () {
+      expect(l10n.setupWizardExpensesEyebrow, isNotEmpty);
+      expect(l10n.setupWizardExpensesEyebrow, isNot('DESPESAS MENSAIS'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Fixes #1145

## Summary

Moves 6 hardcoded Portuguese strings in `setup_wizard_screen.dart` to ARB. Three step-progress eyebrows (`PASSO 1 · 3`, `PASSO 2 · 3`, `PASSO 3 · 3`) share a single parameterised key instead of 3 separate static keys.

**Keys added (×4):** `setupWizardBack`, `setupWizardStepEyebrow({step}: int)`, `setupWizardIncomeEyebrow`, `setupWizardExpensesEyebrow`.

## Files changed

- `lib/l10n/app_en.arb`, `app_pt.arb`, `app_es.arb`, `app_fr.arb` — 4 new keys
- `lib/l10n/generated/` — regenerated via `flutter gen-l10n`
- `lib/screens/setup_wizard_screen.dart` — 6 hardcoded strings replaced; back button uses `S.of(context)` inline (widget has no local `l10n` var); step eyebrows use `l10n.setupWizardStepEyebrow(1/2/3)`
- `test/screens/setup_wizard_l10n_1145_test.dart` — 5 TDD tests (all green)

## Release Notes

Setup wizard step labels (PASSO 1/2/3), section headers (RENDIMENTO, DESPESAS MENSAIS) and the Back button are now properly translated in all supported locales.