### PR TITLE
FAB '+' reserva agora o seu footprint no viewport do scroll em Início e Despesas, em vez de só ter padding no fim da lista (#1202)

### DIFF
--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -215,24 +215,36 @@ class _DashboardScreenState extends State<DashboardScreen> {
       body: RefreshIndicator(
         color: AppColors.ink(context),
         onRefresh: () async => onSnapshotExpenses(),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _buildCalmHeader(context, l10n),
-              const SizedBox(height: 24),
-              if (hasData && dashboardConfig.showHeroCard)
-                _buildHero(context, isPositive, l10n)
-              else if (!hasData)
-                _buildEmptyState(context, l10n),
-              const SizedBox(height: 24),
-              if (hasData) ...[
-                for (final cardId in dashboardConfig.cardOrder)
-                  if (cardId != 'heroCard')
-                    ..._buildCardById(cardId, context, stressResult, monthReview, l10n),
-                const SizedBox(height: 16),
+        child: Padding(
+          // The dashboard tab's FAB (QuickAddLauncher) is injected by the
+          // parent Scaffold in app_home.dart, outside this widget's own
+          // reach — it floats over whatever this scrollable renders in the
+          // bottom-right band. Reserve that footprint here so pre-scroll
+          // content (e.g. TOP CATEGORIAS, VELOCIDADE DE GASTO) never renders
+          // underneath it. Kept inside RefreshIndicator so pull-to-refresh
+          // stays bound to the actual scrollable area.
+          padding: const EdgeInsets.only(
+            bottom: CalmScaffold.fabBottomClearance,
+          ),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildCalmHeader(context, l10n),
+                const SizedBox(height: 24),
+                if (hasData && dashboardConfig.showHeroCard)
+                  _buildHero(context, isPositive, l10n)
+                else if (!hasData)
+                  _buildEmptyState(context, l10n),
+                const SizedBox(height: 24),
+                if (hasData) ...[
+                  for (final cardId in dashboardConfig.cardOrder)
+                    if (cardId != 'heroCard')
+                      ..._buildCardById(cardId, context, stressResult, monthReview, l10n),
+                  const SizedBox(height: 16),
+                ],
               ],
-            ],
+            ),
           ),
         ),
       ),

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -819,7 +819,11 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                   )
                 : _expenses.isEmpty
                 ? _buildEmptyState(l10n)
-                : CustomScrollView(
+                : Padding(
+                    padding: const EdgeInsets.only(
+                      bottom: CalmScaffold.fabBottomClearance,
+                    ),
+                    child: CustomScrollView(
                     key: ExpenseTrackerTourKeys.categoryList,
                     slivers: [
                       // "ALERTAS" card — over-budget categories
@@ -871,7 +875,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                         ),
                       ),
                       SliverPadding(
-                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 80),
+                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
                         sliver: SliverList.builder(
                           itemCount: summaries.length,
                           itemBuilder: (_, i) => CategorySection(
@@ -899,6 +903,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                         ),
                       ),
                     ],
+                    ),
                   ),
           ),
         ],

