### PR TITLE
Torna o texto de estado do orçamento e o texto orçamentado Flexible+ellipsis para o InfoIconButton nunca sair do ecrã a 360px (#1203)

### DIFF
--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -753,21 +753,29 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       : AppColors.ok(context),
                 ),
                 const SizedBox(width: 8),
-                Text(
-                  isOver
-                      ? l10n.expenseTrackerOver
-                      : l10n.expenseTrackerRemaining,
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.ink70(context),
+                Flexible(
+                  child: Text(
+                    isOver
+                        ? l10n.expenseTrackerOver
+                        : l10n.expenseTrackerRemaining,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink70(context),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 const Spacer(),
-                Text(
-                  l10n.expenseTrackerBudgetedLabel(formatCurrency(totalBudgeted)),
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.ink50(context),
+                Flexible(
+                  child: Text(
+                    l10n.expenseTrackerBudgetedLabel(formatCurrency(totalBudgeted)),
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink50(context),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 InfoIconButton(

--- a/monthy_budget_flutter/test/screens/expense_tracker_budget_row_1203_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_budget_row_1203_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/widgets/info_icon_button.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding: at 360px viewport width, the budget summary
+  // row's InfoIconButton was pushed off-screen by the fixed-width children
+  // (pill + status text + budgeted-amount text) with no Flexible/Expanded to
+  // absorb the compression. See lib/screens/expense_tracker_screen.dart:745.
+  testWidgets(
+    'InfoIconButton stays fully within screen bounds at 360px width (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Mirrors the exact repro numbers from the issue: "-128,95 € Acima do
+      // orçamento orç. 1 871,50 €".
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 1871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 2000.45,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(360));
+
+      // The a11y tap target must stay at least 44x44.
+      expect(bottomRight.dx - topLeft.dx, greaterThanOrEqualTo(44));
+      expect(bottomRight.dy - topLeft.dy, greaterThanOrEqualTo(44));
+
+      // The pill ("-128,95 €") must still be fully rendered (not the
+      // budgeted-amount text, which is allowed to ellipsize).
+      expect(find.textContaining('-128,95'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'InfoIconButton stays visible at 360px even with a longer budgeted amount (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Keep the per-category remaining small (actual close to budgeted) so
+      // only the summary row's totals are long — this isolates the case
+      // under test from the unrelated category-row layout.
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 12871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 12871,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(360));
+    },
+  );
+
+  testWidgets(
+    'InfoIconButton stays fully visible at 430px width and budgeted text is unchanged (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(430, 900);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Same fixture as the "longer budgeted amount" case above: keeps the
+      // per-category remaining small so only this test's assertions (on the
+      // summary row) are exercised, independent of the unrelated
+      // category-row layout.
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 12871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 12871,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(430));
+
+      // On the wider viewport there's enough room, so the budgeted-amount
+      // text renders in full (no ellipsis needed). Match on the l10n
+      // prefix + amount fragment rather than the exact separator glyph
+      // (NumberFormat may use a non-breaking thousands separator).
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Text &&
+              (widget.data ?? '').startsWith('budget') &&
+              (widget.data ?? '').contains('871,50'),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Resumo

Torna o texto de estado do orçamento e o texto orçamentado Flexible+ellipsis para o InfoIconButton nunca sair do ecrã a 360px

## O que mudou

Em `lib/screens/expense_tracker_screen.dart` (linha ~745), na Row da linha de resumo do orçamento:

- O `Text` do estado ("Acima do orçamento"/"Restante") passou a estar envolvido num `Flexible` com `maxLines: 1` e `overflow: TextOverflow.ellipsis`.
- O `Text` do valor orçamentado ("orç. {valor}") passou a estar envolvido num `Flexible` com o mesmo tratamento (já estava planeado pelo curator).
- O `CalmPill` (valor do desvio, ex. "-128,95 €") e o `InfoIconButton` (alvo de toque 44×44) mantiveram-se sem alterações — não devem encolher.

## Porque assim

Segui o plano do curator com uma correção adicional: o curator estimou a largura disponível da Row em ~320px (360 − 2×20 de padding), mas medi empiricamente (via teste de widget com `tester.view.physicalSize`) que a largura real disponível é 280px — o `CalmScaffold` já aplica os seus próprios 20px de `bodyPadding` por defeito, e a `Row` está dentro de outro `Padding(horizontal: 20)` explícito, duplicando a margem para 40px de cada lado (80px no total, não 40px).

Com essa largura real, aplicar `Flexible` só ao texto orçamentado (como o curator descreveu como plano principal) não chegava: mesmo com esse texto encolhido a zero, a soma de pill + gap + texto de estado + ícone já ultrapassava os 280px disponíveis — confirmado por um overflow real de 39px no teste antes desta correção adicional. O próprio curator já tinha previsto este cenário como contingência ("se, mesmo com o Flexible, o texto 'Acima do orçamento' for por si só demasiado longo... aplicar o mesmo tratamento") — apliquei-a porque os factos mediram exactamente essa situação, não apenas como precaução.

O `Spacer` manteve-se entre os dois textos flexíveis para preservar o espaçamento visual em ecrãs largos (`phone`/`tablet`) onde há espaço de sobra — nesse caso os três (`Flexible` de estado, `Spacer`, `Flexible` de orçamentado) recebem a sua quota normal e nada é truncado.

Não toquei no `CalmPill`, no `SizedBox(width: 8)`, nem no `InfoIconButton` — confirmando que a causa não estava aí, como o curator indicou.

## Critérios de aceitação

- [x] A 360px de largura, o círculo do `InfoIconButton` fica 100% visível — verificado por teste de widget que mede `getTopLeft`/`getBottomRight` do `InfoIconButton` e confirma que ambos os limites ficam dentro de [0, 360].
- [x] O `InfoIconButton` mantém alvo de toque ≥44×44 — verificado no mesmo teste (`bottomRight - topLeft >= 44` em ambos os eixos). Não foi tornado `Flexible`.
- [x] O texto "orç. {valor}" trunca com ellipsis em vez de forçar overflow — o `Flexible` + `TextOverflow.ellipsis` garantem isto; testado com um orçamento de 12 871,50 € (mais dígitos) a 360px sem overflow.
- [x] O comportamento no viewport `phone` (430px) não muda — testado: ícone continua visível e o texto orçamentado continua a aparecer por inteiro (sem ellipsis) quando há espaço suficiente.
- [x] O pill ("-128,95 €") continua completo em ambos os viewports — testado explicitamente no cenário de 360px que reproduz os números exactos do issue.
- [x] Nenhuma outra linha/ecrã foi alterada — o diff é local às linhas 745-782 de `expense_tracker_screen.dart`; `InfoIconButton` e `CalmPill` (ficheiros de widget partilhados) não foram tocados.

## Testes

Adicionei `test/screens/expense_tracker_budget_row_1203_test.dart` com 3 testes de widget:

1. `InfoIconButton stays fully within screen bounds at 360px width (#1203)` — reproduz os números exactos do issue (orçamento 1871,50 €, gasto 2000,45 €, diferença -128,95 €) a 360×640 e confirma o ícone dentro do ecrã com alvo de toque ≥44×44, e o pill completo.
2. `InfoIconButton stays visible at 360px even with a longer budgeted amount (#1203)` — usa um orçamento de 12871,50 € (mais dígitos) a 360×640 para validar a ellipsis em vez de overflow.
3. `InfoIconButton stays fully visible at 430px width and budgeted text is unchanged (#1203)` — confirma que a 430px nada regride: ícone visível e texto orçamentado completo (sem ellipsis).

Confirmei empiricamente (via `git stash` do fix) que os 3 testes falham sem a correção (overflow real da `RenderFlex` na `Row` da linha 745) e passam com ela.

Resultado da suite completa: 2399 testes passaram, 0 falharam. `flutter analyze --no-fatal-infos --no-fatal-warnings` não introduziu avisos/erros novos nos ficheiros alterados (78 issues pré-existentes noutros ficheiros, inalteradas).

## Testes

2399 passaram, 0 falharam (flutter test completo)

## Linked Issue

Fixes #1203