### PR TITLE
QA: promover dev para main (3 commit(s))

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -131,7 +131,7 @@
             }
         }
     },
-    "monthReviewExpensesExceeded": "Les dépenses réelles ont dépassé le prévu de {amount}ââ€šÂ¬ — ajuster les valeurs dans les paramètres ?",
+    "monthReviewExpensesExceeded": "Les dépenses réelles ont dépassé le prévu de {amount}€ — ajuster les valeurs dans les paramètres ?",
     "@monthReviewExpensesExceeded": {
         "placeholders": {
             "amount": {
@@ -139,7 +139,7 @@
             }
         }
     },
-    "monthReviewSavedMore": "Économisé {amount}ââ€šÂ¬ de plus que prévu — vous pouvez renforcer le fonds d'urgence.",
+    "monthReviewSavedMore": "Économisé {amount}€ de plus que prévu — vous pouvez renforcer le fonds d'urgence.",
     "@monthReviewSavedMore": {
         "placeholders": {
             "amount": {
@@ -750,7 +750,7 @@
     "mealConsolidatedList": "Voir la liste consolidée",
     "mealConsolidatedTitle": "Liste Consolidée",
     "mealAlternatives": "Alternatives",
-    "mealTotalCost": "{cost}ââ€šÂ¬ total",
+    "mealTotalCost": "{cost}€ total",
     "@mealTotalCost": {
         "placeholders": {
             "cost": {
@@ -829,7 +829,7 @@
     "wizardNoLimit": "Sans limite",
     "wizardMinimizeWaste": "Minimiser le gaspillage",
     "wizardMinimizeWasteDesc": "Préférer les recettes réutilisant des ingrédients déjà utilisés",
-    "wizardSettingsInfo": "Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres ââ€ ’ Repas.",
+    "wizardSettingsInfo": "Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres → Repas.",
     "wizardContinue": "Continuer",
     "wizardGeneratePlan": "Générer le Plan",
     "wizardStepOf": "Étape {current} sur {total}",
@@ -912,7 +912,7 @@
     },
     "settingsSalaryActive": "Actif",
     "settingsGrossMonthlySalary": "SALAIRE BRUT MENSUEL",
-    "settingsSubsidyHoliday": "PRIMES DE VACANCES ET NOÃ‹L (DOUZIÈMES)",
+    "settingsSubsidyHoliday": "PRIMES DE VACANCES ET NOËL (DOUZIÈMES)",
     "settingsOtherExemptLabel": "AUTRES REVENUS EXONÉRÉS D'IMPÔT",
     "settingsMealAllowanceLabel": "INDEMNITÉ REPAS",
     "settingsAmountPerDay": "MONTANT/JOUR",
@@ -1708,7 +1708,7 @@
     "onbSkip": "Passer",
     "onbNext": "Suivant",
     "onbGetStarted": "Commencer",
-    "onbSlide0Title": "Votre budget, en un coup d'Ã…“il",
+    "onbSlide0Title": "Votre budget, en un coup d'œil",
     "onbSlide0Body": "Le tableau de bord affiche votre liquidité mensuelle, dépenses et Indice de Sérénité.",
     "onbSlide1Title": "Suivez chaque dépense",
     "onbSlide1Body": "Appuyez sur + pour enregistrer un achat. Assignez une catégorie et regardez les barres se mettre à jour.",
@@ -1852,7 +1852,7 @@
     },
     "taxSimTitle": "Simulateur Fiscal",
     "taxSimPresets": "SCÉNARIOS RAPIDES",
-    "taxSimPresetRaise": "+ââ€šÂ¬200 augmentation",
+    "taxSimPresetRaise": "+€200 augmentation",
     "taxSimPresetMeal": "Carte vs espèces",
     "taxSimPresetTitular": "Conjoint vs séparé",
     "taxSimParameters": "PARAMÈTRES",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -308,12 +308,12 @@ class SFr extends S {
 
   @override
   String monthReviewExpensesExceeded(String amount) {
-    return 'Les dépenses réelles ont dépassé le prévu de $amountââ€šÂ¬ — ajuster les valeurs dans les paramètres ?';
+    return 'Les dépenses réelles ont dépassé le prévu de $amount€ — ajuster les valeurs dans les paramètres ?';
   }
 
   @override
   String monthReviewSavedMore(String amount) {
-    return 'Économisé $amountââ€šÂ¬ de plus que prévu — vous pouvez renforcer le fonds d\'urgence.';
+    return 'Économisé $amount€ de plus que prévu — vous pouvez renforcer le fonds d\'urgence.';
   }
 
   @override
@@ -1323,7 +1323,7 @@ class SFr extends S {
 
   @override
   String mealTotalCost(String cost) {
-    return '$costââ€šÂ¬ total';
+    return '$cost€ total';
   }
 
   @override
@@ -1470,7 +1470,7 @@ class SFr extends S {
 
   @override
   String get wizardSettingsInfo =>
-      'Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres ââ€ ’ Repas.';
+      'Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres → Repas.';
 
   @override
   String get wizardContinue => 'Continuer';
@@ -1655,8 +1655,7 @@ class SFr extends S {
   String get settingsGrossMonthlySalary => 'SALAIRE BRUT MENSUEL';
 
   @override
-  String get settingsSubsidyHoliday =>
-      'PRIMES DE VACANCES ET NOÃ‹L (DOUZIÈMES)';
+  String get settingsSubsidyHoliday => 'PRIMES DE VACANCES ET NOËL (DOUZIÈMES)';
 
   @override
   String get settingsOtherExemptLabel => 'AUTRES REVENUS EXONÉRÉS D\'IMPÔT';
@@ -3207,7 +3206,7 @@ class SFr extends S {
   String get onbGetStarted => 'Commencer';
 
   @override
-  String get onbSlide0Title => 'Votre budget, en un coup d\'Ã…“il';
+  String get onbSlide0Title => 'Votre budget, en un coup d\'œil';
 
   @override
   String get onbSlide0Body =>
@@ -3528,7 +3527,7 @@ class SFr extends S {
   String get taxSimPresets => 'SCÉNARIOS RAPIDES';
 
   @override
-  String get taxSimPresetRaise => '+ââ€šÂ¬200 augmentation';
+  String get taxSimPresetRaise => '+€200 augmentation';
 
   @override
   String get taxSimPresetMeal => 'Carte vs espèces';

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -678,12 +678,15 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       children: [
                         CalmEyebrow(l10n.expenseTrackerThisMonthEyebrow),
                         const SizedBox(height: 4),
-                        Text(
-                          formatCurrency(totalActual),
-                          style: CalmText.amount(context,
-                              size: 22, weight: FontWeight.w600),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            formatCurrency(totalActual),
+                            style: CalmText.amount(context,
+                                size: 22, weight: FontWeight.w600),
+                            maxLines: 1,
+                          ),
                         ),
                       ],
                     ),
@@ -701,12 +704,15 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       children: [
                         CalmEyebrow(l10n.expenseTrackerAvgPerDayEyebrow),
                         const SizedBox(height: 4),
-                        Text(
-                          _avgPerDay(totalActual),
-                          style: CalmText.amount(context,
-                              size: 22, weight: FontWeight.w600),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            _avgPerDay(totalActual),
+                            style: CalmText.amount(context,
+                                size: 22, weight: FontWeight.w600),
+                            maxLines: 1,
+                          ),
                         ),
                       ],
                     ),

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -753,21 +753,29 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       : AppColors.ok(context),
                 ),
                 const SizedBox(width: 8),
-                Text(
-                  isOver
-                      ? l10n.expenseTrackerOver
-                      : l10n.expenseTrackerRemaining,
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.ink70(context),
+                Flexible(
+                  child: Text(
+                    isOver
+                        ? l10n.expenseTrackerOver
+                        : l10n.expenseTrackerRemaining,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink70(context),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 const Spacer(),
-                Text(
-                  l10n.expenseTrackerBudgetedLabel(formatCurrency(totalBudgeted)),
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.ink50(context),
+                Flexible(
+                  child: Text(
+                    l10n.expenseTrackerBudgetedLabel(formatCurrency(totalBudgeted)),
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink50(context),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 InfoIconButton(

--- a/monthy_budget_flutter/lib/widgets/calm/calm_tile.dart
+++ b/monthy_budget_flutter/lib/widgets/calm/calm_tile.dart
@@ -56,12 +56,18 @@ class CalmTile extends StatelessWidget {
         children: [
           Icon(icon, size: 24, color: AppColors.ink(context)),
           const SizedBox(height: 12),
-          Text(
-            label,
-            style: GoogleFonts.inter(
-              fontSize: 15,
-              fontWeight: FontWeight.w600,
-              color: AppColors.ink(context),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              label,
+              maxLines: 1,
+              softWrap: false,
+              style: GoogleFonts.inter(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: AppColors.ink(context),
+              ),
             ),
           ),
           const SizedBox(height: 2),

--- a/monthy_budget_flutter/test/screens/expense_tracker_budget_row_1203_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_budget_row_1203_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/widgets/info_icon_button.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding: at 360px viewport width, the budget summary
+  // row's InfoIconButton was pushed off-screen by the fixed-width children
+  // (pill + status text + budgeted-amount text) with no Flexible/Expanded to
+  // absorb the compression. See lib/screens/expense_tracker_screen.dart:745.
+  testWidgets(
+    'InfoIconButton stays fully within screen bounds at 360px width (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Mirrors the exact repro numbers from the issue: "-128,95 € Acima do
+      // orçamento orç. 1 871,50 €".
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 1871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 2000.45,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(360));
+
+      // The a11y tap target must stay at least 44x44.
+      expect(bottomRight.dx - topLeft.dx, greaterThanOrEqualTo(44));
+      expect(bottomRight.dy - topLeft.dy, greaterThanOrEqualTo(44));
+
+      // The pill ("-128,95 €") must still be fully rendered (not the
+      // budgeted-amount text, which is allowed to ellipsize).
+      expect(find.textContaining('-128,95'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'InfoIconButton stays visible at 360px even with a longer budgeted amount (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Keep the per-category remaining small (actual close to budgeted) so
+      // only the summary row's totals are long — this isolates the case
+      // under test from the unrelated category-row layout.
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 12871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 12871,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(360));
+    },
+  );
+
+  testWidgets(
+    'InfoIconButton stays fully visible at 430px width and budgeted text is unchanged (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(430, 900);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Same fixture as the "longer budgeted amount" case above: keeps the
+      // per-category remaining small so only this test's assertions (on the
+      // summary row) are exercised, independent of the unrelated
+      // category-row layout.
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 12871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 12871,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(430));
+
+      // On the wider viewport there's enough room, so the budgeted-amount
+      // text renders in full (no ellipsis needed). Match on the l10n
+      // prefix + amount fragment rather than the exact separator glyph
+      // (NumberFormat may use a non-breaking thousands separator).
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Text &&
+              (widget.data ?? '').startsWith('budget') &&
+              (widget.data ?? '').contains('871,50'),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}

--- a/monthy_budget_flutter/test/screens/expense_tracker_stat_cards_1201_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_stat_cards_1201_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/onboarding/expense_tracker_tour.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/utils/formatters.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding: the 'Este Mês' and 'Média/Dia' stat cards
+  // truncated the amount with an ellipsis on narrow viewports because the
+  // value Text used a fixed 22px style with maxLines: 1 +
+  // TextOverflow.ellipsis inside an Expanded slice of a 3-card Row that
+  // doesn't have room for long currency strings. See
+  // lib/screens/expense_tracker_screen.dart:665-738.
+  Future<void> pumpStatsRow(WidgetTester tester, Size size) async {
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+
+    final settings = makeSettings(
+      expenses: [
+        makeExpense(id: 'exp_1', category: 'habitacao', amount: 2500),
+      ],
+    );
+    final actual = makeActualExpense(
+      id: 'ae_1',
+      category: 'habitacao',
+      amount: 2000.45,
+    );
+
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        ExpenseTrackerScreen(
+          settings: settings,
+          expenses: [actual],
+          householdId: 'house-1',
+          onAdd: (_) async {},
+          onUpdate: (_) async {},
+          onDelete: (_) async {},
+          onLoadMonth: (_) async => [actual],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // Scoped to the summary Row (key: ExpenseTrackerTourKeys.summary) because
+  // the same formatted amount can also appear in the category list below
+  // (e.g. a single-category fixture shows the same total there at a smaller
+  // font size) — without scoping, `find.text` matches more than one widget.
+  Text findAmountText(WidgetTester tester, String expectedData) {
+    final finder = find.descendant(
+      of: find.byKey(ExpenseTrackerTourKeys.summary),
+      matching: find.byWidgetPredicate(
+        (widget) => widget is Text && widget.data == expectedData,
+      ),
+    );
+    expect(
+      finder,
+      findsOneWidget,
+      reason:
+          "expected the full value '$expectedData' to be rendered in the "
+          'summary row (Text.data is never truncated by FittedBox/ellipsis, '
+          "so this only fails if the wrong amount was formatted)",
+    );
+    return tester.widget<Text>(finder);
+  }
+
+  for (final size in [const Size(360, 640), const Size(430, 932)]) {
+    testWidgets(
+      "'Este Mês' and 'Média/Dia' stat cards render the full amount via "
+      'FittedBox instead of ellipsis at ${size.width.toInt()}px (#1201)',
+      (tester) async {
+        await pumpStatsRow(tester, size);
+
+        final expectedThisMonth = formatCurrency(2000.45);
+        final now = DateTime.now();
+        final elapsedDays = now.day.clamp(1, 31);
+        final expectedAvg = formatCurrency(2000.45 / elapsedDays);
+
+        final summaryText = find.descendant(
+          of: find.byKey(ExpenseTrackerTourKeys.summary),
+          matching: find.text(expectedThisMonth),
+        );
+        final thisMonthText = findAmountText(tester, expectedThisMonth);
+        expect(thisMonthText.overflow, isNot(TextOverflow.ellipsis));
+        expect(
+          find.ancestor(of: summaryText, matching: find.byType(FittedBox)),
+          findsOneWidget,
+          reason: "'Este Mês' value must be wrapped in a FittedBox so it "
+              'scales down instead of truncating',
+        );
+
+        final summaryAvgText = find.descendant(
+          of: find.byKey(ExpenseTrackerTourKeys.summary),
+          matching: find.text(expectedAvg),
+        );
+        final avgText = findAmountText(tester, expectedAvg);
+        expect(avgText.overflow, isNot(TextOverflow.ellipsis));
+        expect(
+          find.ancestor(of: summaryAvgText, matching: find.byType(FittedBox)),
+          findsOneWidget,
+          reason: "'Média/Dia' value must be wrapped in a FittedBox so it "
+              'scales down instead of truncating',
+        );
+
+        // 'Contas' (the 3rd card) is untouched: its count text stays a
+        // plain Text, not wrapped in FittedBox.
+        final billsCountFinder = find.descendant(
+          of: find.byKey(ExpenseTrackerTourKeys.summary),
+          matching: find.text('1'),
+        );
+        expect(billsCountFinder, findsOneWidget);
+        expect(
+          find.ancestor(
+            of: billsCountFinder,
+            matching: find.byType(FittedBox),
+          ),
+          findsNothing,
+          reason: "the 'Contas' card must keep its current behavior — no "
+              'FittedBox wrap',
+        );
+
+        // No RenderFlex overflow or other rendering exception.
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets(
+    "'Este Mês' value keeps the original 22px/w600 style on the tablet "
+    'viewport, i.e. FittedBox does not shrink text that already fits (#1201)',
+    (tester) async {
+      await pumpStatsRow(tester, const Size(768, 1024));
+
+      final expectedThisMonth = formatCurrency(2000.45);
+      final thisMonthText = findAmountText(tester, expectedThisMonth);
+      expect(thisMonthText.style?.fontSize, 22);
+      expect(thisMonthText.style?.fontWeight, FontWeight.w600);
+      expect(thisMonthText.overflow, isNot(TextOverflow.ellipsis));
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/monthy_budget_flutter/test/screens/fr_encoding_mojibake_1232_test.dart
+++ b/monthy_budget_flutter/test/screens/fr_encoding_mojibake_1232_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_fr.dart';
+
+void main() {
+  late SFr fr;
+  setUpAll(() {
+    fr = SFr();
+  });
+
+  group('app_fr.arb mojibake fix (#1232)', () {
+    // Bytes that only ever appear when a UTF-8 string got mis-decoded as
+    // Latin-1/Windows-1252 and re-encoded — the mojibake pattern this issue
+    // fixes. None of the corrected strings below should contain them.
+    final mojibakePattern = RegExp(r'(Ã.|â€.|ââ€)');
+
+    test('monthReviewExpensesExceeded shows € not mojibake', () {
+      final result = fr.monthReviewExpensesExceeded('50');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('monthReviewSavedMore shows € not mojibake', () {
+      final result = fr.monthReviewSavedMore('50');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('mealTotalCost shows € not mojibake', () {
+      final result = fr.mealTotalCost('12');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('wizardSettingsInfo shows → arrow not mojibake', () {
+      expect(fr.wizardSettingsInfo, contains('→'));
+      expect(fr.wizardSettingsInfo, isNot(matches(mojibakePattern)));
+    });
+
+    test('settingsSubsidyHoliday shows NOËL not mojibake', () {
+      expect(fr.settingsSubsidyHoliday, contains('NOËL'));
+      expect(fr.settingsSubsidyHoliday, isNot(matches(mojibakePattern)));
+    });
+
+    test('onbSlide0Title shows œ not mojibake', () {
+      expect(fr.onbSlide0Title, contains('œil'));
+      expect(fr.onbSlide0Title, isNot(matches(mojibakePattern)));
+    });
+
+    test('taxSimPresetRaise shows € not mojibake', () {
+      expect(fr.taxSimPresetRaise, contains('€'));
+      expect(fr.taxSimPresetRaise, isNot(matches(mojibakePattern)));
+    });
+  });
+}

--- a/monthy_budget_flutter/test/widgets/calm/calm_wave_t_widgets_test.dart
+++ b/monthy_budget_flutter/test/widgets/calm/calm_wave_t_widgets_test.dart
@@ -101,6 +101,41 @@ void main() {
     expect(fired, isTrue);
   });
 
+  testWidgets('CalmTile scales down a long label instead of wrapping mid-word',
+      (tester) async {
+    await tester.pumpWidget(light(
+      const Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          child: CalmTile(
+            icon: Icons.kitchen,
+            label: 'Despensa',
+            count: '12 itens',
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final textFinder = find.text('Despensa');
+    expect(textFinder, findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    // Estrutural: o label tem de estar dentro de um FittedBox — sem isto,
+    // find.text() sozinho não distingue 'quebrado a meio' de 'escalado'.
+    expect(
+      find.ancestor(of: textFinder, matching: find.byType(FittedBox)),
+      findsOneWidget,
+    );
+
+    // Comportamental: softWrap/maxLines têm de impedir uma segunda linha —
+    // é isto que impede a quebra a meio da palavra, não o FittedBox sozinho.
+    final textWidget = tester.widget<Text>(textFinder);
+    expect(textWidget.softWrap, isFalse);
+    expect(textWidget.maxLines, 1);
+  });
+
   // ── CalmMealRow ──────────────────────────────────────────────────────────
 
   testWidgets('CalmMealRow renders', (tester) async {


### PR DESCRIPTION
## Summary

Promoção automática de `dev` para `main`: 3 commit(s)
com correções que passaram review **e** verificação de QA na app a correr.

## Release Notes

- Merge remote-tracking branch 'origin/main' into HEAD
- qa/issue-1232: fr: corrige mojibake (UTF-8 mal decodificado) em € / œ / Ë / → em 7 chaves de app_fr.arb (#1232) (#1239)
- qa/issue-1203: Torna o texto de estado do orçamento e o texto orçamentado Flexible+ellipsis para o InfoIconButton nunca sair do ecrã a 360px (#1203) (#1207)
- Envolver o label do CalmTile em FittedBox para 'Despensa' não partir a meio a 360px (#1204) (#1205)

## Linked Issue

Fixes #1203
Fixes #1204
Fixes #1205
Fixes #1207
Fixes #1232
Fixes #1239