### PR TITLE
fix(l10n): extract recurring_expenses_screen hardcoded PT strings to ARB (#1162)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -1451,6 +1451,38 @@
     "recurringExpenseSaved": "Recurring payment saved",
     "recurringExpenseSaveError": "Couldn't save — try again",
     "recurringExpenseDeleteError": "Couldn't delete — try again",
+    "recurringActivePill": "{count, plural, =1{1 active} other{{count} active}}",
+    "@recurringActivePill": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringTotalMonthlyEyebrow": "MONTHLY TOTAL",
+    "recurringActiveTitle": "Active",
+    "recurringSubscriptionCount": "{count, plural, =1{1 subscription} other{{count} subscriptions}}",
+    "@recurringSubscriptionCount": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringPausedTitle": "Paused",
+    "recurringDayOfMonth": "day {day}",
+    "@recurringDayOfMonth": {
+      "placeholders": {
+        "day": { "type": "int" }
+      }
+    },
+    "recurringEmptyTitle": "No recurring payments",
+    "recurringEmptyBody": "Add one to generate them automatically every month.",
+    "recurringEyebrow": "RECURRING",
+    "recurringHeroSubtitle": "{count, plural, =1{1 active subscription} other{{count} active subscriptions}}",
+    "@recurringHeroSubtitle": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringActiveGroupLabel": "ACTIVE",
+    "recurringPausedGroupLabel": "PAUSED",
     "savingsContributionSaveError": "Couldn't save contribution — try again",
     "coachNoApiKeyTitle": "Set up your coach",
     "coachNoApiKeyBody": "Add an OpenAI key in Settings to start chatting.",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -1345,6 +1345,38 @@
     "recurringExpenseSaved": "Pago recurrente guardado",
     "recurringExpenseSaveError": "No se pudo guardar — intenta de nuevo",
     "recurringExpenseDeleteError": "No se pudo eliminar — intenta de nuevo",
+    "recurringActivePill": "{count, plural, =1{1 activa} other{{count} activas}}",
+    "@recurringActivePill": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringTotalMonthlyEyebrow": "TOTAL MENSUAL",
+    "recurringActiveTitle": "Activas",
+    "recurringSubscriptionCount": "{count, plural, =1{1 suscripcion} other{{count} suscripciones}}",
+    "@recurringSubscriptionCount": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringPausedTitle": "Pausadas",
+    "recurringDayOfMonth": "dia {day}",
+    "@recurringDayOfMonth": {
+      "placeholders": {
+        "day": { "type": "int" }
+      }
+    },
+    "recurringEmptyTitle": "Sin pagos recurrentes",
+    "recurringEmptyBody": "Anade uno para generarlos automaticamente cada mes.",
+    "recurringEyebrow": "RECURRENTES",
+    "recurringHeroSubtitle": "{count, plural, =1{1 suscripcion activa} other{{count} suscripciones activas}}",
+    "@recurringHeroSubtitle": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringActiveGroupLabel": "ACTIVAS",
+    "recurringPausedGroupLabel": "PAUSADAS",
     "savingsContributionSaveError": "No se pudo guardar la contribucion — intenta de nuevo",
     "coachNoApiKeyTitle": "Configura tu coach",
     "coachNoApiKeyBody": "Anade una clave OpenAI en Ajustes para comenzar a chatear.",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -1345,6 +1345,38 @@
     "recurringExpenseSaved": "Paiement récurrent enregistré",
     "recurringExpenseSaveError": "Impossible d'enregistrer — reessaye",
     "recurringExpenseDeleteError": "Impossible de supprimer — reessaye",
+    "recurringActivePill": "{count, plural, =1{1 active} other{{count} actives}}",
+    "@recurringActivePill": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringTotalMonthlyEyebrow": "TOTAL MENSUEL",
+    "recurringActiveTitle": "Actives",
+    "recurringSubscriptionCount": "{count, plural, =1{1 abonnement} other{{count} abonnements}}",
+    "@recurringSubscriptionCount": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringPausedTitle": "En pause",
+    "recurringDayOfMonth": "jour {day}",
+    "@recurringDayOfMonth": {
+      "placeholders": {
+        "day": { "type": "int" }
+      }
+    },
+    "recurringEmptyTitle": "Aucun paiement recurrent",
+    "recurringEmptyBody": "Ajoutes-en un pour le generer automatiquement chaque mois.",
+    "recurringEyebrow": "RECURRENTS",
+    "recurringHeroSubtitle": "{count, plural, =1{1 abonnement actif} other{{count} abonnements actifs}}",
+    "@recurringHeroSubtitle": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringActiveGroupLabel": "ACTIFS",
+    "recurringPausedGroupLabel": "EN PAUSE",
     "savingsContributionSaveError": "Impossible d'enregistrer la contribution — reessaye",
     "coachNoApiKeyTitle": "Configure ton coach",
     "coachNoApiKeyBody": "Ajoute une cle OpenAI dans les Reglages pour commencer a discuter.",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -3280,6 +3280,38 @@
     "recurringExpenseDeleteError": "Não foi possível eliminar — tenta de novo",
     "@recurringExpenseSaveError": { "description": "Error snack when saving a recurring expense fails" },
     "@recurringExpenseDeleteError": { "description": "Error snack when deleting a recurring expense fails" },
+    "recurringActivePill": "{count, plural, =1{1 ativa} other{{count} ativas}}",
+    "@recurringActivePill": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringTotalMonthlyEyebrow": "TOTAL MENSAL",
+    "recurringActiveTitle": "Ativas",
+    "recurringSubscriptionCount": "{count, plural, =1{1 subscrição} other{{count} subscrições}}",
+    "@recurringSubscriptionCount": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringPausedTitle": "Pausadas",
+    "recurringDayOfMonth": "dia {day}",
+    "@recurringDayOfMonth": {
+      "placeholders": {
+        "day": { "type": "int" }
+      }
+    },
+    "recurringEmptyTitle": "Sem pagamentos recorrentes",
+    "recurringEmptyBody": "Adicione para gerar automaticamente todos os meses.",
+    "recurringEyebrow": "RECORRENTES",
+    "recurringHeroSubtitle": "{count, plural, =1{1 subscrição ativa} other{{count} subscrições ativas}}",
+    "@recurringHeroSubtitle": {
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "recurringActiveGroupLabel": "ATIVAS",
+    "recurringPausedGroupLabel": "PAUSADAS",
     "savingsContributionSaveError": "Não foi possível guardar a contribuição — tenta de novo",
     "@savingsContributionSaveError": { "description": "Error snack when saving a savings contribution fails" },
     "coachNoApiKeyTitle": "Configura o teu coach",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -4763,6 +4763,78 @@ abstract class S {
   /// **'Não foi possível eliminar — tenta de novo'**
   String get recurringExpenseDeleteError;
 
+  /// No description provided for @recurringActivePill.
+  ///
+  /// In pt, this message translates to:
+  /// **'{count, plural, =1{1 ativa} other{{count} ativas}}'**
+  String recurringActivePill(int count);
+
+  /// No description provided for @recurringTotalMonthlyEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'TOTAL MENSAL'**
+  String get recurringTotalMonthlyEyebrow;
+
+  /// No description provided for @recurringActiveTitle.
+  ///
+  /// In pt, this message translates to:
+  /// **'Ativas'**
+  String get recurringActiveTitle;
+
+  /// No description provided for @recurringSubscriptionCount.
+  ///
+  /// In pt, this message translates to:
+  /// **'{count, plural, =1{1 subscrição} other{{count} subscrições}}'**
+  String recurringSubscriptionCount(int count);
+
+  /// No description provided for @recurringPausedTitle.
+  ///
+  /// In pt, this message translates to:
+  /// **'Pausadas'**
+  String get recurringPausedTitle;
+
+  /// No description provided for @recurringDayOfMonth.
+  ///
+  /// In pt, this message translates to:
+  /// **'dia {day}'**
+  String recurringDayOfMonth(int day);
+
+  /// No description provided for @recurringEmptyTitle.
+  ///
+  /// In pt, this message translates to:
+  /// **'Sem pagamentos recorrentes'**
+  String get recurringEmptyTitle;
+
+  /// No description provided for @recurringEmptyBody.
+  ///
+  /// In pt, this message translates to:
+  /// **'Adicione para gerar automaticamente todos os meses.'**
+  String get recurringEmptyBody;
+
+  /// No description provided for @recurringEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'RECORRENTES'**
+  String get recurringEyebrow;
+
+  /// No description provided for @recurringHeroSubtitle.
+  ///
+  /// In pt, this message translates to:
+  /// **'{count, plural, =1{1 subscrição ativa} other{{count} subscrições ativas}}'**
+  String recurringHeroSubtitle(int count);
+
+  /// No description provided for @recurringActiveGroupLabel.
+  ///
+  /// In pt, this message translates to:
+  /// **'ATIVAS'**
+  String get recurringActiveGroupLabel;
+
+  /// No description provided for @recurringPausedGroupLabel.
+  ///
+  /// In pt, this message translates to:
+  /// **'PAUSADAS'**
+  String get recurringPausedGroupLabel;
+
   /// Error snack when saving a savings contribution fails
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -2570,6 +2570,69 @@ class SEn extends S {
   String get recurringExpenseDeleteError => 'Couldn\'t delete — try again';
 
   @override
+  String recurringActivePill(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count active',
+      one: '1 active',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringTotalMonthlyEyebrow => 'MONTHLY TOTAL';
+
+  @override
+  String get recurringActiveTitle => 'Active';
+
+  @override
+  String recurringSubscriptionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count subscriptions',
+      one: '1 subscription',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPausedTitle => 'Paused';
+
+  @override
+  String recurringDayOfMonth(int day) {
+    return 'day $day';
+  }
+
+  @override
+  String get recurringEmptyTitle => 'No recurring payments';
+
+  @override
+  String get recurringEmptyBody =>
+      'Add one to generate them automatically every month.';
+
+  @override
+  String get recurringEyebrow => 'RECURRING';
+
+  @override
+  String recurringHeroSubtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count active subscriptions',
+      one: '1 active subscription',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringActiveGroupLabel => 'ACTIVE';
+
+  @override
+  String get recurringPausedGroupLabel => 'PAUSED';
+
+  @override
   String get savingsContributionSaveError =>
       'Couldn\'t save contribution — try again';
 

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -2585,6 +2585,69 @@ class SEs extends S {
       'No se pudo eliminar — intenta de nuevo';
 
   @override
+  String recurringActivePill(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count activas',
+      one: '1 activa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringTotalMonthlyEyebrow => 'TOTAL MENSUAL';
+
+  @override
+  String get recurringActiveTitle => 'Activas';
+
+  @override
+  String recurringSubscriptionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count suscripciones',
+      one: '1 suscripcion',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPausedTitle => 'Pausadas';
+
+  @override
+  String recurringDayOfMonth(int day) {
+    return 'dia $day';
+  }
+
+  @override
+  String get recurringEmptyTitle => 'Sin pagos recurrentes';
+
+  @override
+  String get recurringEmptyBody =>
+      'Anade uno para generarlos automaticamente cada mes.';
+
+  @override
+  String get recurringEyebrow => 'RECURRENTES';
+
+  @override
+  String recurringHeroSubtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count suscripciones activas',
+      one: '1 suscripcion activa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringActiveGroupLabel => 'ACTIVAS';
+
+  @override
+  String get recurringPausedGroupLabel => 'PAUSADAS';
+
+  @override
   String get savingsContributionSaveError =>
       'No se pudo guardar la contribucion — intenta de nuevo';
 

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -2591,6 +2591,69 @@ class SFr extends S {
       'Impossible de supprimer — reessaye';
 
   @override
+  String recurringActivePill(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count actives',
+      one: '1 active',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringTotalMonthlyEyebrow => 'TOTAL MENSUEL';
+
+  @override
+  String get recurringActiveTitle => 'Actives';
+
+  @override
+  String recurringSubscriptionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count abonnements',
+      one: '1 abonnement',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPausedTitle => 'En pause';
+
+  @override
+  String recurringDayOfMonth(int day) {
+    return 'jour $day';
+  }
+
+  @override
+  String get recurringEmptyTitle => 'Aucun paiement recurrent';
+
+  @override
+  String get recurringEmptyBody =>
+      'Ajoutes-en un pour le generer automatiquement chaque mois.';
+
+  @override
+  String get recurringEyebrow => 'RECURRENTS';
+
+  @override
+  String recurringHeroSubtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count abonnements actifs',
+      one: '1 abonnement actif',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringActiveGroupLabel => 'ACTIFS';
+
+  @override
+  String get recurringPausedGroupLabel => 'EN PAUSE';
+
+  @override
   String get savingsContributionSaveError =>
       'Impossible d\'enregistrer la contribution — reessaye';
 

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -2583,6 +2583,69 @@ class SPt extends S {
       'Não foi possível eliminar — tenta de novo';
 
   @override
+  String recurringActivePill(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ativas',
+      one: '1 ativa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringTotalMonthlyEyebrow => 'TOTAL MENSAL';
+
+  @override
+  String get recurringActiveTitle => 'Ativas';
+
+  @override
+  String recurringSubscriptionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count subscrições',
+      one: '1 subscrição',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPausedTitle => 'Pausadas';
+
+  @override
+  String recurringDayOfMonth(int day) {
+    return 'dia $day';
+  }
+
+  @override
+  String get recurringEmptyTitle => 'Sem pagamentos recorrentes';
+
+  @override
+  String get recurringEmptyBody =>
+      'Adicione para gerar automaticamente todos os meses.';
+
+  @override
+  String get recurringEyebrow => 'RECORRENTES';
+
+  @override
+  String recurringHeroSubtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count subscrições ativas',
+      one: '1 subscrição ativa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringActiveGroupLabel => 'ATIVAS';
+
+  @override
+  String get recurringPausedGroupLabel => 'PAUSADAS';
+
+  @override
   String get savingsContributionSaveError =>
       'Não foi possível guardar a contribuição — tenta de novo';
 

--- a/monthy_budget_flutter/lib/screens/recurring_expenses_screen.dart
+++ b/monthy_budget_flutter/lib/screens/recurring_expenses_screen.dart
@@ -187,9 +187,8 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
         .fold(0.0, (s, e) => s + e.amount);
     final pillColor =
         activeCount > 0 ? AppColors.ok(context) : AppColors.ink50(context);
-    final pillLabel = activeCount == 1
-        ? '1 ativa' // TODO(l10n): move to ARB (Wave H)
-        : '$activeCount ativas'; // TODO(l10n): move to ARB (Wave H)
+    final l10n = S.of(context);
+    final pillLabel = l10n.recurringActivePill(activeCount);
 
     return CalmCard(
       child: Column(
@@ -197,7 +196,7 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
         children: [
           Row(
             children: [
-              CalmEyebrow('TOTAL MENSAL'), // TODO(l10n): move to ARB (Wave H)
+              CalmEyebrow(l10n.recurringTotalMonthlyEyebrow),
               const Spacer(),
               CalmPill(label: pillLabel, color: pillColor),
             ],
@@ -214,8 +213,8 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
           CalmListTile(
             leadingIcon: Icons.check_circle_outline,
             leadingColor: AppColors.ok(context),
-            title: 'Ativas', // TODO(l10n): move to ARB (Wave H)
-            subtitle: '$activeCount subscrição${activeCount == 1 ? '' : 'ões'}', // TODO(l10n): move to ARB (Wave H)
+            title: l10n.recurringActiveTitle,
+            subtitle: l10n.recurringSubscriptionCount(activeCount),
             trailing: formatCurrency(activeMonthly),
           ),
           if (pausedCount > 0) ...[
@@ -228,8 +227,8 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
             CalmListTile(
               leadingIcon: Icons.pause_circle_outline,
               leadingColor: AppColors.ink50(context),
-              title: 'Pausadas', // TODO(l10n): move to ARB (Wave H)
-              subtitle: '$pausedCount subscrição${pausedCount == 1 ? '' : 'ões'}', // TODO(l10n): move to ARB (Wave H)
+              title: l10n.recurringPausedTitle,
+              subtitle: l10n.recurringSubscriptionCount(pausedCount),
               trailing: formatCurrency(pausedMonthly),
             ),
           ],
@@ -295,7 +294,7 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
     final subtitleParts = <String>[
       formatCurrency(expense.amount),
       if (expense.dayOfMonth != null)
-        'dia ${expense.dayOfMonth}', // TODO(l10n): move to ARB (Wave H)
+        l10n.recurringDayOfMonth(expense.dayOfMonth!),
       if (expense.description != null && expense.description!.isNotEmpty)
         expense.description!,
     ];
@@ -369,8 +368,8 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
           ? Center(
               child: CalmEmptyState(
                 icon: Icons.event_repeat_outlined,
-                title: 'Sem pagamentos recorrentes', // TODO(l10n): move to ARB (Wave H)
-                body: 'Adicione para gerar automaticamente todos os meses.', // TODO(l10n): move to ARB (Wave H)
+                title: l10n.recurringEmptyTitle,
+                body: l10n.recurringEmptyBody,
                 action: CalmEmptyStateAction(
                   label: l10n.recurringExpenseAdd,
                   onPressed: () => _addOrEdit(),
@@ -382,9 +381,9 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
               children: [
                 // Hero — total monthly recurring
                 CalmHero(
-                  eyebrow: 'RECORRENTES', // TODO(l10n): move to ARB (Wave H)
+                  eyebrow: l10n.recurringEyebrow,
                   amount: formatCurrency(_totalMonthly),
-                  subtitle: '${_expenses.where((e) => e.isActive).length} ${_expenses.where((e) => e.isActive).length == 1 ? 'subscrição ativa' : 'subscrições ativas'}', // TODO(l10n): move to ARB (Wave H)
+                  subtitle: l10n.recurringHeroSubtitle(_expenses.where((e) => e.isActive).length),
                 ),
                 const SizedBox(height: 24),
 
@@ -397,7 +396,7 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
                   _buildExpenseGroup(
                     context,
                     l10n,
-                    'ATIVAS', // TODO(l10n): move to ARB (Wave H)
+                    l10n.recurringActiveGroupLabel,
                     active,
                     true,
                   ),
@@ -407,7 +406,7 @@ class _RecurringExpensesScreenState extends State<RecurringExpensesScreen> {
                   _buildExpenseGroup(
                     context,
                     l10n,
-                    'PAUSADAS', // TODO(l10n): move to ARB (Wave H)
+                    l10n.recurringPausedGroupLabel,
                     paused,
                     active.isEmpty,
                   ),

--- a/monthy_budget_flutter/test/screens/recurring_expenses_l10n_1162_test.dart
+++ b/monthy_budget_flutter/test/screens/recurring_expenses_l10n_1162_test.dart
@@ -1,0 +1,87 @@
+// TDD for issue #1162 — recurring_expenses_screen l10n
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
+
+void main() {
+  late SEn en;
+
+  setUpAll(() {
+    en = SEn();
+  });
+
+  tearDownAll(() {});
+
+  test('recurringActivePill singular is not hardcoded PT', () {
+    final v = en.recurringActivePill(1);
+    expect(v, isNotNull);
+    expect(v, isNot('1 ativa'));
+  });
+
+  test('recurringActivePill plural contains count', () {
+    final v = en.recurringActivePill(3);
+    expect(v, contains('3'));
+  });
+
+  test('recurringTotalMonthlyEyebrow exists', () {
+    expect(en.recurringTotalMonthlyEyebrow, isNotNull);
+    expect(en.recurringTotalMonthlyEyebrow, isNot('TOTAL MENSAL'));
+  });
+
+  test('recurringActiveTitle exists', () {
+    expect(en.recurringActiveTitle, isNotNull);
+  });
+
+  test('recurringSubscriptionCount singular is not hardcoded PT', () {
+    final v = en.recurringSubscriptionCount(1);
+    expect(v, isNotNull);
+    expect(v, isNot('1 subscrição'));
+  });
+
+  test('recurringSubscriptionCount plural contains count', () {
+    final v = en.recurringSubscriptionCount(5);
+    expect(v, contains('5'));
+  });
+
+  test('recurringPausedTitle exists', () {
+    expect(en.recurringPausedTitle, isNotNull);
+  });
+
+  test('recurringDayOfMonth contains day number', () {
+    final v = en.recurringDayOfMonth(15);
+    expect(v, contains('15'));
+  });
+
+  test('recurringEmptyTitle is not hardcoded PT', () {
+    expect(en.recurringEmptyTitle, isNot('Sem pagamentos recorrentes'));
+  });
+
+  test('recurringEmptyBody is not hardcoded PT', () {
+    expect(en.recurringEmptyBody, isNot('Adicione para gerar automaticamente todos os meses.'));
+  });
+
+  test('recurringEyebrow exists', () {
+    expect(en.recurringEyebrow, isNotNull);
+    expect(en.recurringEyebrow, isNot('RECORRENTES'));
+  });
+
+  test('recurringHeroSubtitle singular is not hardcoded PT', () {
+    final v = en.recurringHeroSubtitle(1);
+    expect(v, isNotNull);
+    expect(v, isNot('1 subscrição ativa'));
+  });
+
+  test('recurringHeroSubtitle plural contains count', () {
+    final v = en.recurringHeroSubtitle(4);
+    expect(v, contains('4'));
+  });
+
+  test('recurringActiveGroupLabel exists', () {
+    expect(en.recurringActiveGroupLabel, isNotNull);
+    expect(en.recurringActiveGroupLabel, isNot('ATIVAS'));
+  });
+
+  test('recurringPausedGroupLabel exists', () {
+    expect(en.recurringPausedGroupLabel, isNotNull);
+    expect(en.recurringPausedGroupLabel, isNot('PAUSADAS'));
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1162

## Release Notes
Extracts 14 hardcoded Portuguese strings from `recurring_expenses_screen.dart` into ARB localization files (EN/PT/ES/FR). ICU plurals used for count-based labels (active pill, subscription count, hero subtitle). All strings now use `S.of(context)`.

## Labels
release:patch