### PR TITLE
fix(l10n): extract settings_screen AI Coach key notice to ARB (#1174)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -3376,5 +3376,7 @@
     "dashboardHeroOverPace": "Over pace",
     "@dashboardHeroOverPace": {"description": "Dashboard hero pace status: over pace"},
     "dashboardHeroDaysLeft": "{days} days left",
-    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}}
+    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}},
+    "settingsAiKeyProtected": "OpenAI API key secured in Supabase (Edge Function).",
+    "@settingsAiKeyProtected": {"description": "Settings AI Coach section: API key security notice"}
 }

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -3247,5 +3247,7 @@
     "dashboardHeroOverPace": "Por encima del ritmo",
     "@dashboardHeroOverPace": {"description": "Dashboard hero pace status: over pace"},
     "dashboardHeroDaysLeft": "{days} días restantes",
-    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}}
+    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}},
+    "settingsAiKeyProtected": "Clave API de OpenAI protegida en Supabase (Edge Function).",
+    "@settingsAiKeyProtected": {"description": "Settings AI Coach section: API key security notice"}
 }

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -3247,5 +3247,7 @@
     "dashboardHeroOverPace": "Au-dessus du rythme",
     "@dashboardHeroOverPace": {"description": "Dashboard hero pace status: over pace"},
     "dashboardHeroDaysLeft": "{days} jours restants",
-    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}}
+    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}},
+    "settingsAiKeyProtected": "Clé API OpenAI sécurisée dans Supabase (Edge Function).",
+    "@settingsAiKeyProtected": {"description": "Settings AI Coach section: API key security notice"}
 }

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -6105,5 +6105,7 @@
     "dashboardHeroOverPace": "Acima do ritmo",
     "@dashboardHeroOverPace": {"description": "Dashboard hero pace status: over pace"},
     "dashboardHeroDaysLeft": "{days} dias restantes",
-    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}}
+    "@dashboardHeroDaysLeft": {"description": "Dashboard hero days remaining label", "placeholders": {"days": {"type": "String"}}},
+    "settingsAiKeyProtected": "OpenAI API key protegida no Supabase (Edge Function).",
+    "@settingsAiKeyProtected": {"description": "Settings AI Coach section: API key security notice"}
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -11380,6 +11380,12 @@ abstract class S {
   /// In pt, this message translates to:
   /// **'{days} dias restantes'**
   String dashboardHeroDaysLeft(String days);
+
+  /// Settings AI Coach section: API key security notice
+  ///
+  /// In pt, this message translates to:
+  /// **'OpenAI API key protegida no Supabase (Edge Function).'**
+  String get settingsAiKeyProtected;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -6396,4 +6396,8 @@ class SEn extends S {
   String dashboardHeroDaysLeft(String days) {
     return '$days days left';
   }
+
+  @override
+  String get settingsAiKeyProtected =>
+      'OpenAI API key secured in Supabase (Edge Function).';
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -6444,4 +6444,8 @@ class SEs extends S {
   String dashboardHeroDaysLeft(String days) {
     return '$days días restantes';
   }
+
+  @override
+  String get settingsAiKeyProtected =>
+      'Clave API de OpenAI protegida en Supabase (Edge Function).';
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -6457,4 +6457,8 @@ class SFr extends S {
   String dashboardHeroDaysLeft(String days) {
     return '$days jours restants';
   }
+
+  @override
+  String get settingsAiKeyProtected =>
+      'Clé API OpenAI sécurisée dans Supabase (Edge Function).';
 }

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -6440,4 +6440,8 @@ class SPt extends S {
   String dashboardHeroDaysLeft(String days) {
     return '$days dias restantes';
   }
+
+  @override
+  String get settingsAiKeyProtected =>
+      'OpenAI API key protegida no Supabase (Edge Function).';
 }

--- a/monthy_budget_flutter/lib/screens/settings_screen_sections.dart
+++ b/monthy_budget_flutter/lib/screens/settings_screen_sections.dart
@@ -2857,7 +2857,7 @@ extension _SettingsSections on _SettingsScreenState {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    'OpenAI API key protegida no Supabase (Edge Function).',
+                    S.of(context).settingsAiKeyProtected,
                     style: TextStyle(
                       fontSize: 12,
                       color: AppColors.ink(context),

--- a/monthy_budget_flutter/test/screens/settings_l10n_1174_test.dart
+++ b/monthy_budget_flutter/test/screens/settings_l10n_1174_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
+
+void main() {
+  late SEn en;
+  setUpAll(() { en = SEn(); });
+  tearDownAll(() {});
+
+  group('settings_screen_sections l10n keys (#1174)', () {
+    test('settingsAiKeyProtected is EN not PT', () {
+      expect(en.settingsAiKeyProtected, isNotNull);
+      expect(en.settingsAiKeyProtected, isNot(contains('protegida')));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Fixes #1174

## Release Notes
The AI Coach settings section security notice was hardcoded in Portuguese. Extracted to `settingsAiKeyProtected` ARB key across all 4 locales (EN/PT/ES/FR) and wired the settings screen to use `S.of(context)`.

## Changes
- `lib/screens/settings_screen_sections.dart`: line 2860 — replace hardcoded PT with `S.of(context).settingsAiKeyProtected`
- `lib/l10n/app_{en,pt,es,fr}.arb`: add `settingsAiKeyProtected` key
- `test/screens/settings_l10n_1174_test.dart`: 1 unit test verifying the key is EN

release:patch