### PR TITLE
Erro de categoria em falta passa a ser inline no formulário de despesa, em vez de um SnackBar escondido atrás do sheet (#1209)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -1422,6 +1422,7 @@
     "addExpenseDescription": "Description (optional)",
     "addExpenseCustomCategory": "Custom category",
     "addExpenseInvalidAmount": "Enter a valid amount",
+    "addExpenseCategoryRequired": "Select a category",
     "addExpenseTooltip": "Log expense",
     "addExpenseItem": "Expense",
     "addExpenseOthers": "Others",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -1316,6 +1316,7 @@
     "addExpenseDescription": "Descripción (opcional)",
     "addExpenseCustomCategory": "Categoría personalizada",
     "addExpenseInvalidAmount": "Introduce un importe válido",
+    "addExpenseCategoryRequired": "Selecciona una categoría",
     "addExpenseTooltip": "Registrar gasto",
     "addExpenseItem": "Gasto",
     "addExpenseOthers": "Otros",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -1316,6 +1316,7 @@
     "addExpenseDescription": "Description (facultatif)",
     "addExpenseCustomCategory": "Catégorie personnalisée",
     "addExpenseInvalidAmount": "Entrez un montant valide",
+    "addExpenseCategoryRequired": "Sélectionnez une catégorie",
     "addExpenseTooltip": "Saisir une dépense",
     "addExpenseItem": "Dépense",
     "addExpenseOthers": "Autres",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -3171,6 +3171,10 @@
     "@addExpenseInvalidAmount": {
         "description": "Invalid amount error"
     },
+    "addExpenseCategoryRequired": "Selecione uma categoria",
+    "@addExpenseCategoryRequired": {
+        "description": "Missing category error"
+    },
     "addExpenseTooltip": "Registar despesa",
     "@addExpenseTooltip": {
         "description": "FAB tooltip"

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -4589,6 +4589,12 @@ abstract class S {
   /// **'Introduza um valor válido'**
   String get addExpenseInvalidAmount;
 
+  /// Missing category error
+  ///
+  /// In pt, this message translates to:
+  /// **'Selecione uma categoria'**
+  String get addExpenseCategoryRequired;
+
   /// FAB tooltip
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -2481,6 +2481,9 @@ class SEn extends S {
   String get addExpenseInvalidAmount => 'Enter a valid amount';
 
   @override
+  String get addExpenseCategoryRequired => 'Select a category';
+
+  @override
   String get addExpenseTooltip => 'Log expense';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -2493,6 +2493,9 @@ class SEs extends S {
   String get addExpenseInvalidAmount => 'Introduce un importe válido';
 
   @override
+  String get addExpenseCategoryRequired => 'Selecciona una categoría';
+
+  @override
   String get addExpenseTooltip => 'Registrar gasto';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -2497,6 +2497,9 @@ class SFr extends S {
   String get addExpenseInvalidAmount => 'Entrez un montant valide';
 
   @override
+  String get addExpenseCategoryRequired => 'Sélectionnez une catégorie';
+
+  @override
   String get addExpenseTooltip => 'Saisir une dépense';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -2490,6 +2490,9 @@ class SPt extends S {
   String get addExpenseInvalidAmount => 'Introduza um valor válido';
 
   @override
+  String get addExpenseCategoryRequired => 'Selecione uma categoria';
+
+  @override
   String get addExpenseTooltip => 'Registar despesa';
 
   @override

--- a/monthy_budget_flutter/lib/widgets/add_expense_sheet.dart
+++ b/monthy_budget_flutter/lib/widgets/add_expense_sheet.dart
@@ -71,6 +71,7 @@ class _AddExpenseSheet extends StatefulWidget {
 class _AddExpenseSheetState extends State<_AddExpenseSheet> {
   String? _selectedCategory;
   bool _isCustom = false;
+  bool _categoryError = false;
   final _customCategoryController = TextEditingController();
   final _amountController = TextEditingController();
   final _descriptionController = TextEditingController();
@@ -125,6 +126,13 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
     } else {
       _selectedDate = DateTime.now();
     }
+    _customCategoryController.addListener(() {
+      if (_categoryError &&
+          _isCustom &&
+          _customCategoryController.text.trim().isNotEmpty) {
+        setState(() => _categoryError = false);
+      }
+    });
   }
 
   @override
@@ -333,8 +341,11 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
       category = _selectedCategory;
     }
     if (category == null || category.isEmpty) {
-      CalmSnack.error(context, S.of(context).addExpenseCategory);
+      setState(() => _categoryError = true);
       return;
+    }
+    if (_categoryError) {
+      setState(() => _categoryError = false);
     }
 
     final description = _descriptionController.text.trim();
@@ -456,7 +467,9 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                   style: TextStyle(
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
-                    color: AppColors.textSecondary(context),
+                    color: _categoryError
+                        ? AppColors.error(context)
+                        : AppColors.textSecondary(context),
                     letterSpacing: 0.8,
                   )),
               const SizedBox(height: 8),
@@ -478,6 +491,7 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                           _selectedCategory = choice.categoryKey;
                           _isCustom = false;
                           _customCategoryController.clear();
+                          _categoryError = false;
                         });
                       },
                       selectedColor: chipColor != null
@@ -508,6 +522,7 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                       _isCustom = true;
                       _selectedCategory = null;
                       _customCategoryController.clear();
+                      _categoryError = false;
                     }),
                     selectedColor: AppColors.primaryLight(context),
                     side: BorderSide(
@@ -531,6 +546,16 @@ class _AddExpenseSheetState extends State<_AddExpenseSheet> {
                         horizontal: 16, vertical: 12),
                   ),
                   textCapitalization: TextCapitalization.sentences,
