### PR TITLE
Fix ellipsis truncation of 'Este Mês'/'Média/Dia' amounts on narrow viewports with FittedBox scale-down (#1201)

### DIFF
--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -678,12 +678,15 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       children: [
                         CalmEyebrow(l10n.expenseTrackerThisMonthEyebrow),
                         const SizedBox(height: 4),
-                        Text(
-                          formatCurrency(totalActual),
-                          style: CalmText.amount(context,
-                              size: 22, weight: FontWeight.w600),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            formatCurrency(totalActual),
+                            style: CalmText.amount(context,
+                                size: 22, weight: FontWeight.w600),
+                            maxLines: 1,
+                          ),
                         ),
                       ],
                     ),
@@ -701,12 +704,15 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       children: [
                         CalmEyebrow(l10n.expenseTrackerAvgPerDayEyebrow),
                         const SizedBox(height: 4),
-                        Text(
-                          _avgPerDay(totalActual),
-                          style: CalmText.amount(context,
-                              size: 22, weight: FontWeight.w600),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            _avgPerDay(totalActual),
+                            style: CalmText.amount(context,
+                                size: 22, weight: FontWeight.w600),
+                            maxLines: 1,
+                          ),
                         ),
                       ],
                     ),

--- a/monthy_budget_flutter/test/screens/expense_tracker_stat_cards_1201_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_stat_cards_1201_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/onboarding/expense_tracker_tour.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/utils/formatters.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding: the 'Este Mês' and 'Média/Dia' stat cards
+  // truncated the amount with an ellipsis on narrow viewports because the
+  // value Text used a fixed 22px style with maxLines: 1 +
+  // TextOverflow.ellipsis inside an Expanded slice of a 3-card Row that
+  // doesn't have room for long currency strings. See
+  // lib/screens/expense_tracker_screen.dart:665-738.
+  Future<void> pumpStatsRow(WidgetTester tester, Size size) async {
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+
+    final settings = makeSettings(
+      expenses: [
+        makeExpense(id: 'exp_1', category: 'habitacao', amount: 2500),
+      ],
+    );
+    final actual = makeActualExpense(
+      id: 'ae_1',
+      category: 'habitacao',
+      amount: 2000.45,
+    );
+
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        ExpenseTrackerScreen(
+          settings: settings,
+          expenses: [actual],
+          householdId: 'house-1',
+          onAdd: (_) async {},
+          onUpdate: (_) async {},
+          onDelete: (_) async {},
+          onLoadMonth: (_) async => [actual],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // Scoped to the summary Row (key: ExpenseTrackerTourKeys.summary) because
+  // the same formatted amount can also appear in the category list below
+  // (e.g. a single-category fixture shows the same total there at a smaller
+  // font size) — without scoping, `find.text` matches more than one widget.
+  Text findAmountText(WidgetTester tester, String expectedData) {
+    final finder = find.descendant(
+      of: find.byKey(ExpenseTrackerTourKeys.summary),
+      matching: find.byWidgetPredicate(
+        (widget) => widget is Text && widget.data == expectedData,
+      ),
+    );
+    expect(
+      finder,
+      findsOneWidget,
+      reason:
+          "expected the full value '$expectedData' to be rendered in the "
+          'summary row (Text.data is never truncated by FittedBox/ellipsis, '
+          "so this only fails if the wrong amount was formatted)",
+    );
+    return tester.widget<Text>(finder);
+  }
+
+  for (final size in [const Size(360, 640), const Size(430, 932)]) {
+    testWidgets(
+      "'Este Mês' and 'Média/Dia' stat cards render the full amount via "
+      'FittedBox instead of ellipsis at ${size.width.toInt()}px (#1201)',
+      (tester) async {
+        await pumpStatsRow(tester, size);
+
+        final expectedThisMonth = formatCurrency(2000.45);
+        final now = DateTime.now();
+        final elapsedDays = now.day.clamp(1, 31);
+        final expectedAvg = formatCurrency(2000.45 / elapsedDays);
+
+        final summaryText = find.descendant(
+          of: find.byKey(ExpenseTrackerTourKeys.summary),
+          matching: find.text(expectedThisMonth),
+        );
+        final thisMonthText = findAmountText(tester, expectedThisMonth);
+        expect(thisMonthText.overflow, isNot(TextOverflow.ellipsis));
+        expect(
+          find.ancestor(of: summaryText, matching: find.byType(FittedBox)),
+          findsOneWidget,
+          reason: "'Este Mês' value must be wrapped in a FittedBox so it "
+              'scales down instead of truncating',
+        );
+
+        final summaryAvgText = find.descendant(
+          of: find.byKey(ExpenseTrackerTourKeys.summary),
+          matching: find.text(expectedAvg),
+        );
+        final avgText = findAmountText(tester, expectedAvg);
+        expect(avgText.overflow, isNot(TextOverflow.ellipsis));
+        expect(
+          find.ancestor(of: summaryAvgText, matching: find.byType(FittedBox)),
+          findsOneWidget,
+          reason: "'Média/Dia' value must be wrapped in a FittedBox so it "
+              'scales down instead of truncating',
+        );
+
+        // 'Contas' (the 3rd card) is untouched: its count text stays a
+        // plain Text, not wrapped in FittedBox.
+        final billsCountFinder = find.descendant(
+          of: find.byKey(ExpenseTrackerTourKeys.summary),
+          matching: find.text('1'),
+        );
+        expect(billsCountFinder, findsOneWidget);
+        expect(
+          find.ancestor(
+            of: billsCountFinder,
+            matching: find.byType(FittedBox),
+          ),
+          findsNothing,
+          reason: "the 'Contas' card must keep its current behavior — no "
+              'FittedBox wrap',
+        );
+
+        // No RenderFlex overflow or other rendering exception.
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets(
+    "'Este Mês' value keeps the original 22px/w600 style on the tablet "
+    'viewport, i.e. FittedBox does not shrink text that already fits (#1201)',
+    (tester) async {
+      await pumpStatsRow(tester, const Size(768, 1024));
+
+      final expectedThisMonth = formatCurrency(2000.45);
+      final thisMonthText = findAmountText(tester, expectedThisMonth);
+      expect(thisMonthText.style?.fontSize, 22);
+      expect(thisMonthText.style?.fontWeight, FontWeight.w600);
+      expect(thisMonthText.overflow, isNot(TextOverflow.ellipsis));
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+}


### PR DESCRIPTION
## Resumo

Fix ellipsis truncation of 'Este Mês'/'Média/Dia' amounts on narrow viewports with FittedBox scale-down

## O que mudou

Em `lib/screens/expense_tracker_screen.dart`, nos dois `Text` de valor monetário dos cartões 'Este Mês' (linhas ~681-687) e 'Média/Dia' (linhas ~704-710) da linha de estatísticas do ecrã Despesas:

- Envolvi cada `Text` num `FittedBox(fit: BoxFit.scaleDown, alignment: Alignment.centerLeft, ...)`.
- Removi `overflow: TextOverflow.ellipsis` de ambos (mantendo `maxLines: 1`).

O cartão 'Contas' (terceiro) e o `Row`/`Expanded`/`SizedBox(width: 8)` do layout não foram tocados.

## Porque assim

Segui exactamente o plano do curator: o valor não cabia nos ~73px disponíveis por cartão em viewports estreitos (360/430px), e `TextOverflow.ellipsis` cortava o texto em vez de o encolher. `FittedBox` com `BoxFit.scaleDown` reduz a escala do texto só quando não cabe — em viewports largos (tablet, 768px) onde já cabia a 22px, o comportamento visual não muda. Este é o mesmo padrão já usado em `lib/widgets/calm/calm_tile.dart:59-65`.

## Critérios de aceitação

- [x] Small (360×640): 'Este Mês' mostra o valor completo sem reticências — coberto por teste que verifica `Text.data` completo + ausência de `TextOverflow.ellipsis` + presença de `FittedBox`.
- [x] Small (360×640): 'Média/Dia' mostra o valor completo sem reticências — idem.
- [x] Phone (430×932): ambos os cartões mostram os valores completos — mesmo teste parametrizado para 430×932.
- [x] Tablet (768px): tamanho do texto mantém-se 22px/w600 — teste dedicado verifica `style.fontSize == 22` e `style.fontWeight == FontWeight.w600` nesse viewport.
- [x] Cartão 'Contas' inalterado — teste verifica que o `Text` da contagem não tem `FittedBox` como ancestral.
- [x] Nenhum overflow visual introduzido — `tester.takeException()` verificado como `null` em todos os viewports testados.
- [x] Layout dos 3 cartões (larguras iguais, gaps 8px) inalterado — não mexi no `Row`/`Expanded`/`SizedBox`.

## Testes

Criei `test/screens/expense_tracker_stat_cards_1201_test.dart` com 3 testes:

1. Parametrizado para 360×640 e 430×932: verifica que o valor completo formatado ('Este Mês' e 'Média/Dia') está presente na árvore, sem `TextOverflow.ellipsis`, envolvido por `FittedBox`; confirma que o cartão 'Contas' não foi afectado; confirma ausência de excepções de renderização.
2. Um teste para 768×1024: confirma que o estilo do texto de 'Este Mês' permanece a 22px/w600, sem ellipsis.

Verifiquei que os 3 testes falham sem o fix (fiz `git stash` só do ficheiro de produção e corri a suite: as 3 falhas mostram `RenderFlex overflow`/ausência de `FittedBox`/`TextOverflow.ellipsis` presente) e passam com o fix aplicado — confirma que o teste apanha a regressão.

Resultado da suite completa: **2409 testes passaram, 0 falharam.**

## Testes

2409 passaram, 0 falharam (flutter test completo); novo ficheiro test/screens/expense_tracker_stat_cards_1201_test.dart com 3 testes, verificados a falhar sem o fix e a passar com o fix

## Linked Issue

Fixes #1201