### PR TITLE
fix(l10n): extract grocery_screen hardcoded PT strings to ARB

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -437,6 +437,17 @@
     "cmdCapabilityClearChecked": "Clear checked items",
     "cmdCapabilityClearCheckedExample": "Clear checked items",
     "groceryTitle": "Grocery",
+    "groceryPantryTitle": "Pantry",
+    "@groceryPantryTitle": {
+        "description": "Page header title for the pantry/grocery screen"
+    },
+    "groceryItemCountEyebrow": "{count} items",
+    "@groceryItemCountEyebrow": {
+        "description": "Eyebrow showing total item count in the pantry screen",
+        "placeholders": {
+            "count": { "type": "int" }
+        }
+    },
     "grocerySearchHint": "Search product...",
     "groceryLoadingLabel": "Loading products",
     "groceryLoadingMessage": "Loading products...",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -392,6 +392,8 @@
     "cmdCapabilityClearChecked": "Limpiar marcados",
     "cmdCapabilityClearCheckedExample": "Limpiar elementos marcados",
     "groceryTitle": "Supermercado",
+    "groceryPantryTitle": "Despensa",
+    "groceryItemCountEyebrow": "{count} artículos",
     "grocerySearchHint": "Buscar producto...",
     "groceryLoadingLabel": "Cargando productos",
     "groceryLoadingMessage": "Cargando productos...",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -392,6 +392,8 @@
     "cmdCapabilityClearChecked": "Vider les coches",
     "cmdCapabilityClearCheckedExample": "Effacer les elements coches",
     "groceryTitle": "Courses",
+    "groceryPantryTitle": "Garde-manger",
+    "groceryItemCountEyebrow": "{count} articles",
     "grocerySearchHint": "Rechercher un produit...",
     "groceryLoadingLabel": "Chargement des produits",
     "groceryLoadingMessage": "Chargement des produits...",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -919,6 +919,17 @@
     "@groceryTitle": {
         "description": "Grocery screen title"
     },