+                ),
+              ],
+              if (_categoryError) ...[
+                const SizedBox(height: 6),
+                Text(
+                  l10n.addExpenseCategoryRequired,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: AppColors.error(context),
+                  ),
                 ),
               ],
               const SizedBox(height: 20),

--- a/monthy_budget_flutter/test/widgets/add_expense_sheet_test.dart
+++ b/monthy_budget_flutter/test/widgets/add_expense_sheet_test.dart
@@ -1,8 +1,25 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
 import 'package:monthly_management/models/actual_expense.dart';
 import 'package:monthly_management/widgets/add_expense_sheet.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    locale: const Locale('en'),
+    home: Scaffold(body: child),
+  );
+}
 
 void main() {
   group('ExpenseFormResult', () {
@@ -40,6 +57,97 @@ void main() {
       expect(result.expense.attachmentUrls, ['https://storage/old.jpg']);
       expect(result.newAttachmentFiles, hasLength(2));
       expect(result.newAttachmentFiles.first.path, '/tmp/receipt.jpg');
+    });
+  });
+
+  group('_AddExpenseSheet category validation', () {
+    Future<void> openSheet(WidgetTester tester) async {
+      await tester.pumpWidget(_wrap(Builder(builder: (context) {
+        return ElevatedButton(
+          onPressed: () async {
+            await showAddExpenseSheet(
+              context: context,
+              budgetExpenses: const [],
+              currentExpenses: const [],
+            );
+          },
+          child: const Text('open'),
+        );
+      })));
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    // The sheet's Save button sits below the fold of the (0.65-height)
+    // DraggableScrollableSheet, so it must be scrolled into view before it
+    // can be tapped.
+    Future<void> tapSave(WidgetTester tester) async {
+      await tester.dragUntilVisible(
+        find.text('Save'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        'tapping Save without a category keeps the sheet open and shows an inline error',
+        (tester) async {
+      await openSheet(tester);
+
+      await tester.enterText(find.byType(TextFormField).first, '25');
+      await tapSave(tester);
+
+      // The sheet is still mounted (no pop happened) and the error is
+      // visible inline, not hidden behind the sheet as a SnackBar.
+      expect(find.text('Select a category'), findsOneWidget);
+      expect(find.byType(ChoiceChip), findsWidgets);
+    });
+
+    testWidgets('error persists across repeated Save taps', (tester) async {
+      await openSheet(tester);
+
+      await tester.enterText(find.byType(TextFormField).first, '25');
+      await tapSave(tester);
+      expect(find.text('Select a category'), findsOneWidget);
+
+      await tapSave(tester);
+      expect(find.text('Select a category'), findsOneWidget);
+    });
+
+    testWidgets(
+        'selecting a category chip clears the error and Save then closes the sheet',
+        (tester) async {
+      await openSheet(tester);
+
+      await tester.enterText(find.byType(TextFormField).first, '25');
+      await tapSave(tester);
+      expect(find.text('Select a category'), findsOneWidget);
+
+      await tester.tap(find.byType(ChoiceChip).first);
+      await tester.pumpAndSettle();
+      expect(find.text('Select a category'), findsNothing);
+
+      await tapSave(tester);
+
+      // Sheet closed: its content is no longer in the tree.
+      expect(find.byType(ChoiceChip), findsNothing);
+      expect(find.text('Save'), findsNothing);
+    });
+
+    testWidgets(
+        'selecting the custom category chip also clears a previously shown error',
+        (tester) async {
+      await openSheet(tester);
+
+      await tester.enterText(find.byType(TextFormField).first, '25');
+      await tapSave(tester);
+      expect(find.text('Select a category'), findsOneWidget);
+
+      await tester.tap(find.text('Custom category'));
+      await tester.pumpAndSettle();
+      expect(find.text('Select a category'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Resumo

Erro de categoria em falta passa a ser inline no formulário de despesa, em vez de um SnackBar escondido atrás do sheet

## O que mudou

- `lib/widgets/add_expense_sheet.dart`: adicionado o estado `bool _categoryError`. Em `_save()`, quando não há categoria selecionada, o código já não depende de `CalmSnack.error` (que injeta um `SnackBar` no `ScaffoldMessenger` da página por trás do sheet, invisível enquanto o sheet cobre 65–95% do ecrã) — em vez disso faz `setState(() => _categoryError = true)` e mantém o sheet aberto. O label "Categoria" muda para a cor de erro (`AppColors.error(context)`) enquanto `_categoryError` é `true`, e por baixo do `Wrap` de chips (e do campo de categoria personalizada, quando visível) passa a aparecer um texto de erro `addExpenseCategoryRequired`. `_categoryError` é limpo nos três pontos onde a categoria muda: `onSelected` de cada chip predefinido/existente, `onSelected` do chip "Categoria personalizada", e um listener no `_customCategoryController` que limpa o erro assim que o utilizador escreve texto não vazio numa categoria personalizada.
- `lib/l10n/app_pt.arb`, `app_en.arb`, `app_es.arb`, `app_fr.arb`: nova chave `addExpenseCategoryRequired` ("Selecione uma categoria" / "Select a category" / "Selecciona una categoría" / "Sélectionnez une catégorie"), a seguir a `addExpenseInvalidAmount`, mesmo padrão de string de erro.
- `lib/l10n/generated/*`: regenerados via `flutter gen-l10n` (sem edição manual).
- `test/widgets/add_expense_sheet_test.dart`: adicionado `testWidgets` cobrindo o fluxo (grupo `_AddExpenseSheet category validation`, 4 casos) via `showAddExpenseSheet` dentro de um `MaterialApp`/`Scaffold` de teste real, incluindo scroll até ao botão "Save" com `dragUntilVisible` (o botão está fora do viewport inicial do `DraggableScrollableSheet` a 0.65).

## Porque assim

Segui o plano do curator sem desvios: validação inline em vez de depender do `ScaffoldMessenger`, que é a causa raiz confirmada (o `SnackBar` do erro de categoria é disparado mas fica atrás do próprio sheet modal, exatamente como o de Montante ficaria se o `TextFormField` não já mostrasse erro inline). Mantive o `validator` do campo Montante intocado, como instruído. Não usei `CalmSnack.error` como reforço secundário (a nota do curator diz que é opcional e estruturalmente escondido de qualquer forma) — removi-o para não deixar código morto que sugira que o SnackBar é parte do mecanismo de erro.

## Critérios de aceitação

- [x] Montante válido + sem categoria + "Guardar": sheet continua aberto, secção "Categoria" mostra erro visível — coberto por `add_expense_sheet_test.dart`.
- [x] Erro desaparece ao selecionar qualquer chip (predefinido, personalizada existente, "Categoria personalizada" nova) — coberto pelos 3 `onSelected` + listener do `_customCategoryController`, testado em 2 casos.
- [x] Repetir "Guardar" sem categoria volta a mostrar o erro (não desaparece sozinho) — teste "error persists across repeated Save taps".
- [x] Montante válido + categoria selecionada: "Guardar" fecha o sheet e cria a despesa — teste "selecting a category chip clears the error and Save then closes the sheet".
- [x] Comportamento do Montante inalterado — `validator` da linha 445-452 não foi tocado.
- [x] Editar despesa existente com categoria preenchida não mostra erro ao abrir — `_categoryError` nasce `false` e só `initState` popula `_selectedCategory`/`_isCustom`, nunca `_categoryError`.
- [x] Nova mensagem traduzida em pt/en/es/fr, gerada via `flutter gen-l10n` — confirmado, sem edições manuais em `lib/l10n/generated/`.
- [x] `test/widgets/add_expense_sheet_test.dart` (incluindo os novos `testWidgets`) e toda a suite passam.

## Testes

- `flutter test test/widgets/add_expense_sheet_test.dart`: 6 passaram, 0 falharam (2 testes de modelo pré-existentes + 4 novos `testWidgets`).
- `flutter test` (suite completa): 2413 passaram, 0 falharam.
- `flutter analyze --no-fatal-infos --no-fatal-warnings`: 78 issues, todas pré-existentes e não relacionadas com os ficheiros alterados (confirmado por linha — nenhuma aponta para código novo em `add_expense_sheet.dart` ou `add_expense_sheet_test.dart`).

## Testes

flutter test: 2413 passaram, 0 falharam (inclui 4 novos testWidgets em test/widgets/add_expense_sheet_test.dart)

## Linked Issue

Fixes #1209