### PR TITLE
fr: corrige mojibake (UTF-8 mal decodificado) em € / œ / Ë / → em 7 chaves de app_fr.arb (#1232)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -131,7 +131,7 @@
             }
         }
     },
-    "monthReviewExpensesExceeded": "Les dépenses réelles ont dépassé le prévu de {amount}ââ€šÂ¬ — ajuster les valeurs dans les paramètres ?",
+    "monthReviewExpensesExceeded": "Les dépenses réelles ont dépassé le prévu de {amount}€ — ajuster les valeurs dans les paramètres ?",
     "@monthReviewExpensesExceeded": {
         "placeholders": {
             "amount": {
@@ -139,7 +139,7 @@
             }
         }
     },
-    "monthReviewSavedMore": "Économisé {amount}ââ€šÂ¬ de plus que prévu — vous pouvez renforcer le fonds d'urgence.",
+    "monthReviewSavedMore": "Économisé {amount}€ de plus que prévu — vous pouvez renforcer le fonds d'urgence.",
     "@monthReviewSavedMore": {
         "placeholders": {
             "amount": {
@@ -750,7 +750,7 @@
     "mealConsolidatedList": "Voir la liste consolidée",
     "mealConsolidatedTitle": "Liste Consolidée",
     "mealAlternatives": "Alternatives",
-    "mealTotalCost": "{cost}ââ€šÂ¬ total",
+    "mealTotalCost": "{cost}€ total",
     "@mealTotalCost": {
         "placeholders": {
             "cost": {
@@ -829,7 +829,7 @@
     "wizardNoLimit": "Sans limite",
     "wizardMinimizeWaste": "Minimiser le gaspillage",
     "wizardMinimizeWasteDesc": "Préférer les recettes réutilisant des ingrédients déjà utilisés",
-    "wizardSettingsInfo": "Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres ââ€ ’ Repas.",
+    "wizardSettingsInfo": "Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres → Repas.",
     "wizardContinue": "Continuer",
     "wizardGeneratePlan": "Générer le Plan",
     "wizardStepOf": "Étape {current} sur {total}",
@@ -912,7 +912,7 @@
     },
     "settingsSalaryActive": "Actif",
     "settingsGrossMonthlySalary": "SALAIRE BRUT MENSUEL",
-    "settingsSubsidyHoliday": "PRIMES DE VACANCES ET NOÃ‹L (DOUZIÈMES)",
+    "settingsSubsidyHoliday": "PRIMES DE VACANCES ET NOËL (DOUZIÈMES)",
     "settingsOtherExemptLabel": "AUTRES REVENUS EXONÉRÉS D'IMPÔT",
     "settingsMealAllowanceLabel": "INDEMNITÉ REPAS",
     "settingsAmountPerDay": "MONTANT/JOUR",
@@ -1708,7 +1708,7 @@
     "onbSkip": "Passer",
     "onbNext": "Suivant",
     "onbGetStarted": "Commencer",
-    "onbSlide0Title": "Votre budget, en un coup d'Ã…“il",
+    "onbSlide0Title": "Votre budget, en un coup d'œil",
     "onbSlide0Body": "Le tableau de bord affiche votre liquidité mensuelle, dépenses et Indice de Sérénité.",
     "onbSlide1Title": "Suivez chaque dépense",
     "onbSlide1Body": "Appuyez sur + pour enregistrer un achat. Assignez une catégorie et regardez les barres se mettre à jour.",
@@ -1852,7 +1852,7 @@
     },
     "taxSimTitle": "Simulateur Fiscal",
     "taxSimPresets": "SCÉNARIOS RAPIDES",
-    "taxSimPresetRaise": "+ââ€šÂ¬200 augmentation",
+    "taxSimPresetRaise": "+€200 augmentation",
     "taxSimPresetMeal": "Carte vs espèces",
     "taxSimPresetTitular": "Conjoint vs séparé",
     "taxSimParameters": "PARAMÈTRES",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -308,12 +308,12 @@ class SFr extends S {
 
   @override
   String monthReviewExpensesExceeded(String amount) {
-    return 'Les dépenses réelles ont dépassé le prévu de $amountââ€šÂ¬ — ajuster les valeurs dans les paramètres ?';
+    return 'Les dépenses réelles ont dépassé le prévu de $amount€ — ajuster les valeurs dans les paramètres ?';
   }
 
   @override
   String monthReviewSavedMore(String amount) {
-    return 'Économisé $amountââ€šÂ¬ de plus que prévu — vous pouvez renforcer le fonds d\'urgence.';
+    return 'Économisé $amount€ de plus que prévu — vous pouvez renforcer le fonds d\'urgence.';
   }
 
   @override
@@ -1323,7 +1323,7 @@ class SFr extends S {
 
   @override
   String mealTotalCost(String cost) {
-    return '$costââ€šÂ¬ total';
+    return '$cost€ total';
   }
 
   @override
@@ -1470,7 +1470,7 @@ class SFr extends S {
 
   @override
   String get wizardSettingsInfo =>
-      'Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres ââ€ ’ Repas.';
+      'Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres → Repas.';
 
   @override
   String get wizardContinue => 'Continuer';
@@ -1655,8 +1655,7 @@ class SFr extends S {
   String get settingsGrossMonthlySalary => 'SALAIRE BRUT MENSUEL';
 
   @override
-  String get settingsSubsidyHoliday =>
-      'PRIMES DE VACANCES ET NOÃ‹L (DOUZIÈMES)';
+  String get settingsSubsidyHoliday => 'PRIMES DE VACANCES ET NOËL (DOUZIÈMES)';
 
   @override
   String get settingsOtherExemptLabel => 'AUTRES REVENUS EXONÉRÉS D\'IMPÔT';
@@ -3207,7 +3206,7 @@ class SFr extends S {
   String get onbGetStarted => 'Commencer';
 
   @override
-  String get onbSlide0Title => 'Votre budget, en un coup d\'Ã…“il';
+  String get onbSlide0Title => 'Votre budget, en un coup d\'œil';
 
   @override
   String get onbSlide0Body =>
@@ -3528,7 +3527,7 @@ class SFr extends S {
   String get taxSimPresets => 'SCÉNARIOS RAPIDES';
 
   @override
-  String get taxSimPresetRaise => '+ââ€šÂ¬200 augmentation';
+  String get taxSimPresetRaise => '+€200 augmentation';
 
   @override
   String get taxSimPresetMeal => 'Carte vs espèces';

--- a/monthy_budget_flutter/test/screens/fr_encoding_mojibake_1232_test.dart
+++ b/monthy_budget_flutter/test/screens/fr_encoding_mojibake_1232_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_fr.dart';
+
+void main() {
+  late SFr fr;
+  setUpAll(() {
+    fr = SFr();
+  });
+
+  group('app_fr.arb mojibake fix (#1232)', () {
+    // Bytes that only ever appear when a UTF-8 string got mis-decoded as
+    // Latin-1/Windows-1252 and re-encoded — the mojibake pattern this issue
+    // fixes. None of the corrected strings below should contain them.
+    final mojibakePattern = RegExp(r'(Ã.|â€.|ââ€)');
+
+    test('monthReviewExpensesExceeded shows € not mojibake', () {
+      final result = fr.monthReviewExpensesExceeded('50');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('monthReviewSavedMore shows € not mojibake', () {
+      final result = fr.monthReviewSavedMore('50');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('mealTotalCost shows € not mojibake', () {
+      final result = fr.mealTotalCost('12');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('wizardSettingsInfo shows → arrow not mojibake', () {
+      expect(fr.wizardSettingsInfo, contains('→'));
+      expect(fr.wizardSettingsInfo, isNot(matches(mojibakePattern)));
+    });
+
+    test('settingsSubsidyHoliday shows NOËL not mojibake', () {
+      expect(fr.settingsSubsidyHoliday, contains('NOËL'));
+      expect(fr.settingsSubsidyHoliday, isNot(matches(mojibakePattern)));
+    });
+
+    test('onbSlide0Title shows œ not mojibake', () {
+      expect(fr.onbSlide0Title, contains('œil'));
+      expect(fr.onbSlide0Title, isNot(matches(mojibakePattern)));
+    });
+
+    test('taxSimPresetRaise shows € not mojibake', () {
+      expect(fr.taxSimPresetRaise, contains('€'));
+      expect(fr.taxSimPresetRaise, isNot(matches(mojibakePattern)));
+    });
+  });
+}


### PR DESCRIPTION
## Resumo

fr: corrige mojibake (UTF-8 mal decodificado) em € / œ / Ë / → em 7 chaves de app_fr.arb

## O que mudou

- `lib/l10n/app_fr.arb`: corrigidas as 7 chaves com corrupção de codificação (UTF-8 reinterpretado como Latin-1/Windows-1252 e regravado) identificadas no issue:
  - `monthReviewExpensesExceeded` (L134): `ââ€šÂ¬` → `€`.
  - `monthReviewSavedMore` (L142): `ââ€šÂ¬` → `€`.
  - `mealTotalCost` (L753): `ââ€šÂ¬` → `€`.
  - `wizardSettingsInfo` (L832): `ââ€ ’` (com um non-breaking space escondido no meio) → `→`.
  - `settingsSubsidyHoliday` (L915): `NOÃ‹L` → `NOËL`.
  - `onbSlide0Title` (L1711): `d'Ã…“il` → `d'œil`.
  - `taxSimPresetRaise` (L1855): `+ââ€šÂ¬200` → `+€200`.
- `lib/l10n/generated/app_localizations_fr.dart`: regenerado via `flutter gen-l10n` — reflete as 7 correcções acima (ficheiro está versionado no repo, não está no `.gitignore`).
- `test/screens/fr_encoding_mojibake_1232_test.dart` (novo): 7 testes, um por chave, que verificam o carácter correcto presente e que nenhuma string corresponde ao padrão regex de mojibake `(Ã.|â€.|ââ€)`.

## Porque assim

Segui o plano do curator/critic tal como descrito no issue: substituição directa das sequências corrompidas pelos caracteres correctos, sem tocar nas restantes locales.

Para `wizardSettingsInfo`, confirmei o carácter correcto (`→`, U+2192) comparando com `app_en.arb`/`app_pt.arb` como pedia o critério de aceitação — aí a sequência é `â†’`, cujos bytes UTF-8 (`c3 a2 e2 80 a0 e2 80 99` → codepoints â, †, ’) decodificam exactamente para os bytes UTF-8 de `→` (E2 86 92) se reinterpretados como Windows-1252. Isto confirma que a seta original era `→`, seguindo o padrão 'Settings → Meals' / 'Definições → Refeições' visível nas outras locales.

Durante a substituição descobri que a sequência corrompida em `wizardSettingsInfo` continha um non-breaking space (U+00A0) invisível entre `€` e `’`, o que fez a primeira tentativa com a ferramenta de edição de texto falhar por não-correspondência exacta; resolvi com substituição byte-a-byte em Python para garantir precisão.

**Nota fora do âmbito deste issue**: ao correr o grep de smoke test pedido (`grep -rnE "(Ã.|â€.|ââ€)" lib/l10n/*.arb`) confirmei que a corrupção não se repete no resto de `app_fr.arb`, mas descobri que `app_en.arb`, `app_pt.arb` e `app_es.arb` têm o mesmo padrão de mojibake em `wizardSettingsInfo` (`â†’` em vez de `→`) e possivelmente noutras chaves — não investiguei exaustivamente porque o critério de aceitação deste issue proíbe alterar outras locales ('Nenhuma outra locale foi alterada por este fix'). Recomendo abrir um issue de seguimento para as restantes locales.

## Critérios de aceitação

- [x] `grep -nE "(Ã.|â€.|ââ€)" lib/l10n/app_fr.arb` devolve zero resultados após a correcção — confirmado (exit code 1, sem matches).
- [x] As 7 chaves mostram o carácter correcto (`€`, `Ë`, `œ`, `→`) — confirmado via `flutter gen-l10n` + leitura directa do `.arb` e do `.dart` gerado.
- [x] `wizardSettingsInfo` foi confirmado contra `app_en.arb`/`app_pt.arb` antes de decidir o carácter substituto (`→`) — feito, ver secção "Porque assim".
- [x] `app_fr.arb` gravado em UTF-8 sem BOM — confirmado (`file` reporta "JSON text data"; leitura dos 3 primeiros bytes não é o BOM `EF BB BF`).
- [x] Nenhuma outra locale foi alterada — confirmado via `git status --short`: só `app_fr.arb` e o `app_localizations_fr.dart` gerado (específico do francês) mudaram.

## Testes

- Novo: `test/screens/fr_encoding_mojibake_1232_test.dart` (7 testes) — verifiquei empiricamente que falham com o `.arb` antigo (fiz `git stash` da correcção, regenerei `flutter gen-l10n`, corri os testes: 2 falharam com os valores mojibake exactos no output de erro) e passam com a correcção (`git stash pop` + regeneração).
- Suite completa: `flutter test` → **2406 passaram, 0 falharam** (2399 pré-existentes + 7 novos).
- `flutter analyze --no-fatal-infos --no-fatal-warnings`: sem issues novos (78 issues pré-existentes, nenhum nos ficheiros tocados).

## Testes

2406 passaram, 0 falharam

## Linked Issue

Fixes #1232