### PR TITLE
Botões icon-only (sino de notificações, setas de mês) passam a expor nome acessível via IconButton.tooltip (#1211)

### DIFF
--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -267,20 +267,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
       eyebrow: eyebrow,
       title: monthLabel,
       actions: [
-        Tooltip(
-          message: l10n.notificationSettings,
-          child: IconButton(
-            icon: Badge(
-              isLabelVisible: false,
-              child: Icon(
-                Icons.notifications_outlined,
-                size: 24,
-                color: AppColors.ink70(context),
-              ),
+        IconButton(
+          tooltip: l10n.notificationSettings,
+          icon: Badge(
+            isLabelVisible: false,
+            child: Icon(
+              Icons.notifications_outlined,
+              size: 24,
+              color: AppColors.ink70(context),
             ),
-            onPressed: widget.onOpenNotificationSettings ??
-                () => _openNotificationSettings(context),
           ),
+          onPressed: widget.onOpenNotificationSettings ??
+              () => _openNotificationSettings(context),
         ),
         Tooltip(
           message: l10n.dashboardOpenSettings,

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -631,6 +631,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
               children: [
                 IconButton(
                   onPressed: _loading ? null : () => _navigateMonth(-1),
+                  tooltip: l10n.mealPlannerPreviousMonth,
                   icon: Icon(
                     Icons.chevron_left,
                     color: _loading
@@ -648,6 +649,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                 ),
                 IconButton(
                   onPressed: _loading ? null : () => _navigateMonth(1),
+                  tooltip: l10n.mealPlannerNextMonth,
                   icon: Icon(
                     Icons.chevron_right,
                     color: _loading

--- a/monthy_budget_flutter/test/screens/dashboard_a11y_1211_test.dart
+++ b/monthy_budget_flutter/test/screens/dashboard_a11y_1211_test.dart
@@ -1,0 +1,104 @@
+// Regression test for issue #1211: icon-only buttons without an accessible
+// name. The notification bell IconButton on the Dashboard header wrapped a
+// Tooltip *around* itself instead of passing `tooltip:` to the IconButton,
+// so the accessible label lived on a non-focusable ancestor node instead of
+// the actual `Semantics(button: true)` node that screen readers/keyboard
+// navigation land on.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/models/budget_summary.dart';
+import 'package:monthly_management/models/local_dashboard_config.dart';
+import 'package:monthly_management/models/purchase_record.dart';
+import 'package:monthly_management/screens/dashboard_screen.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  Widget buildDashboard() {
+    return wrapWithTestApp(
+      DashboardScreen(
+        settings: const AppSettings(),
+        summary: const BudgetSummary(
+          totalGross: 2000,
+          totalNetWithMeal: 1800,
+          totalExpenses: 900,
+          netLiquidity: 900,
+        ),
+        purchaseHistory: const PurchaseHistory(),
+        dashboardConfig: const LocalDashboardConfig(
+          showSummaryCards: false,
+          showSalaryBreakdown: false,
+          showBudgetVsActual: false,
+          showPurchaseHistory: false,
+          showCharts: false,
+          showStressIndex: false,
+          showMonthReview: false,
+          showUpcomingBills: false,
+          showTaxDeductions: false,
+          showSavingsGoals: false,
+          showExpensesBreakdown: false,
+          showBudgetStreaks: false,
+        ),
+        expenseHistory: const {},
+        actualExpenses: const [],
+        monthlyBudgets: const {},
+        recurringExpenses: const [],
+        actualExpenseHistory: const {},
+        onOpenSettings: () {},
+        onSaveSettings: (_) {},
+        onSnapshotExpenses: () {},
+        onAddExpense: () {},
+        onOpenExpenseTracker: () {},
+        householdName: 'Casa Silva',
+      ),
+    );
+  }
+
+  group('#1211 dashboard notification bell accessible name', () {
+    testWidgets(
+      'the focusable Semantics(button:true) node of the bell IconButton '
+      'carries the notificationSettings label (not a Tooltip ancestor)',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(buildDashboard());
+        await tester.pumpAndSettle();
+
+        final bellIconButtonFinder = find.ancestor(
+          of: find.byIcon(Icons.notifications_outlined),
+          matching: find.byType(IconButton),
+        );
+        expect(bellIconButtonFinder, findsOneWidget);
+
+        // The IconButton's own SemanticsNode (the one screen readers/keyboard
+        // navigation focus, flags: isButton/isFocusable) must carry the name
+        // directly. Flutter exposes an IconButton's `tooltip:` via the
+        // SemanticsData.tooltip field, which the web engine concatenates
+        // into the DOM node's aria-label — but only when it lives on the
+        // *same* SemanticsNode as the button flags. Wrapping a `Tooltip`
+        // *around* the IconButton instead puts it on a separate, ancestor,
+        // non-focusable SemanticsNode.
+        final semantics = tester.getSemantics(bellIconButtonFinder);
+        expect(
+          semantics.flagsCollection.isButton,
+          isTrue,
+          reason: 'sanity check: the located node must be the focusable button',
+        );
+        expect(
+          semantics.tooltip,
+          'Notification Settings',
+          reason:
+              'The bell IconButton itself must expose the accessible name; '
+              'a Tooltip wrapped around the IconButton puts the label on a '
+              'non-focusable ancestor instead.',
+        );
+
+        handle.dispose();
+      },
+    );
+  });
+}

--- a/monthy_budget_flutter/test/screens/expense_tracker_a11y_1211_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_a11y_1211_test.dart
@@ -1,0 +1,63 @@
+// Regression test for issue #1211: the month-navigation chevrons ('<' / '>')
+// on the Expenses screen are icon-only IconButtons with no `tooltip:`, so
+// they expose no accessible name at all to screen readers/keyboard nav.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  Widget buildScreen() {
+    return wrapWithTestApp(
+      ExpenseTrackerScreen(
+        settings: makeSettings(),
+        expenses: const [],
+        householdId: 'house-1',
+        onAdd: (_) async {},
+        onUpdate: (_) async {},
+        onDelete: (_) async {},
+        onLoadMonth: (_) async => [],
+      ),
+    );
+  }
+
+  group('#1211 expense tracker month-nav chevrons accessible name', () {
+    testWidgets(
+      'previous/next month IconButtons expose distinct, non-empty labels',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        final prevButtonFinder = find.ancestor(
+          of: find.byIcon(Icons.chevron_left),
+          matching: find.byType(IconButton),
+        );
+        final nextButtonFinder = find.ancestor(
+          of: find.byIcon(Icons.chevron_right),
+          matching: find.byType(IconButton),
+        );
+        expect(prevButtonFinder, findsOneWidget);
+        expect(nextButtonFinder, findsOneWidget);
+
+        final prevSemantics = tester.getSemantics(prevButtonFinder);
+        final nextSemantics = tester.getSemantics(nextButtonFinder);
+
+        // IconButton exposes `tooltip:` via SemanticsData.tooltip (merged
+        // into the DOM node's aria-label by the web engine) — not `label`.
+        // A missing `tooltip:` param leaves both label and tooltip empty.
+        expect(prevSemantics.tooltip, isNotEmpty,
+            reason: 'previous-month chevron must have an accessible name');
+        expect(nextSemantics.tooltip, isNotEmpty,
+            reason: 'next-month chevron must have an accessible name');
+        expect(prevSemantics.tooltip, isNot(equals(nextSemantics.tooltip)),
+            reason:
+                'previous and next must be distinguishable, not the same label');
+
+        handle.dispose();
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Resumo

Botões icon-only (sino de notificações, setas de mês) passam a expor nome acessível via IconButton.tooltip

## O que mudou

- `lib/screens/dashboard_screen.dart`: o `IconButton` do sino de notificações deixou de estar envolvido por um `Tooltip(...)` externo. O `message: l10n.notificationSettings` foi movido para o parâmetro `tooltip:` do próprio `IconButton`.
- `lib/screens/expense_tracker_screen.dart`: os dois `IconButton` de navegação de mês ('<' e '>') passaram a ter `tooltip: l10n.mealPlannerPreviousMonth` e `tooltip: l10n.mealPlannerNextMonth`, reutilizando as strings já traduzidas nos 4 idiomas (en/fr/es/pt) do Meal Planner, tal como sugerido pelo curator.

Nenhuma chave `.arb` nova foi criada — reutilizaram-se as chaves `mealPlannerPreviousMonth`/`mealPlannerNextMonth`, já presentes e traduzidas em `app_en.arb`, `app_fr.arb`, `app_es.arb`, `app_pt.arb`.

## Porque assim

Segui o plano do curator sem desvios. A causa raiz confirmada no código: `Tooltip` a envolver `IconButton` por FORA cria uma `Semantics(tooltip: ...)` num nó DIFERENTE (ancestral) do `Semantics(button: true)` que o próprio `IconButton` gera internamente (`icon_button.dart:835-839` do SDK do Flutter) — por isso o nó focável/tapável real fica sem nome. Passar `tooltip:` como parâmetro do `IconButton` faz o `Tooltip` interno do widget envolver o conteúdo e o `Semantics(button:true)` externo herdar/mesclar esse `tooltip` no mesmo nó.

Verifiquei isto empiricamente inspecionando o engine web do Flutter (`web_ui/lib/src/engine/semantics/label_and_value.dart:computeDomSemanticsLabel`): o campo `tooltip` do `SemanticsData` é concatenado pelo motor web para formar o `aria-label` do nó DOM correspondente — mas só quando vive no MESMO `SemanticsNode` que as flags de botão. Dump da árvore de semântica antes do fix confirmou dois nós separados (um com `tooltip`, sem `isButton`; outro com `isButton`, sem `tooltip`); depois do fix, um único nó mesclado com ambos.

Não toquei nos `IconButton`s de export/pesquisa/recorrentes em `expense_tracker_screen.dart:594-620` (já usavam `tooltip:` correctamente, serviam de referência).

## Critérios de aceitação

- [x] `IconButton` do sino em `dashboard_screen.dart` já não envolvido por `Tooltip` externo; usa `tooltip: l10n.notificationSettings`.
- [x] Nó de semântica focável do sino tem nome não vazio igual a `l10n.notificationSettings` — verificado via `tester.getSemantics(...).tooltip` (não `.label`; ver nota em Testes) no teste `dashboard_a11y_1211_test.dart`.
- [x] `IconButton` da seta '<' em `expense_tracker_screen.dart` tem `tooltip:` não vazio (`l10n.mealPlannerPreviousMonth`).
- [x] `IconButton` da seta '>' tem `tooltip:` não vazio e diferente da seta '<' (`l10n.mealPlannerNextMonth`).
- [x] `IconButton`s de export/pesquisa/recorrentes não alterados (confirmado por diff).
- [x] Comportamento visual (ícone, tamanho de alvo de toque, cor quando `_loading`) e `onPressed` inalterados — só se moveu o parâmetro `tooltip`, sem tocar em `icon:`/`onPressed:`/estilos.
- [x] Não foram criadas chaves `.arb` novas — reutilizaram-se `mealPlannerPreviousMonth`/`mealPlannerNextMonth`, já presentes nos 4 idiomas.

## Testes

**Passo vermelho:** escrevi primeiro `test/screens/dashboard_a11y_1211_test.dart` e `test/screens/expense_tracker_a11y_1211_test.dart` e corri-os contra o código antes do fix. Falharam pela razão certa:
- Dashboard: `Expected: 'Notification Settings' / Actual: ''` no nó `Semantics(button:true)` do `IconButton` do sino.
- Expenses: `Expected: non-empty / Actual: ''` em ambas as setas.

**Nota técnica importante descoberta durante o TDD:** o `SemanticsData` do Flutter tem um campo `label` e um campo `tooltip` SEPARADOS — `IconButton.tooltip` popula `SemanticsData.tooltip`, não `.label`. A minha primeira versão do teste assertava sobre `.label` e continuava a falhar mesmo depois do fix (falso vermelho por razão errada). Investiguei o motor web (`web_ui/.../label_and_value.dart`) para confirmar que é o campo `tooltip`, mesclado no mesmo nó que as flags `isButton`, que o engine concatena para formar o `aria-label` real no DOM — e corrigi a asserção para `.tooltip`. Também confirmei via `debugDumpSemanticsTree()` num teste descartável que, antes do fix, o `tooltip` vivia num `SemanticsNode` ancestral separado do nó `isButton` (exactamente o defeito descrito no issue), e depois do fix os dois campos mesclam no mesmo nó.

**Casos cobertos:**
- Nome acessível no nó focável correcto (não num ancestral) — sino.
- Nome não vazio em cada seta de mês, individualmente.
- Setas '<' e '>' com nomes DISTINTOS entre si (evita regressão onde ambas ficassem com o mesmo texto).
- Sanity check de que o `IconButton` localizado é de facto o nó com a flag `isButton` (evita falso positivo por o finder apanhar o nó errado).

**Sanity-check:** revertidos ambos os ficheiros de produção (`git stash` só em `dashboard_screen.dart`/`expense_tracker_screen.dart`, mantendo os testes), corridos os dois testes — ambos falharam com as mesmas mensagens do passo vermelho original. Restaurado (`git stash pop`) e confirmado que voltam a passar.

**Ficheiros de teste e resultado final:**
- `test/screens/dashboard_a11y_1211_test.dart`
- `test/screens/expense_tracker_a11y_1211_test.dart`
- Suite completa: 2431 testes passaram, 0 falharam.

`flutter analyze --no-fatal-infos --no-fatal-warnings` não introduziu erros/warnings novos nos ficheiros tocados (confirmado por diff: o único warning nos ficheiros de produção, um `unused_import` em `dashboard_screen.dart:36`, é pré-existente, não relacionado com este fix).

## Testes

2431 testes passaram, 0 falharam (flutter test completo)

## Linked Issue

Fixes #1211