### PR TITLE
qa/issue-1241: yearly-summary: traduz categorias (localizedCategoryLabel) e acentua 5 títulos em ap

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -131,7 +131,7 @@
             }
         }
     },
-    "monthReviewExpensesExceeded": "Les dépenses réelles ont dépassé le prévu de {amount}ââ€šÂ¬ — ajuster les valeurs dans les paramètres ?",
+    "monthReviewExpensesExceeded": "Les dépenses réelles ont dépassé le prévu de {amount}€ — ajuster les valeurs dans les paramètres ?",
     "@monthReviewExpensesExceeded": {
         "placeholders": {
             "amount": {
@@ -139,7 +139,7 @@
             }
         }
     },
-    "monthReviewSavedMore": "Économisé {amount}ââ€šÂ¬ de plus que prévu — vous pouvez renforcer le fonds d'urgence.",
+    "monthReviewSavedMore": "Économisé {amount}€ de plus que prévu — vous pouvez renforcer le fonds d'urgence.",
     "@monthReviewSavedMore": {
         "placeholders": {
             "amount": {
@@ -750,7 +750,7 @@
     "mealConsolidatedList": "Voir la liste consolidée",
     "mealConsolidatedTitle": "Liste Consolidée",
     "mealAlternatives": "Alternatives",
-    "mealTotalCost": "{cost}ââ€šÂ¬ total",
+    "mealTotalCost": "{cost}€ total",
     "@mealTotalCost": {
         "placeholders": {
             "cost": {
@@ -829,7 +829,7 @@
     "wizardNoLimit": "Sans limite",
     "wizardMinimizeWaste": "Minimiser le gaspillage",
     "wizardMinimizeWasteDesc": "Préférer les recettes réutilisant des ingrédients déjà utilisés",
-    "wizardSettingsInfo": "Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres ââ€ ’ Repas.",
+    "wizardSettingsInfo": "Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres → Repas.",
     "wizardContinue": "Continuer",
     "wizardGeneratePlan": "Générer le Plan",
     "wizardStepOf": "Étape {current} sur {total}",
@@ -912,7 +912,7 @@
     },
     "settingsSalaryActive": "Actif",
     "settingsGrossMonthlySalary": "SALAIRE BRUT MENSUEL",
-    "settingsSubsidyHoliday": "PRIMES DE VACANCES ET NOÃ‹L (DOUZIÈMES)",
+    "settingsSubsidyHoliday": "PRIMES DE VACANCES ET NOËL (DOUZIÈMES)",
     "settingsOtherExemptLabel": "AUTRES REVENUS EXONÉRÉS D'IMPÔT",
     "settingsMealAllowanceLabel": "INDEMNITÉ REPAS",
     "settingsAmountPerDay": "MONTANT/JOUR",
@@ -1708,7 +1708,7 @@
     "onbSkip": "Passer",
     "onbNext": "Suivant",
     "onbGetStarted": "Commencer",
-    "onbSlide0Title": "Votre budget, en un coup d'Ã…“il",
+    "onbSlide0Title": "Votre budget, en un coup d'œil",
     "onbSlide0Body": "Le tableau de bord affiche votre liquidité mensuelle, dépenses et Indice de Sérénité.",
     "onbSlide1Title": "Suivez chaque dépense",
     "onbSlide1Body": "Appuyez sur + pour enregistrer un achat. Assignez une catégorie et regardez les barres se mettre à jour.",
@@ -1852,7 +1852,7 @@
     },
     "taxSimTitle": "Simulateur Fiscal",
     "taxSimPresets": "SCÉNARIOS RAPIDES",
-    "taxSimPresetRaise": "+ââ€šÂ¬200 augmentation",
+    "taxSimPresetRaise": "+€200 augmentation",
     "taxSimPresetMeal": "Carte vs espèces",
     "taxSimPresetTitular": "Conjoint vs séparé",
     "taxSimParameters": "PARAMÈTRES",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -5723,27 +5723,27 @@
     "yearlySummaryTitle": "Resumo Anual",
     "yearlySummaryIncome": "Rendimento Total",
     "yearlySummaryExpenses": "Despesas Totais",
-    "yearlySummaryNetSavings": "Poupanca Liquida",
-    "yearlySummarySavingsRate": "Taxa de poupanca: {rate}%",
+    "yearlySummaryNetSavings": "Poupança Líquida",
+    "yearlySummarySavingsRate": "Taxa de poupança: {rate}%",
     "@yearlySummarySavingsRate": {
         "placeholders": {
             "rate": {"type": "String"}
         }
     },
     "yearlySummaryHighlights": "Destaques",
-    "yearlySummaryBestMonth": "Melhor mes ({month})",
+    "yearlySummaryBestMonth": "Melhor mês ({month})",
     "@yearlySummaryBestMonth": {
         "placeholders": {
             "month": {"type": "String"}
         }
     },
-    "yearlySummaryWorstMonth": "Pior mes ({month})",
+    "yearlySummaryWorstMonth": "Pior mês ({month})",
     "@yearlySummaryWorstMonth": {
         "placeholders": {
             "month": {"type": "String"}
         }
     },
-    "yearlySummaryCategoryBreakdown": "Distribuicao por Categoria",
+    "yearlySummaryCategoryBreakdown": "Distribuição por Categoria",
     "mealSectionHousehold": "Quem come?",
     "mealSectionHouseholdSub": "Agregado familiar e membros",
     "mealSectionGoals": "Objetivo",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -10382,13 +10382,13 @@ abstract class S {
   /// No description provided for @yearlySummaryNetSavings.
   ///
   /// In pt, this message translates to:
-  /// **'Poupanca Liquida'**
+  /// **'Poupança Líquida'**
   String get yearlySummaryNetSavings;
 
   /// No description provided for @yearlySummarySavingsRate.
   ///
   /// In pt, this message translates to:
-  /// **'Taxa de poupanca: {rate}%'**
+  /// **'Taxa de poupança: {rate}%'**
   String yearlySummarySavingsRate(String rate);
 
   /// No description provided for @yearlySummaryHighlights.
@@ -10400,19 +10400,19 @@ abstract class S {
   /// No description provided for @yearlySummaryBestMonth.
   ///
   /// In pt, this message translates to:
-  /// **'Melhor mes ({month})'**
+  /// **'Melhor mês ({month})'**
   String yearlySummaryBestMonth(String month);
 
   /// No description provided for @yearlySummaryWorstMonth.
   ///
   /// In pt, this message translates to:
-  /// **'Pior mes ({month})'**
+  /// **'Pior mês ({month})'**
   String yearlySummaryWorstMonth(String month);
 
   /// No description provided for @yearlySummaryCategoryBreakdown.
   ///
   /// In pt, this message translates to:
-  /// **'Distribuicao por Categoria'**
+  /// **'Distribuição por Categoria'**
   String get yearlySummaryCategoryBreakdown;
 
   /// No description provided for @mealSectionHousehold.

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -308,12 +308,12 @@ class SFr extends S {
 
   @override
   String monthReviewExpensesExceeded(String amount) {
-    return 'Les dépenses réelles ont dépassé le prévu de $amountââ€šÂ¬ — ajuster les valeurs dans les paramètres ?';
+    return 'Les dépenses réelles ont dépassé le prévu de $amount€ — ajuster les valeurs dans les paramètres ?';
   }
 
   @override
   String monthReviewSavedMore(String amount) {
-    return 'Économisé $amountââ€šÂ¬ de plus que prévu — vous pouvez renforcer le fonds d\'urgence.';
+    return 'Économisé $amount€ de plus que prévu — vous pouvez renforcer le fonds d\'urgence.';
   }
 
   @override
@@ -1323,7 +1323,7 @@ class SFr extends S {
 
   @override
   String mealTotalCost(String cost) {
-    return '$costââ€šÂ¬ total';
+    return '$cost€ total';
   }
 
   @override
@@ -1470,7 +1470,7 @@ class SFr extends S {
 
   @override
   String get wizardSettingsInfo =>
-      'Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres ââ€ ’ Repas.';
+      'Vous pouvez modifier les paramètres du planificateur à tout moment dans Paramètres → Repas.';
 
   @override
   String get wizardContinue => 'Continuer';
@@ -1655,8 +1655,7 @@ class SFr extends S {
   String get settingsGrossMonthlySalary => 'SALAIRE BRUT MENSUEL';
 
   @override
-  String get settingsSubsidyHoliday =>
-      'PRIMES DE VACANCES ET NOÃ‹L (DOUZIÈMES)';
+  String get settingsSubsidyHoliday => 'PRIMES DE VACANCES ET NOËL (DOUZIÈMES)';
 
   @override
   String get settingsOtherExemptLabel => 'AUTRES REVENUS EXONÉRÉS D\'IMPÔT';
@@ -3207,7 +3206,7 @@ class SFr extends S {
   String get onbGetStarted => 'Commencer';
 
   @override
-  String get onbSlide0Title => 'Votre budget, en un coup d\'Ã…“il';
+  String get onbSlide0Title => 'Votre budget, en un coup d\'œil';
 
   @override
   String get onbSlide0Body =>
@@ -3528,7 +3527,7 @@ class SFr extends S {
   String get taxSimPresets => 'SCÉNARIOS RAPIDES';
 
   @override
-  String get taxSimPresetRaise => '+ââ€šÂ¬200 augmentation';
+  String get taxSimPresetRaise => '+€200 augmentation';
 
   @override
   String get taxSimPresetMeal => 'Carte vs espèces';

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -5831,11 +5831,11 @@ class SPt extends S {
   String get yearlySummaryExpenses => 'Despesas Totais';
 
   @override
-  String get yearlySummaryNetSavings => 'Poupanca Liquida';
+  String get yearlySummaryNetSavings => 'Poupança Líquida';
 
   @override
   String yearlySummarySavingsRate(String rate) {
-    return 'Taxa de poupanca: $rate%';
+    return 'Taxa de poupança: $rate%';
   }
 
   @override
@@ -5843,16 +5843,16 @@ class SPt extends S {
 
   @override
   String yearlySummaryBestMonth(String month) {
-    return 'Melhor mes ($month)';
+    return 'Melhor mês ($month)';
   }
 
   @override
   String yearlySummaryWorstMonth(String month) {
-    return 'Pior mes ($month)';
+    return 'Pior mês ($month)';
   }
 
   @override
-  String get yearlySummaryCategoryBreakdown => 'Distribuicao por Categoria';
+  String get yearlySummaryCategoryBreakdown => 'Distribuição por Categoria';
 
   @override
   String get mealSectionHousehold => 'Quem come?';

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -753,21 +753,29 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                       : AppColors.ok(context),
                 ),
                 const SizedBox(width: 8),
-                Text(
-                  isOver
-                      ? l10n.expenseTrackerOver
-                      : l10n.expenseTrackerRemaining,
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.ink70(context),
+                Flexible(
+                  child: Text(
+                    isOver
+                        ? l10n.expenseTrackerOver
+                        : l10n.expenseTrackerRemaining,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink70(context),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 const Spacer(),
-                Text(
-                  l10n.expenseTrackerBudgetedLabel(formatCurrency(totalBudgeted)),
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.ink50(context),
+                Flexible(
+                  child: Text(
+                    l10n.expenseTrackerBudgetedLabel(formatCurrency(totalBudgeted)),
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink50(context),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 InfoIconButton(

--- a/monthy_budget_flutter/lib/screens/yearly_summary_screen.dart
+++ b/monthy_budget_flutter/lib/screens/yearly_summary_screen.dart
@@ -3,6 +3,7 @@ import 'package:monthly_management/widgets/calm/calm.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../services/yearly_summary_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/category_helpers.dart';
 import '../utils/formatters.dart';
 
 /// A screen that displays the yearly summary / annual report.
@@ -135,7 +136,7 @@ class _CategoryBreakdownCard extends StatelessWidget {
           const SizedBox(height: 12),
           for (var i = 0; i < sorted.length; i++) ...[
             _KpiRow(
-              label: sorted[i].key,
+              label: localizedCategoryLabel(sorted[i].key, l10n),
               value: formatCurrency(sorted[i].value),
             ),
             if (i < sorted.length - 1)

--- a/monthy_budget_flutter/lib/widgets/calm/calm_tile.dart
+++ b/monthy_budget_flutter/lib/widgets/calm/calm_tile.dart
@@ -56,12 +56,18 @@ class CalmTile extends StatelessWidget {
         children: [
           Icon(icon, size: 24, color: AppColors.ink(context)),
           const SizedBox(height: 12),
-          Text(
-            label,
-            style: GoogleFonts.inter(
-              fontSize: 15,
-              fontWeight: FontWeight.w600,
-              color: AppColors.ink(context),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              label,
+              maxLines: 1,
+              softWrap: false,
+              style: GoogleFonts.inter(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: AppColors.ink(context),
+              ),
             ),
           ),
           const SizedBox(height: 2),

--- a/monthy_budget_flutter/test/screens/expense_tracker_budget_row_1203_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_budget_row_1203_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/widgets/info_icon_button.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding: at 360px viewport width, the budget summary
+  // row's InfoIconButton was pushed off-screen by the fixed-width children
+  // (pill + status text + budgeted-amount text) with no Flexible/Expanded to
+  // absorb the compression. See lib/screens/expense_tracker_screen.dart:745.
+  testWidgets(
+    'InfoIconButton stays fully within screen bounds at 360px width (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Mirrors the exact repro numbers from the issue: "-128,95 € Acima do
+      // orçamento orç. 1 871,50 €".
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 1871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 2000.45,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(360));
+
+      // The a11y tap target must stay at least 44x44.
+      expect(bottomRight.dx - topLeft.dx, greaterThanOrEqualTo(44));
+      expect(bottomRight.dy - topLeft.dy, greaterThanOrEqualTo(44));
+
+      // The pill ("-128,95 €") must still be fully rendered (not the
+      // budgeted-amount text, which is allowed to ellipsize).
+      expect(find.textContaining('-128,95'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'InfoIconButton stays visible at 360px even with a longer budgeted amount (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Keep the per-category remaining small (actual close to budgeted) so
+      // only the summary row's totals are long — this isolates the case
+      // under test from the unrelated category-row layout.
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 12871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 12871,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(360));
+    },
+  );
+
+  testWidgets(
+    'InfoIconButton stays fully visible at 430px width and budgeted text is unchanged (#1203)',
+    (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(430, 900);
+      tester.view.devicePixelRatio = 1.0;
+
+      // Same fixture as the "longer budgeted amount" case above: keeps the
+      // per-category remaining small so only this test's assertions (on the
+      // summary row) are exercised, independent of the unrelated
+      // category-row layout.
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 12871.50),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 12871,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final infoIconFinder = find.byType(InfoIconButton);
+      expect(infoIconFinder, findsOneWidget);
+
+      final topLeft = tester.getTopLeft(infoIconFinder);
+      final bottomRight = tester.getBottomRight(infoIconFinder);
+
+      expect(topLeft.dx, greaterThanOrEqualTo(0));
+      expect(bottomRight.dx, lessThanOrEqualTo(430));
+
+      // On the wider viewport there's enough room, so the budgeted-amount
+      // text renders in full (no ellipsis needed). Match on the l10n
+      // prefix + amount fragment rather than the exact separator glyph
+      // (NumberFormat may use a non-breaking thousands separator).
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Text &&
+              (widget.data ?? '').startsWith('budget') &&
+              (widget.data ?? '').contains('871,50'),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}

--- a/monthy_budget_flutter/test/screens/fr_encoding_mojibake_1232_test.dart
+++ b/monthy_budget_flutter/test/screens/fr_encoding_mojibake_1232_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_fr.dart';
+
+void main() {
+  late SFr fr;
+  setUpAll(() {
+    fr = SFr();
+  });
+
+  group('app_fr.arb mojibake fix (#1232)', () {
+    // Bytes that only ever appear when a UTF-8 string got mis-decoded as
+    // Latin-1/Windows-1252 and re-encoded — the mojibake pattern this issue
+    // fixes. None of the corrected strings below should contain them.
+    final mojibakePattern = RegExp(r'(Ã.|â€.|ââ€)');
+
+    test('monthReviewExpensesExceeded shows € not mojibake', () {
+      final result = fr.monthReviewExpensesExceeded('50');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('monthReviewSavedMore shows € not mojibake', () {
+      final result = fr.monthReviewSavedMore('50');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('mealTotalCost shows € not mojibake', () {
+      final result = fr.mealTotalCost('12');
+      expect(result, contains('€'));
+      expect(result, isNot(matches(mojibakePattern)));
+    });
+
+    test('wizardSettingsInfo shows → arrow not mojibake', () {
+      expect(fr.wizardSettingsInfo, contains('→'));
+      expect(fr.wizardSettingsInfo, isNot(matches(mojibakePattern)));
+    });
+
+    test('settingsSubsidyHoliday shows NOËL not mojibake', () {
+      expect(fr.settingsSubsidyHoliday, contains('NOËL'));
+      expect(fr.settingsSubsidyHoliday, isNot(matches(mojibakePattern)));
+    });
+
+    test('onbSlide0Title shows œ not mojibake', () {
+      expect(fr.onbSlide0Title, contains('œil'));
+      expect(fr.onbSlide0Title, isNot(matches(mojibakePattern)));
+    });
+
+    test('taxSimPresetRaise shows € not mojibake', () {
+      expect(fr.taxSimPresetRaise, contains('€'));
+      expect(fr.taxSimPresetRaise, isNot(matches(mojibakePattern)));
+    });
+  });
+}

--- a/monthy_budget_flutter/test/screens/yearly_summary_screen_test.dart
+++ b/monthy_budget_flutter/test/screens/yearly_summary_screen_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/app_shell.dart';
+import 'package:monthly_management/screens/yearly_summary_screen.dart';
+import 'package:monthly_management/services/yearly_summary_service.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  // Predefined categories (raw keys) plus a custom category (stored display
+  // name), so the test proves the screen translates the former and passes the
+  // latter through verbatim.
+  const report = YearlySummaryReport(
+    year: 2025,
+    totalIncome: 6000,
+    totalExpenses: 3000,
+    netSavings: 3000,
+    categoryTotals: {
+      'habitacao': 1200,
+      'alimentacao': 800,
+      'Férias': 300,
+    },
+    categoryTrends: {
+      'habitacao': [100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0],
+      'alimentacao': [66.7, 66.7, 66.7, 66.7, 66.7, 66.7, 66.7, 66.7, 66.7, 66.7, 66.7, 66.7],
+      'Férias': [25.0, 25.0, 25.0, 25.0, 25.0, 25.0, 25.0, 25.0, 25.0, 25.0, 25.0, 25.0],
+    },
+    bestMonth: '2025-01',
+    worstMonth: '2025-03',
+    bestMonthNet: 1500,
+    worstMonthNet: -200,
+  );
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        const YearlySummaryScreen(report: report),
+        controller: AppShellController(locale: const Locale('pt')),
+      ),
+    );
+  }
+
+  testWidgets('translates predefined category keys and keeps custom names',
+      (tester) async {
+    await pumpScreen(tester);
+
+    // Predefined categories render their translated, accented names.
+    expect(find.text('Habitação'), findsOneWidget);
+    expect(find.text('Alimentação'), findsOneWidget);
+
+    // Custom category renders the stored display name verbatim.
+    expect(find.text('Férias'), findsOneWidget);
+
+    // No raw internal key is ever shown to the user.
+    expect(find.text('habitacao'), findsNothing);
+    expect(find.text('alimentacao'), findsNothing);
+  });
+
+  testWidgets('renders accented pt-PT titles', (tester) async {
+    await pumpScreen(tester);
+
+    // "Poupança Líquida" appears twice: the hero eyebrow and the bottom KPI row.
+    expect(find.text('Poupança Líquida'), findsNWidgets(2));
+    expect(find.text('Taxa de poupança: 50.0%'), findsOneWidget);
+    expect(find.text('Distribuição por Categoria'), findsOneWidget);
+    expect(find.text('Melhor mês (2025-01)'), findsOneWidget);
+    expect(find.text('Pior mês (2025-03)'), findsOneWidget);
+
+    // The old unaccented strings must not be present.
+    expect(find.text('Poupanca Liquida'), findsNothing);
+    expect(find.text('Distribuicao por Categoria'), findsNothing);
+  });
+}

--- a/monthy_budget_flutter/test/widgets/calm/calm_wave_t_widgets_test.dart
+++ b/monthy_budget_flutter/test/widgets/calm/calm_wave_t_widgets_test.dart
@@ -101,6 +101,41 @@ void main() {
     expect(fired, isTrue);
   });
 
+  testWidgets('CalmTile scales down a long label instead of wrapping mid-word',
+      (tester) async {
+    await tester.pumpWidget(light(
+      const Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          child: CalmTile(
+            icon: Icons.kitchen,
+            label: 'Despensa',
+            count: '12 itens',
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final textFinder = find.text('Despensa');
+    expect(textFinder, findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    // Estrutural: o label tem de estar dentro de um FittedBox — sem isto,
+    // find.text() sozinho não distingue 'quebrado a meio' de 'escalado'.
+    expect(
+      find.ancestor(of: textFinder, matching: find.byType(FittedBox)),
+      findsOneWidget,
+    );
+
+    // Comportamental: softWrap/maxLines têm de impedir uma segunda linha —
+    // é isto que impede a quebra a meio da palavra, não o FittedBox sozinho.
+    final textWidget = tester.widget<Text>(textFinder);
+    expect(textWidget.softWrap, isFalse);
+    expect(textWidget.maxLines, 1);
+  });
+
   // ── CalmMealRow ──────────────────────────────────────────────────────────
 
   testWidgets('CalmMealRow renders', (tester) async {


### PR DESCRIPTION
Recuperado: o trabalho foi implementado e enviado, mas o `gh pr create` falhou.

## Linked Issue

Fixes #1241