### PR TITLE
fix(l10n): extract SUGESTÕES eyebrow in coach_screen to ARB

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -312,6 +312,10 @@
     "@coachEmptyBody": {
         "description": "Empty state body in coach chat"
     },
+    "coachSuggestionsEyebrow": "Suggestions",
+    "@coachSuggestionsEyebrow": {
+        "description": "Eyebrow label above quick-prompt suggestion chips in coach screen"
+    },
     "coachQuickPrompt1": "Where can I cut expenses this month?",
     "@coachQuickPrompt1": {
         "description": "Quick prompt suggestion 1"

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -306,6 +306,7 @@
     "coachDeleteTooltip": "Eliminar",
     "coachEmptyTitle": "Tu coach financiero",
     "coachEmptyBody": "Pregunta lo que quieras sobre tu presupuesto, gastos o ahorros. Usare tus datos reales para darte consejos personalizados.",
+    "coachSuggestionsEyebrow": "Sugerencias",
     "coachQuickPrompt1": "Donde puedo recortar gastos este mes?",
     "coachQuickPrompt2": "Como puedo mejorar mi ahorro?",
     "coachQuickPrompt3": "Ayudame a crear un plan de 30 dias.",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -306,6 +306,7 @@
     "coachDeleteTooltip": "Supprimer",
     "coachEmptyTitle": "Votre coach financier",
     "coachEmptyBody": "Posez toute question sur votre budget, depenses ou epargne. J'utiliserai vos donnees reelles pour des conseils personnalises.",
+    "coachSuggestionsEyebrow": "Suggestions",
     "coachQuickPrompt1": "Ou puis-je reduire mes depenses ce mois-ci ?",
     "coachQuickPrompt2": "Comment ameliorer mon epargne ?",
     "coachQuickPrompt3": "Aidez-moi a creer un plan sur 30 jours.",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -791,6 +791,10 @@
     "@coachEmptyBody": {
         "description": "Empty state body in coach chat"
     },
+    "coachSuggestionsEyebrow": "Sugestões",
+    "@coachSuggestionsEyebrow": {
+        "description": "Eyebrow label above quick-prompt suggestion chips in coach screen"
+    },
     "coachQuickPrompt1": "Onde posso cortar despesas este mes?",
     "@coachQuickPrompt1": {
         "description": "Quick prompt suggestion 1"

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -1151,6 +1151,12 @@ abstract class S {
   /// **'Pergunta o que quiseres sobre o teu orcamento, despesas ou poupancas. Vou usar os teus dados reais para dar conselhos personalizados.'**
   String get coachEmptyBody;
 
+  /// Eyebrow label above quick-prompt suggestion chips in coach screen
+  ///
+  /// In pt, this message translates to:
+  /// **'Sugestões'**
+  String get coachSuggestionsEyebrow;
+
   /// Quick prompt suggestion 1
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -581,6 +581,9 @@ class SEn extends S {
       'Ask anything about your budget, expenses, or savings. I\'ll use your real data to give personalized advice.';
 
   @override
+  String get coachSuggestionsEyebrow => 'Suggestions';
+
+  @override
   String get coachQuickPrompt1 => 'Where can I cut expenses this month?';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -583,6 +583,9 @@ class SEs extends S {
       'Pregunta lo que quieras sobre tu presupuesto, gastos o ahorros. Usare tus datos reales para darte consejos personalizados.';
 
   @override
+  String get coachSuggestionsEyebrow => 'Sugerencias';
+
+  @override
   String get coachQuickPrompt1 => 'Donde puedo recortar gastos este mes?';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -584,6 +584,9 @@ class SFr extends S {
       'Posez toute question sur votre budget, depenses ou epargne. J\'utiliserai vos donnees reelles pour des conseils personnalises.';
 
   @override
+  String get coachSuggestionsEyebrow => 'Suggestions';
+
+  @override
   String get coachQuickPrompt1 =>
       'Ou puis-je reduire mes depenses ce mois-ci ?';
 

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -583,6 +583,9 @@ class SPt extends S {
       'Pergunta o que quiseres sobre o teu orcamento, despesas ou poupancas. Vou usar os teus dados reais para dar conselhos personalizados.';
 
   @override
+  String get coachSuggestionsEyebrow => 'Sugestões';
+
+  @override
   String get coachQuickPrompt1 => 'Onde posso cortar despesas este mes?';
 
   @override

--- a/monthy_budget_flutter/lib/screens/coach_screen.dart
+++ b/monthy_budget_flutter/lib/screens/coach_screen.dart
@@ -1047,8 +1047,7 @@ class _CoachScreenState extends State<CoachScreen> with WidgetsBindingObserver {
                 body: l10n.coachEmptyBody,
               ),
               const SizedBox(height: 20),
-              // TODO(l10n): extract "Sugestões" eyebrow.
-              const CalmEyebrow('SUGESTÕES'),
+              CalmEyebrow(l10n.coachSuggestionsEyebrow),
               const SizedBox(height: 8),
               // Suggestion chips — Calm action pills, scroll horizontal.
               SizedBox(

--- a/monthy_budget_flutter/test/screens/coach_l10n_1147_test.dart
+++ b/monthy_budget_flutter/test/screens/coach_l10n_1147_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
+
+void main() {
+  late S l10n;
+
+  setUpAll(() async {
+    l10n = await S.delegate.load(const Locale('en'));
+  });
+
+  group('coach_screen l10n #1147', () {
+    test('coachSuggestionsEyebrow exists and is not hardcoded PT', () {
+      final value = l10n.coachSuggestionsEyebrow;
+      expect(value, isNotEmpty);
+      expect(value.toUpperCase(), isNot(equals('SUGESTÕES')));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1147

## Changes
- Added `coachSuggestionsEyebrow` ARB key to all 4 locale files (EN/PT/ES/FR)
- Replaced `const CalmEyebrow('SUGESTÕES')` with `CalmEyebrow(l10n.coachSuggestionsEyebrow)` in `coach_screen.dart`
- Added TDD test `test/screens/coach_l10n_1147_test.dart`

## Release Notes
Localize the suggestions section eyebrow in the financial coach screen; the label now adapts to the user's language instead of always showing in Portuguese.