### PR TITLE
fix(l10n): extract remaining meal_planner_screen PT strings to ARB (#1168)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -3258,6 +3258,8 @@
     "mealSubstituteOtherCategories": "Other categories",
     "mealPlannerDetailEyebrow": "DETAIL",
     "mealPlannerMealsEyebrow": "MEALS",
+    "mealPlannerMonthlyPlanEyebrow": "MONTHLY PLAN",
+    "mealPlannerWeekEyebrow": "WEEK",
     "wizardCourseStructure": "Meal structure",
     "wizardIncludeSoupStarter": "Include soup or starter",
     "wizardSoupStarterHint": "Adds a soup or starter as the first course",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -3137,6 +3137,8 @@
     "mealSubstituteOtherCategories": "Otras categorias",
     "mealPlannerDetailEyebrow": "DETALLE",
     "mealPlannerMealsEyebrow": "COMIDAS",
+    "mealPlannerMonthlyPlanEyebrow": "PLAN MENSUAL",
+    "mealPlannerWeekEyebrow": "SEMANA",
     "wizardCourseStructure": "Estructura de la comida",
     "wizardIncludeSoupStarter": "Incluir sopa o entrada",
     "wizardSoupStarterHint": "Anade una sopa o entrada como primer plato",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -3137,6 +3137,8 @@
     "mealSubstituteOtherCategories": "Autres categories",
     "mealPlannerDetailEyebrow": "DÉTAIL",
     "mealPlannerMealsEyebrow": "REPAS",
+    "mealPlannerMonthlyPlanEyebrow": "PLAN DU MOIS",
+    "mealPlannerWeekEyebrow": "SEMAINE",
     "wizardCourseStructure": "Structure du repas",
     "wizardIncludeSoupStarter": "Inclure soupe ou entree",
     "wizardSoupStarterHint": "Ajoute une soupe ou entree en premier plat",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -5981,6 +5981,8 @@
     "mealSubstituteOtherCategories": "Outras categorias",
     "mealPlannerDetailEyebrow": "DETALHE",
     "mealPlannerMealsEyebrow": "REFEIÇÕES",
+    "mealPlannerMonthlyPlanEyebrow": "PLANO DO MÊS",
+    "mealPlannerWeekEyebrow": "SEMANA",
     "wizardCourseStructure": "Estrutura da refeicao",
     "wizardIncludeSoupStarter": "Incluir sopa ou entrada",
     "wizardSoupStarterHint": "Adiciona uma sopa ou entrada como primeiro prato",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -10763,6 +10763,18 @@ abstract class S {
   /// **'REFEIÇÕES'**
   String get mealPlannerMealsEyebrow;
 
+  /// No description provided for @mealPlannerMonthlyPlanEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'PLANO DO MÊS'**
+  String get mealPlannerMonthlyPlanEyebrow;
+
+  /// No description provided for @mealPlannerWeekEyebrow.
+  ///
+  /// In pt, this message translates to:
+  /// **'SEMANA'**
+  String get mealPlannerWeekEyebrow;
+
   /// No description provided for @wizardCourseStructure.
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -6055,6 +6055,12 @@ class SEn extends S {
   String get mealPlannerMealsEyebrow => 'MEALS';
 
   @override
+  String get mealPlannerMonthlyPlanEyebrow => 'MONTHLY PLAN';
+
+  @override
+  String get mealPlannerWeekEyebrow => 'WEEK';
+
+  @override
   String get wizardCourseStructure => 'Meal structure';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -6102,6 +6102,12 @@ class SEs extends S {
   String get mealPlannerMealsEyebrow => 'COMIDAS';
 
   @override
+  String get mealPlannerMonthlyPlanEyebrow => 'PLAN MENSUAL';
+
+  @override
+  String get mealPlannerWeekEyebrow => 'SEMANA';
+
+  @override
   String get wizardCourseStructure => 'Estructura de la comida';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -6115,6 +6115,12 @@ class SFr extends S {
   String get mealPlannerMealsEyebrow => 'REPAS';
 
   @override
+  String get mealPlannerMonthlyPlanEyebrow => 'PLAN DU MOIS';
+
+  @override
+  String get mealPlannerWeekEyebrow => 'SEMAINE';
+
+  @override
   String get wizardCourseStructure => 'Structure du repas';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -6098,6 +6098,12 @@ class SPt extends S {
   String get mealPlannerMealsEyebrow => 'REFEIÇÕES';
 
   @override
+  String get mealPlannerMonthlyPlanEyebrow => 'PLANO DO MÊS';
+
+  @override
+  String get mealPlannerWeekEyebrow => 'SEMANA';
+
+  @override
   String get wizardCourseStructure => 'Estrutura da refeicao';
 
   @override

--- a/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
+++ b/monthy_budget_flutter/lib/screens/meal_planner_screen.dart
@@ -1593,7 +1593,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          CalmEyebrow('PLANO DO MÊS'),
+                          CalmEyebrow(l10n.mealPlannerMonthlyPlanEyebrow),
                           const SizedBox(height: 8),
                           Text(
                             '${plan.totalEstimatedCost.toStringAsFixed(2)}${currencySymbol()}',
@@ -1633,7 +1633,7 @@ class _MealPlannerScreenState extends State<MealPlannerScreen> {
                     CalmEyebrow(
                       _showFullMonth
                           ? l10n.mealPlannerFullMonthView.toUpperCase()
-                          : 'SEMANA',
+                          : l10n.mealPlannerWeekEyebrow,
                     ),
                     const Spacer(),
                     SizedBox(

--- a/monthy_budget_flutter/test/screens/meal_planner_l10n2_1168_test.dart
+++ b/monthy_budget_flutter/test/screens/meal_planner_l10n2_1168_test.dart
@@ -1,0 +1,23 @@
+// TDD for issue #1168 — meal_planner_screen remaining l10n
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
+
+void main() {
+  late SEn en;
+
+  setUpAll(() {
+    en = SEn();
+  });
+
+  tearDownAll(() {});
+
+  test('mealPlannerMonthlyPlanEyebrow exists and is not hardcoded PT', () {
+    expect(en.mealPlannerMonthlyPlanEyebrow, isNotNull);
+    expect(en.mealPlannerMonthlyPlanEyebrow, isNot('PLANO DO MÊS'));
+  });
+
+  test('mealPlannerWeekEyebrow exists and is not hardcoded PT', () {
+    expect(en.mealPlannerWeekEyebrow, isNotNull);
+    expect(en.mealPlannerWeekEyebrow, isNot('SEMANA'));
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1168

## Release Notes
Extracts 2 missed hardcoded Portuguese strings (`'PLANO DO MÊS'` and `'SEMANA'`) from `meal_planner_screen.dart` into ARB keys across EN/PT/ES/FR.

## Labels
release:patch