--- a/monthy_budget_flutter/lib/widgets/calm/calm_scaffold.dart
+++ b/monthy_budget_flutter/lib/widgets/calm/calm_scaffold.dart
@@ -16,6 +16,17 @@ import 'package:monthly_management/theme/app_colors.dart';
 /// - Default `automaticallyImplyLeading` is preserved so the OS back button
 ///   appears on push routes without extra wiring.
 class CalmScaffold extends StatelessWidget {
+  /// Bottom clearance a scrollable body must reserve when a persistent
+  /// `floatingActionButton` floats over it (own or injected by a parent
+  /// `Scaffold`, e.g. the dashboard tab's FAB in `app_home.dart`).
+  ///
+  /// Covers the FAB's ~56dp footprint plus its default margin so early,
+  /// pre-scroll content never renders underneath it. Screens with a FAB
+  /// must wrap their scrollable viewport (not just append trailing list
+  /// padding) in `Padding(bottom: fabBottomClearance)` — trailing padding
+  /// only protects the last item, not content visible before any scroll.
+  static const double fabBottomClearance = 88.0;
+
   const CalmScaffold({
     super.key,
     this.title,

--- a/monthy_budget_flutter/test/screens/dashboard_fab_overlap_1202_test.dart
+++ b/monthy_budget_flutter/test/screens/dashboard_fab_overlap_1202_test.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/local_dashboard_config.dart';
+import 'package:monthly_management/screens/dashboard_screen.dart';
+import 'package:monthly_management/widgets/calm/calm_list_tile.dart';
+import 'package:monthly_management/widgets/calm/calm_pill.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding (#1202): on the 'Início' tab, the FAB '+'
+  // floated over TOP CATEGORIAS rows and the VELOCIDADE DE GASTO pace
+  // badge with NO scroll, on small/phone viewports. Root cause: the FAB
+  // is injected by the parent Scaffold in lib/app_home.dart, outside
+  // DashboardScreen's own reach — its SingleChildScrollView never
+  // reserved that footprint. This harness mirrors app_home.dart's actual
+  // structure (Scaffold + floatingActionButton wrapping the screen's
+  // Expanded content) so the test exercises the real integration, not
+  // just DashboardScreen in isolation.
+  //
+  // Fix: lib/screens/dashboard_screen.dart wraps the SingleChildScrollView
+  // (inside RefreshIndicator) in a Padding(bottom:
+  // CalmScaffold.fabBottomClearance).
+  //
+  // The regression check compares the scrollable viewport's OWN box
+  // against the FAB's box rather than individual card/row rects: a row
+  // that straddles the viewport's bottom edge is still laid out (and
+  // therefore still has a geometric Rect) below that edge even though the
+  // viewport clips it from view — asserting on the viewport's box is what
+  // the fix actually guarantees and avoids false positives from that
+  // clipped, invisible tail.
+  Future<void> pumpDashboardWithFab(WidgetTester tester, Size size) async {
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+
+    final settings = makeSettings();
+    final summary = makeBudgetSummary(
+      totalGross: 2200,
+      totalNet: 1900,
+      totalNetWithMeal: 2000,
+      totalExpenses: 1500,
+      netLiquidity: 500,
+    );
+    final actualExpenses = [
+      makeActualExpense(id: 'ae_1', category: 'alimentacao', amount: 400),
+      makeActualExpense(id: 'ae_2', category: 'transporte', amount: 350),
+      makeActualExpense(id: 'ae_3', category: 'lazer', amount: 300),
+      makeActualExpense(id: 'ae_4', category: 'saude', amount: 250),
+      makeActualExpense(id: 'ae_5', category: 'educacao', amount: 200),
+    ];
+
+    const dashboardConfig = LocalDashboardConfig(
+      showHeroCard: false,
+      showStressIndex: false,
+      showMonthReview: false,
+      showSummaryCards: false,
+      showUpcomingBills: false,
+      showBudgetVsActual: false,
+      showCashFlowForecast: false,
+      showBurnRate: true,
+      showTopCategories: true,
+      showSavingsRate: false,
+      showCoachInsight: false,
+      showQuickActions: false,
+      showSpendingAnomalies: false,
+      cardOrder: ['heroCard', 'burnRate', 'topCategories'],
+    );
+
+    // Mirrors lib/app_home.dart:2337-2354 — the FAB is a sibling of the
+    // screen's Expanded content inside a plain Scaffold, not something
+    // DashboardScreen controls itself.
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        Scaffold(
+          body: Column(
+            children: [
+              Expanded(
+                child: DashboardScreen(
+                  settings: settings,
+                  summary: summary,
+                  purchaseHistory: makePurchaseHistory(),
+                  onOpenSettings: () {},
+                  onSaveSettings: (_) {},
+                  dashboardConfig: dashboardConfig,
+                  expenseHistory: const {},
+                  onSnapshotExpenses: () {},
+                  actualExpenses: actualExpenses,
+                  onAddExpense: () {},
+                  onOpenExpenseTracker: () {},
+                ),
+              ),
+            ],
+          ),
+          floatingActionButton: Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: FloatingActionButton(
+              key: const Key('test_fab'),
+              onPressed: () {},
+              child: const Icon(Icons.add),
+            ),
+          ),
+          floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  for (final size in [const Size(360, 640), const Size(430, 932)]) {
+    testWidgets(
+      'FAB does not overlap the dashboard scroll viewport, and TOP '
+      'CATEGORIAS + the burn-rate pace badge are visible without scroll, '
+      'at ${size.width.toInt()}px (#1202)',
+      (tester) async {
+        await pumpDashboardWithFab(tester, size);
+
+        final fabRect = tester.getRect(find.byKey(const Key('test_fab')));
+        final viewportFinder = find.byType(SingleChildScrollView);
+        expect(viewportFinder, findsOneWidget);
+        final viewportRect = tester.getRect(viewportFinder);
+
+        expect(
+          viewportRect.overlaps(fabRect),
+          isFalse,
+          reason: 'the dashboard scroll viewport must stop above the FAB '
+              'so nothing painted inside it can render underneath the '
+              'button (#1202); viewport=$viewportRect fab=$fabRect',
+        );
+
+        // burnRate is the first card, topCategories the second — both
+        // must start within the visible (pre-scroll) viewport, matching
+        // the bug report (both the pace badge and the category rows were
+        // covered before any scroll).
+        final pillFinder = find.byType(CalmPill);
+        expect(pillFinder, findsOneWidget);
+        expect(
+          tester.getTopLeft(pillFinder).dy,
+          lessThan(viewportRect.bottom),
+          reason: "the burn-rate 'Acima do ritmo'/'A bom ritmo' badge must "
+              'be part of the pre-scroll fold, or this test would not '
+              'exercise the reported bug',
+        );
+
+        // Only the FIRST row is required to be part of the pre-scroll fold
+        // — with 5 categories the list legitimately extends below it, and
+        // rows below the fold simply require scrolling (not a bug; the
+        // bug was specifically about the fold itself, e.g. 'Educação').
+        final rowFinder = find.byType(CalmListTile);
+        expect(
+          rowFinder.evaluate().length,
+          greaterThan(0),
+          reason: 'fixture must produce TOP CATEGORIAS rows',
+        );
+        expect(
+          tester.getTopLeft(rowFinder.first).dy,
+          lessThan(viewportRect.bottom),
+          reason: 'the first TOP CATEGORIAS row must start within the '
+              'pre-scroll fold, or this test would not exercise the '
+              'reported bug',
+        );
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets(
+    'pull-to-refresh still works on the Início tab after the FAB clearance '
+    'fix (#1202)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      var refreshed = false;
+      final settings = makeSettings();
+      // hasData == false (totalGross <= 0) renders the empty state instead
+      // showHeroCard: false avoids a pre-existing overflow in the hero
+      // Row at narrow widths (unrelated to #1202, out of scope for this
+      // fix); burnRate + topCategories give enough content to actually
+      // overflow the viewport so the drag gesture has something to
+      // scroll against.
+      final summary = makeBudgetSummary(totalGross: 2200);
+      final actualExpenses = [
+        makeActualExpense(id: 'ae_1', category: 'alimentacao', amount: 400),
+        makeActualExpense(id: 'ae_2', category: 'transporte', amount: 350),
+        makeActualExpense(id: 'ae_3', category: 'lazer', amount: 300),
+      ];
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          DashboardScreen(
+            settings: settings,
+            summary: summary,
+            purchaseHistory: makePurchaseHistory(),
+            onOpenSettings: () {},
+            onSaveSettings: (_) {},
+            dashboardConfig: const LocalDashboardConfig(
+              showHeroCard: false,
+              cardOrder: ['heroCard', 'burnRate', 'topCategories'],
+            ),
+            expenseHistory: const {},
+            onSnapshotExpenses: () => refreshed = true,
+            actualExpenses: actualExpenses,
+            onAddExpense: () {},
+            onOpenExpenseTracker: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(RefreshIndicator),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+
+      expect(refreshed, isTrue);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/monthy_budget_flutter/test/screens/expense_tracker_fab_overlap_1202_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_fab_overlap_1202_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/onboarding/expense_tracker_tour.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/widgets/expense/expense_alerts_card.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding (#1202): the FAB '+' floated over the ALERTAS
+  // card's first row (the over-budget 'alimentacao' category, analogous to
+  // the reported 'Alimentação +65,60 €' row) with NO scroll, on small/phone
+  // viewports — the '€' symbol was hidden behind the button. Root cause:
+  // the CustomScrollView in lib/screens/expense_tracker_screen.dart never
+  // reserved the FAB's footprint in its OWN viewport height, only the
+  // trailing SliverPadding did, which only protects the last list item.
+  //
+  // Fix: lib/screens/expense_tracker_screen.dart:822 wraps the
+  // CustomScrollView in a Padding(bottom: CalmScaffold.fabBottomClearance),
+  // constraining its viewport instead of only padding after the content.
+  //
+  // The regression check compares the scrollable's OWN box (keyed
+  // ExpenseTrackerTourKeys.categoryList) against the FAB's box rather than
+  // individual row rects: a row that straddles the viewport's bottom edge
+  // is still laid out (and therefore still has a geometric Rect) below
+  // that edge even though the viewport clips it from view — asserting on
+  // the viewport's box is what the fix actually guarantees and avoids
+  // false positives from that clipped, invisible tail.
+  //
+  // Note: rendering a real over-budget category also builds its
+  // lib/widgets/expense/category_section.dart:81 CategorySection row,
+  // which has a pre-existing, width-sensitive RenderFlex overflow
+  // unrelated to #1202 (a CalmPill + Text Row without Flexible/Expanded).
+  // Tests below drain — but do not assert on — render exceptions for that
+  // reason; they are out of scope for this fix.
+  Future<void> pumpScreen(WidgetTester tester, Size size) async {
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+
+    final settings = makeSettings(
+      expenses: [
+        makeExpense(id: 'exp_1', category: 'alimentacao', amount: 100),
+      ],
+    );
+    final actual = makeActualExpense(
+      id: 'ae_1',
+      category: 'alimentacao',
+      amount: 165.60,
+    );
+
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        ExpenseTrackerScreen(
+          settings: settings,
+          expenses: [actual],
+          householdId: 'house-1',
+          onAdd: (_) async {},
+          onUpdate: (_) async {},
+          onDelete: (_) async {},
+          onLoadMonth: (_) async => [actual],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  for (final size in [const Size(360, 640), const Size(430, 932)]) {
+    testWidgets(
+      "FAB does not overlap the category list viewport, and the ALERTAS "
+      'card is visible without scroll, at ${size.width.toInt()}px (#1202)',
+      (tester) async {
+        await pumpScreen(tester, size);
+
+        final fabFinder = find.byKey(ExpenseTrackerTourKeys.addFab);
+        expect(fabFinder, findsOneWidget);
+        final fabRect = tester.getRect(fabFinder);
+
+        final viewportFinder =
+            find.byKey(ExpenseTrackerTourKeys.categoryList);
+        expect(viewportFinder, findsOneWidget);
+        final viewportRect = tester.getRect(viewportFinder);
+
+        expect(
+          viewportRect.overlaps(fabRect),
+          isFalse,
+          reason: 'the category list viewport must stop above the FAB so '
+              'nothing painted inside it can render underneath the button '
+              '(#1202); viewport=$viewportRect fab=$fabRect',
+        );
+
+        // The ALERTAS card (with the over-budget row) is the first sliver,
+        // so it must start within the visible viewport, i.e. it is
+        // pre-scroll content — matching the bug report exactly (the
+        // overlap happened before any scroll).
+        final alertsCardFinder = find.byType(ExpenseAlertsCard);
+        expect(alertsCardFinder, findsOneWidget);
+        final alertsTop = tester.getTopLeft(alertsCardFinder).dy;
+        expect(
+          alertsTop,
+          lessThan(viewportRect.bottom),
+          reason: 'the ALERTAS card must be part of the pre-scroll fold, '
+              'or this test would not exercise the reported bug',
+        );
+
+        // Not asserted — see the pre-existing category_section.dart:81
+        // overflow note above; only drained so it doesn't leak into the
+        // next test.
+        tester.takeException();
+      },
+    );
+  }
+
+  testWidgets(
+    'scrolling to the end of POR CATEGORIA does not push content past the '
+    "viewport's reserved FAB clearance (no regression) at 360px (#1202)",
+    (tester) async {
+      // Reuses the same single-category fixture as the parametrized test
+      // above (proven not to hit the pre-existing, unrelated overflow in
+      // lib/widgets/expense/category_section.dart:81 that a multi-category
+      // fixture triggers at narrow widths) — the invariant under test
+      // (viewport box vs FAB box) is scroll-offset independent by
+      // construction of the fix, so a single category is sufficient to
+      // exercise it before and after a scroll gesture.
+      await pumpScreen(tester, const Size(360, 640));
+
+      final fabRect =
+          tester.getRect(find.byKey(ExpenseTrackerTourKeys.addFab));
+
+      await tester.fling(
+        find.byKey(ExpenseTrackerTourKeys.categoryList),
+        const Offset(0, -1000),
+        3000,
+      );
+      await tester.pumpAndSettle();
+
+      // The viewport's box is a fixed layout constraint, not scroll-offset
+      // dependent — it must stay clear of the FAB before AND after
+      // scrolling, which is exactly what guarantees the last category can
+      // never render underneath the button once scrolled into view.
+      final viewportRect =
+          tester.getRect(find.byKey(ExpenseTrackerTourKeys.categoryList));
+      expect(viewportRect.overlaps(fabRect), isFalse);
+
+      // Not asserted — see the pre-existing category_section.dart:81
+      // overflow note above; only drained so it doesn't fail teardown.
+      tester.takeException();
+    },
+  );
+}


### PR DESCRIPTION
## Resumo

FAB '+' reserva agora o seu footprint no viewport do scroll em Início e Despesas, em vez de só ter padding no fim da lista

## O que mudou

- `lib/widgets/calm/calm_scaffold.dart` — adicionada a constante partilhada `CalmScaffold.fabBottomClearance = 88.0`, documentada, para os dois ecrãs reservarem o mesmo espaço para o FAB em vez de valores ad-hoc.
- `lib/screens/expense_tracker_screen.dart` — o `CustomScrollView` (chave `ExpenseTrackerTourKeys.categoryList`) passou a estar envolvido num `Padding(bottom: CalmScaffold.fabBottomClearance)` dentro do `Expanded` do corpo, encolhendo a altura do próprio viewport em vez de só adicionar espaço a seguir ao conteúdo. O `SliverPadding` final da lista 'POR CATEGORIA' (linha ~878) foi reduzido de `bottom: 80` para `bottom: 16`, porque com o viewport já encolhido em 88px esse valor de 80 tinha ficado redundante (ficaria ~168px de espaço morto no fundo da lista).
- `lib/screens/dashboard_screen.dart` — o `SingleChildScrollView` passou a estar envolvido num `Padding(bottom: CalmScaffold.fabBottomClearance)`, colocado **dentro** do `RefreshIndicator` (não à sua volta), para o pull-to-refresh continuar ligado à área scrollável real.

## Porque assim

Segui o plano do curator sem desvios: a causa raiz identificada era que nenhum dos dois ecrãs reservava a altura do FAB na altura de viewport do conteúdo scrollável — só havia padding no fim da lista, que só protege o último item, não o conteúdo visível antes de qualquer scroll (caso do cartão ALERTAS em Despesas e das linhas TOP CATEGORIAS/VELOCIDADE DE GASTO em Início). A correção reduz a altura disponível ao `CustomScrollView`/`SingleChildScrollView` através de um `Padding` externo, que é o mecanismo que efetivamente empurra o conteúdo desse tamanho para baixo do fold, em vez de só adicionar espaço vazio.

O `Padding` no dashboard ficou dentro do `RefreshIndicator` e não à sua volta, exatamente como o curator avisou, para não quebrar o pull-to-refresh.

## Critérios de aceitação

- [x] Início, sem scroll (small/phone): nenhum valor de TOP CATEGORIAS (incl. 'Educação') fica coberto pelo FAB — verificado por teste: o rect do `SingleChildScrollView` nunca sobrepõe o rect do FAB, e a primeira linha `CalmListTile` de TOP CATEGORIAS está dentro do fold pré-scroll.
- [x] Início, sem scroll: o badge 'Acima do ritmo'/'A bom ritmo' (`CalmPill` do burn rate) fica totalmente visível — mesmo teste, verificado explicitamente.
- [x] Despesas, sem scroll, com categoria acima do orçamento: o valor completo (incl. '€') fica visível — verificado: o rect do `CustomScrollView` nunca sobrepõe o FAB, e o `ExpenseAlertsCard` está dentro do fold pré-scroll.
- [x] Scroll até ao fim de 'POR CATEGORIA': última categoria continua visível sem o FAB por cima — verificado após um `fling` até ao fim da lista; a invariante (viewport não sobrepõe o FAB) é independente do offset de scroll por construção da correção.
- [x] Pull-to-refresh em Início continua a funcionar — verificado com um `fling` sobre o `RefreshIndicator` que dispara `onSnapshotExpenses`.
- [x] Viewports mais altos / conteúdo maior que o ecrã: comportamento de scroll normal inalterado — a correção só reduz a altura do viewport pelo valor fixo `fabBottomClearance`, não altera lógica de scroll.
- [x] Nenhum outro ecrã com FAB próprio tocado — só `expense_tracker_screen.dart`, `dashboard_screen.dart` e o `calm_scaffold.dart` partilhado (só a constante) foram alterados; `savings_goals_screen.dart`, `shopping_list_screen.dart` e `recurring_expenses_screen.dart` não foram tocados, porque o issue não confirmou o mesmo padrão nesses ecrãs.

## Testes

Dois ficheiros novos, escritos antes da correção estarem prontos e falhando sem ela:

- `test/screens/expense_tracker_fab_overlap_1202_test.dart` (3 testes): viewport vs FAB sem overlap em 360px e 430px + o `ExpenseAlertsCard` está no fold pré-scroll; e um teste de scroll até ao fim que confirma a mesma invariante após um `fling`.
- `test/screens/dashboard_fab_overlap_1202_test.dart` (3 testes): viewport vs FAB sem overlap em 360px e 430px + a primeira linha TOP CATEGORIAS e o `CalmPill` do burn rate estão no fold pré-scroll (harness replica a estrutura real de `app_home.dart`, já que o FAB do dashboard é injetado por fora do próprio `DashboardScreen`); e um teste de pull-to-refresh.

Nota metodológica: os testes comparam o rect do **viewport scrollável** com o rect do FAB, não o rect de cada linha individual — um item que atravessa o limite inferior do viewport continua a ter um rect geométrico completo (incl. a parte cortada/invisível pelo clip), o que dava falsos positivos ao comparar rects de item. Comparar o rect do viewport é o que a correção efetivamente garante e evita esse artefacto.

Nota separada, fora do âmbito: ao construir o fixture de teste com categorias 'não-over-budget' e múltiplas categorias, descobri um `RenderFlex overflow` pré-existente e não relacionado em `lib/widgets/expense/category_section.dart:81` (um `Row` com `CalmPill` + `Text` sem `Flexible`/`Expanded`, sensível a larguras estreitas). Não copio o critério de aceitação de #1202 para esse bug — ajustei os meus fixtures para não o disparar sempre que possível, e nos dois testes que o continuam a disparar (por usarem categorias reais acima do orçamento) deixei comentado porque não faço `assert` a exceções de render aí, só dreno a queue para não vazar para o teste seguinte. Vale um issue novo.

Resultado da suite completa: `flutter test` → 2419 testes, 0 falhas.

## Testes

2419 passaram, 0 falharam (flutter test completo); 6 testes novos em test/screens/expense_tracker_fab_overlap_1202_test.dart e test/screens/dashboard_fab_overlap_1202_test.dart

## Linked Issue

Fixes #1202