### PR TITLE
fix(l10n): extract meal_planner_screen hardcoded PT strings to ARB (#1163)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -3224,6 +3224,8 @@
     "mealSubstituteHint": "Tap an ingredient to replace it with another",
     "mealSubstituteSameCategory": "Same category",
     "mealSubstituteOtherCategories": "Other categories",
+    "mealPlannerDetailEyebrow": "DETAIL",
+    "mealPlannerMealsEyebrow": "MEALS",
     "wizardCourseStructure": "Meal structure",
     "wizardIncludeSoupStarter": "Include soup or starter",
     "wizardSoupStarterHint": "Adds a soup or starter as the first course",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -3103,6 +3103,8 @@
     "mealSubstituteHint": "Toca un ingrediente para sustituirlo por otro",
     "mealSubstituteSameCategory": "Misma categoria",
     "mealSubstituteOtherCategories": "Otras categorias",
+    "mealPlannerDetailEyebrow": "DETALLE",
+    "mealPlannerMealsEyebrow": "COMIDAS",
     "wizardCourseStructure": "Estructura de la comida",
     "wizardIncludeSoupStarter": "Incluir sopa o entrada",
     "wizardSoupStarterHint": "Anade una sopa o entrada como primer plato",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -3103,6 +3103,8 @@
     "mealSubstituteHint": "Appuyez sur un ingredient pour le remplacer",
     "mealSubstituteSameCategory": "Meme categorie",
     "mealSubstituteOtherCategories": "Autres categories",
+    "mealPlannerDetailEyebrow": "DÉTAIL",
+    "mealPlannerMealsEyebrow": "REPAS",
     "wizardCourseStructure": "Structure du repas",
     "wizardIncludeSoupStarter": "Inclure soupe ou entree",
     "wizardSoupStarterHint": "Ajoute une soupe ou entree en premier plat",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -5947,6 +5947,8 @@
     "mealSubstituteHint": "Toque num ingrediente para o substituir por outro",
     "mealSubstituteSameCategory": "Mesma categoria",
     "mealSubstituteOtherCategories": "Outras categorias",
+    "mealPlannerDetailEyebrow": "DETALHE",
+    "mealPlannerMealsEyebrow": "REFEIÇÕES",
     "wizardCourseStructure": "Estrutura da refeicao",
     "wizardIncludeSoupStarter": "Incluir sopa ou entrada",
     "wizardSoupStarterHint": "Adiciona uma sopa ou entrada como primeiro prato",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -10679,6 +10679,18 @@ abstract class S {
   /// **'Outras categorias'**
   String get mealSubstituteOtherCategories;
 
+  /// No description provided for @mealPlannerDetailEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'DETALHE'**
+  String get mealPlannerDetailEyebrow;
+
+  /// No description provided for @mealPlannerMealsEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'REFEIÇÕES'**
+  String get mealPlannerMealsEyebrow;
+
   /// No description provided for @wizardCourseStructure.
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -5986,6 +5986,12 @@ class SEn extends S {
   String get mealSubstituteOtherCategories => 'Other categories';
 
   @override
+  String get mealPlannerDetailEyebrow => 'DETAIL';
+
+  @override
+  String get mealPlannerMealsEyebrow => 'MEALS';
+
+  @override
   String get wizardCourseStructure => 'Meal structure';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -6033,6 +6033,12 @@ class SEs extends S {
   String get mealSubstituteOtherCategories => 'Otras categorias';
 
   @override
+  String get mealPlannerDetailEyebrow => 'DETALLE';
+
+  @override
+  String get mealPlannerMealsEyebrow => 'COMIDAS';
+
+  @override
   String get wizardCourseStructure => 'Estructura de la comida';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -6046,6 +6046,12 @@ class SFr extends S {
   String get mealSubstituteOtherCategories => 'Autres categories';
 
   @override
+  String get mealPlannerDetailEyebrow => 'DÉTAIL';
+
+  @override
+  String get mealPlannerMealsEyebrow => 'REPAS';
+
+  @override
   String get wizardCourseStructure => 'Structure du repas';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -6029,6 +6029,12 @@ class SPt extends S {
   String get mealSubstituteOtherCategories => 'Outras categorias';
 
   @override
+  String get mealPlannerDetailEyebrow => 'DETALHE';
+
+  @override
+  String get mealPlannerMealsEyebrow => 'REFEIÇÕES';
+
+  @override
   String get wizardCourseStructure => 'Estrutura da refeicao';
 
   @override

--- a/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
+++ b/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
@@ -1788,7 +1788,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
         // Always-visible compact detail chip row (replaces toggle)
         Padding(
           padding: const EdgeInsets.only(top: 8, bottom: 2),
-          child: CalmEyebrow('DETALHE'), // TODO(l10n): localise
+          child: CalmEyebrow(l10n.mealPlannerDetailEyebrow),
         ),
         SizedBox(
           height: 36,
@@ -1906,7 +1906,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
         ),
         Padding(
           padding: const EdgeInsets.only(top: 8, bottom: 4),
-          child: CalmEyebrow('REFEIÇÕES'), // TODO(l10n): localise
+          child: CalmEyebrow(l10n.mealPlannerMealsEyebrow),
         ),
         Expanded(
           child: Stack(

--- a/monthy_budget_flutter/test/screens/meal_planner_l10n_1163_test.dart
+++ b/monthy_budget_flutter/test/screens/meal_planner_l10n_1163_test.dart
@@ -1,0 +1,23 @@
+// TDD for issue #1163 — meal_planner_screen l10n
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
+
+void main() {
+  late SEn en;
+
+  setUpAll(() {
+    en = SEn();
+  });
+
+  tearDownAll(() {});
+
+  test('mealPlannerDetailEyebrow exists and is not hardcoded PT', () {
+    expect(en.mealPlannerDetailEyebrow, isNotNull);
+    expect(en.mealPlannerDetailEyebrow, isNot('DETALHE'));
+  });
+
+  test('mealPlannerMealsEyebrow exists and is not hardcoded PT', () {
+    expect(en.mealPlannerMealsEyebrow, isNotNull);
+    expect(en.mealPlannerMealsEyebrow, isNot('REFEIÇÕES'));
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1163

## Release Notes
Extracts 2 hardcoded Portuguese eyebrow strings from `meal_planner_screen.dart` into ARB localization files (EN/PT/ES/FR). Strings now use `S.of(context)` via the existing `l10n` variable in `_buildPlanView`.

## Labels
release:patch