### PR TITLE
fix(l10n): wire setup_wizard_screen _finishExpenses to l10n labels (#1172)

### DIFF
--- a/monthy_budget_flutter/lib/screens/setup_wizard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/setup_wizard_screen.dart
@@ -208,7 +208,7 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
     widget.onComplete(_draft);
   }
 
-  void _finishExpenses() {
+  void _finishExpenses(BuildContext context) {
     final l10nKeys = _expenseKeyOrder();
     final expenses = <ExpenseItem>[];
     for (final key in l10nKeys) {
@@ -216,7 +216,7 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
       if (amount > 0) {
         expenses.add(ExpenseItem(
           id: 'wizard_$key',
-          label: _expenseLabelFallback(key),
+          label: _expenseL10nLabel(S.of(context), key),
           amount: amount,
           category: _expenseCategory(key),
         ));
@@ -234,19 +234,6 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
 
   List<String> _expenseKeyOrder() =>
       ['rent', 'groceries', 'transport', 'utilities', 'telecom', 'health', 'leisure'];
-
-  String _expenseLabelFallback(String key) {
-    switch (key) {
-      case 'rent': return 'Renda';
-      case 'groceries': return 'Alimentação';
-      case 'transport': return 'Transportes';
-      case 'utilities': return 'Utilidades';
-      case 'telecom': return 'Telecomunicações';
-      case 'health': return 'Saúde';
-      case 'leisure': return 'Lazer';
-      default: return key;
-    }
-  }
 
   String _expenseCategory(String key) {
     switch (key) {
@@ -330,7 +317,7 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
             expenseKeyOrder: _expenseKeyOrder(),
             expenseIcon: _expenseIcon,
             expenseLabel: (key) => _expenseL10nLabel(S.of(context), key),
-            onFinish: _finishExpenses,
+            onFinish: () => _finishExpenses(context),
             onBack: _back,
           ),
           // Step 2: Completion

--- a/monthy_budget_flutter/test/screens/setup_wizard_l10n_1172_test.dart
+++ b/monthy_budget_flutter/test/screens/setup_wizard_l10n_1172_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
+
+void main() {
+  late SEn en;
+  setUpAll(() { en = SEn(); });
+  tearDownAll(() {});
+
+  group('setup_wizard_screen expense l10n keys (#1172)', () {
+    test('setupWizardExpRent is EN not PT', () {
+      expect(en.setupWizardExpRent, isNotNull);
+      expect(en.setupWizardExpRent, isNot('Renda'));
+    });
+
+    test('setupWizardExpGroceries is EN not PT', () {
+      expect(en.setupWizardExpGroceries, isNotNull);
+      expect(en.setupWizardExpGroceries, isNot('Alimentação'));
+    });
+
+    test('setupWizardExpTransport is EN not PT', () {
+      expect(en.setupWizardExpTransport, isNotNull);
+      expect(en.setupWizardExpTransport, isNot('Transportes'));
+    });
+
+    test('setupWizardExpUtilities is EN not PT', () {
+      expect(en.setupWizardExpUtilities, isNotNull);
+      expect(en.setupWizardExpUtilities, isNot('Utilidades'));
+    });
+
+    test('setupWizardExpTelecom is EN not PT', () {
+      expect(en.setupWizardExpTelecom, isNotNull);
+      expect(en.setupWizardExpTelecom, isNot('Telecomunicações'));
+    });
+
+    test('setupWizardExpHealth is EN not PT', () {
+      expect(en.setupWizardExpHealth, isNotNull);
+      expect(en.setupWizardExpHealth, isNot('Saúde'));
+    });
+
+    test('setupWizardExpLeisure is EN not PT', () {
+      expect(en.setupWizardExpLeisure, isNotNull);
+      expect(en.setupWizardExpLeisure, isNot('Lazer'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1172

## Release Notes
Fixed a wiring gap in the setup wizard: expenses created during wizard completion were saved with hardcoded Portuguese labels (`'Renda'`, `'Alimentação'`, etc.) despite the `_expenseL10nLabel` method already existing. Removed `_expenseLabelFallback` and wired `_finishExpenses` to use `S.of(context)` via the existing l10n helper. No new ARB keys needed.

## Changes
- `lib/screens/setup_wizard_screen.dart`: remove 13-line `_expenseLabelFallback` method; `_finishExpenses` now accepts `BuildContext` and calls `_expenseL10nLabel(S.of(context), key)`; call site updated to `onFinish: () => _finishExpenses(context)`
- `test/screens/setup_wizard_l10n_1172_test.dart`: 7 unit tests verifying `setupWizardExp*` ARB keys are EN strings

release:patch