+    "groceryPantryTitle": "Despensa",
+    "@groceryPantryTitle": {
+        "description": "Page header title for the pantry/grocery screen"
+    },
+    "groceryItemCountEyebrow": "{count} itens",
+    "@groceryItemCountEyebrow": {
+        "description": "Eyebrow showing total item count in the pantry screen",
+        "placeholders": {
+            "count": { "type": "int" }
+        }
+    },
     "grocerySearchHint": "Pesquisar produto...",
     "@grocerySearchHint": {
         "description": "Grocery search field hint"

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -1523,6 +1523,18 @@ abstract class S {
   /// **'Supermercado'**
   String get groceryTitle;
 
+  /// Page header title for the pantry/grocery screen
+  ///
+  /// In pt, this message translates to:
+  /// **'Despensa'**
+  String get groceryPantryTitle;
+
+  /// Eyebrow showing total item count in the pantry screen
+  ///
+  /// In pt, this message translates to:
+  /// **'{count} itens'**
+  String groceryItemCountEyebrow(int count);
+
   /// Grocery search field hint
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -788,6 +788,14 @@ class SEn extends S {
   String get groceryTitle => 'Grocery';
 
   @override
+  String get groceryPantryTitle => 'Pantry';
+
+  @override
+  String groceryItemCountEyebrow(int count) {
+    return '$count items';
+  }
+
+  @override
   String get grocerySearchHint => 'Search product...';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -792,6 +792,14 @@ class SEs extends S {
   String get groceryTitle => 'Supermercado';
 
   @override
+  String get groceryPantryTitle => 'Despensa';
+
+  @override
+  String groceryItemCountEyebrow(int count) {
+    return '$count artículos';
+  }
+
+  @override
   String get grocerySearchHint => 'Buscar producto...';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -796,6 +796,14 @@ class SFr extends S {
   String get groceryTitle => 'Courses';
 
   @override
+  String get groceryPantryTitle => 'Garde-manger';
+
+  @override
+  String groceryItemCountEyebrow(int count) {
+    return '$count articles';
+  }
+
+  @override
   String get grocerySearchHint => 'Rechercher un produit...';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -791,6 +791,14 @@ class SPt extends S {
   String get groceryTitle => 'Supermercado';
 
   @override
+  String get groceryPantryTitle => 'Despensa';
+
+  @override
+  String groceryItemCountEyebrow(int count) {
+    return '$count itens';
+  }
+
+  @override
   String get grocerySearchHint => 'Pesquisar produto...';
 
   @override

--- a/monthy_budget_flutter/lib/screens/grocery_screen.dart
+++ b/monthy_budget_flutter/lib/screens/grocery_screen.dart
@@ -221,9 +221,8 @@ class _GroceryScreenState extends State<GroceryScreen> {
     final cats = byCategory.keys.toList()..sort();
 
     // §13 eyebrow: "{total} ITENS · {low} EM FALTA"
-    // TODO(l10n): extract to ARB
     final totalItems = widget.products.length;
-    final eyebrowText = '$totalItems ITENS';
+    final eyebrowText = l10n.groceryItemCountEyebrow(totalItems);
 
     // Search bar: bgSunk radius 14 padding 10/14, search icon ink50 — §13
     final searchBar = Padding(
@@ -258,11 +257,10 @@ class _GroceryScreenState extends State<GroceryScreen> {
       ),
     );
 
-    // §13 header block: CalmPageHeader "Despensa" + scan icon trailing
-    // TODO(l10n): "Despensa" label
+    // §13 header block: CalmPageHeader with scan icon trailing
     final pageHeader = CalmPageHeader(
       eyebrow: eyebrowText,
-      title: 'Despensa',
+      title: l10n.groceryPantryTitle,
       showBack: false,
       trailing: widget.onAddToShoppingList != null
           ? IconButton(
@@ -511,15 +509,13 @@ class _GroceryScreenState extends State<GroceryScreen> {
                   Padding(
                     padding: const EdgeInsets.only(right: 6),
                     child: CalmPill(
-                      label: '${groceryData.partialStoreCount} parcial',
-                      // TODO(l10n): "parcial"
+                      label: l10n.groceryStorePartialCount(groceryData.partialStoreCount),
                       color: AppColors.warn(context),
                     ),
                   ),
                 if (groceryData.failedStoreCount > 0)
                   CalmPill(
-                    label: '${groceryData.failedStoreCount} falhou',
-                    // TODO(l10n): "falhou"
+                    label: l10n.groceryStoreFailedCount(groceryData.failedStoreCount),
                     color: AppColors.bad(context),
                   ),
               ],

--- a/monthy_budget_flutter/test/screens/grocery_l10n_1153_test.dart
+++ b/monthy_budget_flutter/test/screens/grocery_l10n_1153_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
+
+void main() {
+  late S l10n;
+
+  setUpAll(() async {
+    l10n = await S.delegate.load(const Locale('en'));
+  });
+
+  group('grocery_screen l10n #1153', () {
+    test('groceryItemCountEyebrow contains count and is not hardcoded PT', () {
+      final value = l10n.groceryItemCountEyebrow(7);
+      expect(value, contains('7'));
+      expect(value.toUpperCase(), isNot(contains('ITENS')));
+    });
+
+    test('groceryPantryTitle exists and is not hardcoded PT', () {
+      final value = l10n.groceryPantryTitle;
+      expect(value, isNotEmpty);
+      expect(value.toLowerCase(), isNot(equals('despensa')));
+    });
+
+    test('groceryStorePartialCount contains count', () {
+      final value = l10n.groceryStorePartialCount(3);
+      expect(value, contains('3'));
+    });
+
+    test('groceryStoreFailedCount contains count', () {
+      final value = l10n.groceryStoreFailedCount(2);
+      expect(value, contains('2'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1153

## Changes
- Added 2 new ARB keys to all 4 locale files: `groceryPantryTitle`, `groceryItemCountEyebrow(int count)`
- `grocery_screen.dart`: replaced `'$totalItems ITENS'` with `l10n.groceryItemCountEyebrow(totalItems)`, `'Despensa'` with `l10n.groceryPantryTitle`, and wired the already-existing `groceryStorePartialCount`/`groceryStoreFailedCount` keys to the pill labels (replacing `'${n} parcial'` and `'${n} falhou'`)
- Added TDD test `test/screens/grocery_l10n_1153_test.dart` (4 assertions)

## Release Notes
Localize pantry title, item count eyebrow, and store health pill labels in the grocery/pantry screen.