### PR TITLE
fix(l10n): extract expense_search_view hardcoded PT string to ARB (#1166)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -1790,6 +1790,7 @@
             }
         }
     },
+    "searchEmptyTitle": "Nothing found",
     "expenseTypeLabel": "TYPE",
     "expenseFixed": "Fixed",
     "expenseVariable": "Variable",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -1644,6 +1644,7 @@
             }
         }
     },
+    "searchEmptyTitle": "Nada encontrado",
     "expenseTypeLabel": "TIPO",
     "expenseFixed": "Fijo",
     "expenseVariable": "Variable",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -1644,6 +1644,7 @@
             }
         }
     },
+    "searchEmptyTitle": "Rien trouve",
     "expenseTypeLabel": "TYPE",
     "expenseFixed": "Fixe",
     "expenseVariable": "Variable",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -3956,6 +3956,7 @@
             }
         }
     },
+    "searchEmptyTitle": "Nada encontrado",
     "expenseTypeLabel": "TIPO",
     "expenseFixed": "Fixo",
     "@expenseFixed": {

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -5693,6 +5693,12 @@ abstract class S {
   /// **'{count} resultados'**
   String searchResultCount(int count);
 
+  /// No description provided for @searchEmptyTitle.
+  ///
+  /// In pt, this message translates to:
+  /// **'Nada encontrado'**
+  String get searchEmptyTitle;
+
   /// No description provided for @expenseTypeLabel.
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -3083,6 +3083,9 @@ class SEn extends S {
   }
 
   @override
+  String get searchEmptyTitle => 'Nothing found';
+
+  @override
   String get expenseTypeLabel => 'TYPE';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -3099,6 +3099,9 @@ class SEs extends S {
   }
 
   @override
+  String get searchEmptyTitle => 'Nada encontrado';
+
+  @override
   String get expenseTypeLabel => 'TIPO';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -3105,6 +3105,9 @@ class SFr extends S {
   }
 
   @override
+  String get searchEmptyTitle => 'Rien trouve';
+
+  @override
   String get expenseTypeLabel => 'TYPE';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -3097,6 +3097,9 @@ class SPt extends S {
   }
 
   @override
+  String get searchEmptyTitle => 'Nada encontrado';
+
+  @override
   String get expenseTypeLabel => 'TIPO';
 
   @override

--- a/monthy_budget_flutter/lib/widgets/expense/expense_search_view.dart
+++ b/monthy_budget_flutter/lib/widgets/expense/expense_search_view.dart
@@ -146,8 +146,7 @@ class ExpenseSearchView extends StatelessWidget {
                         ? Center(
                             child: CalmEmptyState(
                               icon: Icons.search_off,
-                              // TODO(l10n): move to ARB (Wave H)
-                              title: 'Nada encontrado',
+                              title: l10n.searchEmptyTitle,
                               body: l10n.searchNoResults,
                             ),
                           )

--- a/monthy_budget_flutter/test/widgets/expense_search_l10n_1166_test.dart
+++ b/monthy_budget_flutter/test/widgets/expense_search_l10n_1166_test.dart
@@ -1,0 +1,18 @@
+// TDD for issue #1166 — expense_search_view l10n
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
+
+void main() {
+  late SEn en;
+
+  setUpAll(() {
+    en = SEn();
+  });
+
+  tearDownAll(() {});
+
+  test('searchEmptyTitle exists and is not hardcoded PT', () {
+    expect(en.searchEmptyTitle, isNotNull);
+    expect(en.searchEmptyTitle, isNot('Nada encontrado'));
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1166

## Release Notes
Extracts the hardcoded `'Nada encontrado'` empty-state title from `expense_search_view.dart` into ARB key `searchEmptyTitle` across EN/PT/ES/FR.

## Labels
release:patch