### PR TITLE
Hero (Resumo Financeiro/Liquidez Mensal) do Início passa a usar as despesas reais, não o orçamento, corrigindo a divergência com Orçamento vs Real (#1217)

### DIFF
--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -181,7 +181,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
     final hasData = summary.totalGross > 0;
-    final isPositive = summary.netLiquidity >= 0;
+
+    // Real expenses of the month (Expense Tracker), computed once so the
+    // Hero card and the Budget vs Actual block can never disagree about
+    // "gasto do mês" — see #1217. summary.totalExpenses/netLiquidity are
+    // BUDGETED figures and must not be used for either.
+    final categoryBudgetSummaries = _buildCategoryBudgetSummaries();
+    final totalActualExpenses =
+        categoryBudgetSummaries.fold(0.0, (s, e) => s + e.actual);
+    final netLiquidity = summary.totalNetWithMeal - totalActualExpenses;
+    final isPositive = netLiquidity >= 0;
 
     // Stress Index — calculate and persist if changed.
     final stressResult = calculateStressIndex(
@@ -235,14 +244,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
               _buildCalmHeader(context, l10n),
               const SizedBox(height: 24),
               if (hasData && dashboardConfig.showHeroCard)
-                _buildHero(context, isPositive, l10n)
+                _buildHero(context, isPositive, l10n, totalActualExpenses)
               else if (!hasData)
                 _buildEmptyState(context, l10n),
               const SizedBox(height: 24),
               if (hasData) ...[
                 for (final cardId in dashboardConfig.cardOrder)
                   if (cardId != 'heroCard')
-                    ..._buildCardById(cardId, context, stressResult, monthReview, l10n),
+                    ..._buildCardById(cardId, context, stressResult,
+                        monthReview, l10n, categoryBudgetSummaries),
                 const SizedBox(height: 16),
               ],
             ],
@@ -330,13 +340,17 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   // ───────────────────────────────── Hero ──────────────────────────────────
 
-  Widget _buildHero(BuildContext context, bool isPositive, S l10n) {
+  Widget _buildHero(BuildContext context, bool isPositive, S l10n,
+      double totalActualExpenses) {
     final now = DateTime.now();
     final daysInMonth = DateTime(now.year, now.month + 1, 0).day;
     final daysPassed = now.day;
     final daysLeft = daysInMonth - daysPassed;
     final totalBudget = summary.totalNetWithMeal;
-    final spent = summary.totalExpenses;
+    // Real expenses lançadas no Expense Tracker — NOT summary.totalExpenses,
+    // which is the budgeted total (see #1217). `remaining` below therefore
+    // equals the real Liquidez Mensal, matching the Budget vs Actual block.
+    final spent = totalActualExpenses;
     final remaining = totalBudget - spent;
     final isOverBudget = remaining < 0;
     final onTrack = totalBudget <= 0 ||
@@ -348,7 +362,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
     return Semantics(
       key: DashboardTourKeys.heroCard,
       label: l10n.dashboardHeroLabel(
-        formatCurrency(summary.netLiquidity),
+        formatCurrency(remaining),
         isPositive
             ? l10n.dashboardPositiveBalance
             : l10n.dashboardNegativeBalance,
@@ -358,7 +372,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
         children: [
           CalmHero(
             eyebrow: l10n.dashboardMonthlyLiquidity.toUpperCase(),
-            amount: formatCurrency(summary.netLiquidity),
+            amount: formatCurrency(remaining),
             subtitle: l10n.dashboardFinancialSummary,
             size: 64,
           ),
@@ -469,6 +483,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
     StressIndexResult stressResult,
     MonthReviewResult? monthReview,
     S l10n,
+    List<CategoryBudgetSummary> categoryBudgetSummaries,
   ) {
     if (!dashboardConfig.isCardVisible(cardId)) return const [];
     switch (cardId) {
@@ -576,7 +591,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
         ];
       case 'budgetVsActual':
         return [
-          _buildBudgetVsActualCard(context),
+          _buildBudgetVsActualCard(context, categoryBudgetSummaries),
           if (onViewTrends != null) ...[
             const SizedBox(height: 16),
             _buildViewTrendsButton(context, l10n),
@@ -1269,17 +1284,25 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   // ───────────────────────── Budget vs Actual ──────────────────────────────
 
-  Widget _buildBudgetVsActualCard(BuildContext context) {
-    final l10n = S.of(context);
+  /// Real expenses of the month per category (actualExpenses lançadas +
+  /// food purchases merged into 'alimentacao'). Computed once per build()
+  /// and shared by the Hero card and the Budget vs Actual block so "gasto
+  /// do mês" cannot diverge between them again — see #1217.
+  List<CategoryBudgetSummary> _buildCategoryBudgetSummaries() {
     final now = DateTime.now();
     final foodSpent = purchaseHistory.spentInMonth(now.year, now.month);
-    final summaries = CategoryBudgetSummary.buildSummaries(
+    return CategoryBudgetSummary.buildSummaries(
       settings.expenses,
       actualExpenses,
       monthlyBudgets: monthlyBudgets,
       foodPurchaseSpent: foodSpent,
       now: now,
     );
+  }
+
+  Widget _buildBudgetVsActualCard(
+      BuildContext context, List<CategoryBudgetSummary> summaries) {
+    final l10n = S.of(context);
     final totalBudgeted = summaries.fold(0.0, (s, e) => s + e.budgeted);
     final totalActual = summaries.fold(0.0, (s, e) => s + e.actual);
 

--- a/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
+++ b/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations_en.dart';
 import 'package:monthly_management/models/actual_expense.dart';
 import 'package:monthly_management/models/app_settings.dart';
 import 'package:monthly_management/models/budget_summary.dart';
 import 'package:monthly_management/models/local_dashboard_config.dart';
 import 'package:monthly_management/models/purchase_record.dart';
 import 'package:monthly_management/screens/dashboard_screen.dart';
+import 'package:monthly_management/utils/formatters.dart';
 import 'package:monthly_management/widgets/calm/calm_list_tile.dart';
 
 import '../helpers/test_app.dart';
@@ -505,5 +507,167 @@ void main() {
     await tester.pump();
 
     expect(openRecurringCalled, 1);
+  });
+
+  // Regression coverage for #1217: the Hero card (Resumo Financeiro /
+  // Liquidez Mensal) used to source "gasto" from summary.totalExpenses,
+  // which is the BUDGETED total, not the real expenses shown by the
+  // Budget vs Actual block — see dashboard_screen.dart's _buildHero.
+  group('Hero spent/liquidity mirrors Budget vs Actual real total (#1217)',
+      () {
+    final l10n = SEn();
+
+    Widget buildDashboard({
+      required double budgeted,
+      required List<ActualExpense> actualExpenses,
+    }) {
+      return wrapWithTestApp(
+        DashboardScreen(
+          settings: AppSettings(
+            expenses: [
+              ExpenseItem(
+                id: 'e1',
+                label: 'Renda',
+                amount: budgeted,
+                category: 'habitacao',
+              ),
+            ],
+          ),
+          summary: BudgetSummary(
+            totalGross: 3000,
+            totalNetWithMeal: 3000,
+            // Deliberately the BUDGETED figures — this is exactly the
+            // shape of the bug: BudgetSummary carries planned amounts,
+            // not the real expenses lançadas no Expense Tracker.
+            totalExpenses: budgeted,
+            netLiquidity: 3000 - budgeted,
+          ),
+          purchaseHistory: const PurchaseHistory(),
+          dashboardConfig: const LocalDashboardConfig(
+            showSalaryBreakdown: false,
+            showPurchaseHistory: false,
+            showCharts: false,
+            showStressIndex: false,
+            showMonthReview: false,
+            showUpcomingBills: false,
+            showTaxDeductions: false,
+            showSavingsGoals: false,
+            showExpensesBreakdown: false,
+            showBudgetStreaks: false,
+            showCashFlowForecast: false,
+            showBurnRate: false,
+            showTopCategories: false,
+            showSavingsRate: false,
+            showCoachInsight: false,
+            showQuickActions: false,
+            showSpendingAnomalies: false,
+            showSummaryCards: false,
+            showBudgetVsActual: true,
+          ),
+          expenseHistory: const {},
+          actualExpenses: actualExpenses,
+          monthlyBudgets: const {},
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: () {},
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+        ),
+      );
+    }
+
+    testWidgets('real > budgeted: Hero shows the real total, not budgeted',
+        (tester) async {
+      const budgeted = 1945.00;
+      const actual = 2189.85;
+      final now = DateTime.now();
+
+      await tester.pumpWidget(buildDashboard(
+        budgeted: budgeted,
+        actualExpenses: [
+          ActualExpense(
+            id: 'a1',
+            category: 'habitacao',
+            amount: actual,
+            date: DateTime(now.year, now.month, 10),
+            monthKey: '${now.year}-${now.month.toString().padLeft(2, '0')}',
+          ),
+        ],
+      ));
+      await tester.pumpAndSettle();
+
+      // Hero "spent" label: must be the REAL total (2 189,85 €), matching
+      // the Budget vs Actual "Actual" total, not the budgeted total.
+      expect(
+        find.text(l10n.dashboardHeroSpentLabel(formatCurrency(actual))),
+        findsOneWidget,
+      );
+      expect(
+        find.text(l10n.dashboardHeroSpentLabel(formatCurrency(budgeted))),
+        findsNothing,
+      );
+      expect(
+        find.text('${l10n.expenseTrackerActual}: ${formatCurrency(actual)}'),
+        findsOneWidget,
+      );
+
+      // Hero amount (Liquidez Mensal) = totalNetWithMeal - REAL total.
+      expect(find.text(formatCurrency(3000 - actual)), findsOneWidget);
+      expect(find.text(formatCurrency(3000 - budgeted)), findsNothing);
+    });
+
+    testWidgets('real < budgeted: not hardcoded to "real always bigger"',
+        (tester) async {
+      const budgeted = 2000.00;
+      const actual = 500.00;
+      final now = DateTime.now();
+
+      await tester.pumpWidget(buildDashboard(
+        budgeted: budgeted,
+        actualExpenses: [
+          ActualExpense(
+            id: 'a1',
+            category: 'habitacao',
+            amount: actual,
+            date: DateTime(now.year, now.month, 10),
+            monthKey: '${now.year}-${now.month.toString().padLeft(2, '0')}',
+          ),
+        ],
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(l10n.dashboardHeroSpentLabel(formatCurrency(actual))),
+        findsOneWidget,
+      );
+      expect(
+        find.text(l10n.dashboardHeroSpentLabel(formatCurrency(budgeted))),
+        findsNothing,
+      );
+      expect(find.text(formatCurrency(3000 - actual)), findsOneWidget);
+    });
+
+    testWidgets('empty actualExpenses: Hero shows 0 spent, not the budget',
+        (tester) async {
+      const budgeted = 1945.00;
+
+      await tester.pumpWidget(buildDashboard(
+        budgeted: budgeted,
+        actualExpenses: const [],
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(l10n.dashboardHeroSpentLabel(formatCurrency(0))),
+        findsOneWidget,
+      );
+      expect(
+        find.text(l10n.dashboardHeroSpentLabel(formatCurrency(budgeted))),
+        findsNothing,
+      );
+      expect(find.text(formatCurrency(3000)), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Resumo

Hero (Resumo Financeiro/Liquidez Mensal) do Início passa a usar as despesas reais, não o orçamento, corrigindo a divergência com Orçamento vs Real

## O que mudou

Em `lib/screens/dashboard_screen.dart`:

- Novo método `_buildCategoryBudgetSummaries()` extrai a lógica que já existia em `_buildBudgetVsActualCard` (chamada a `CategoryBudgetSummary.buildSummaries` com `settings.expenses`, `actualExpenses`, `monthlyBudgets` e `purchaseHistory.spentInMonth(...)` fundido em 'alimentacao'). É chamado **uma vez** em `build()`.
- `build()` calcula `totalActualExpenses` (soma de `.actual` de todas as categorias) e `netLiquidity = summary.totalNetWithMeal - totalActualExpenses` a partir dessa lista única, e usa esse `netLiquidity` para `isPositive` (em vez de `summary.netLiquidity >= 0`).
- `_buildHero` passa a receber `totalActualExpenses` como parâmetro; a variável local `spent` (antes `summary.totalExpenses`) passa a ser esse valor real. `remaining = totalBudget - spent` já era calculado a partir de `spent`, por isso herda automaticamente o valor correto — usei-o para substituir as duas ocorrências de `summary.netLiquidity` (rótulo de acessibilidade `Semantics.label` e `CalmHero.amount`).
- `_buildCardById` passa a receber `categoryBudgetSummaries` e repassa-o ao caso `'budgetVsActual'`.
- `_buildBudgetVsActualCard` deixou de calcular a sua própria lista de `CategoryBudgetSummary` — recebe-a como parâmetro. Resultado: Hero e Orçamento vs Real consomem literalmente a mesma lista computada uma única vez, o que torna a divergência estruturalmente impossível de voltar a acontecer.
- Nada mudou em `lib/utils/calculations.dart`, `BudgetSummary`, nem em qualquer chamador fora de `dashboard_screen.dart` (wizard, coach, projection sheet, app_home.dart continuam a usar `calculateBudgetSummary`/`summary.totalExpenses`/`summary.netLiquidity` inalterados).
- `_buildSavingsRateCard` (Taxa de Poupança) não foi tocado — fica fora de âmbito, tal como indicado pelo curator.

## Porque assim

Segui o plano do curator no essencial (reutilizar `CategoryBudgetSummary.buildSummaries` em vez de reimplementar a soma, e calcular o total real uma vez em `build()` para partilhar entre Hero e Orçamento vs Real). Único desvio: em vez de passar um `netLiquidity` calculado separadamente para `_buildHero`, deixei o `_buildHero` recalcular `remaining = totalBudget - spent` internamente (como já fazia) e usei essa mesma variável para a Liquidez Mensal mostrada — evita um segundo lugar onde `totalNetWithMeal - despesas reais` poderia divergir do `remaining` já usado na barra de progresso/rótulo "dentro do ritmo".

## Critérios de aceitação

- [x] Hero e Orçamento vs Real mostram o mesmo valor "gasto"/"Real" no mesmo carregamento — ambos consomem a mesma lista `categoryBudgetSummaries`.
- [x] Liquidez Mensal = `totalNetWithMeal - despesas reais do mês` (via `remaining` em `_buildHero`).
- [x] Rótulo de acessibilidade (positivo/negativo) usa `isPositive` derivado do `netLiquidity` real calculado em `build()`.
- [x] `setup_wizard_screen.dart`, `coach_screen.dart`, `coach_chat_controller.dart`, `projection_sheet.dart`, `app_home.dart` não foram tocados — confirmado por `git diff --stat` (só `dashboard_screen.dart` e o teste mudaram).
- [x] `lib/utils/calculations.dart` não alterado.
- [x] Orçamento vs Real continua a mostrar o mesmo "Real" que mostrava antes — não regride (testes existentes desse bloco continuam a passar sem alteração).
- [x] Cartão Taxa de Poupança não alterado.

## Testes

- **Passo vermelho:** escrevi 3 testes novos em `test/functional/dashboard_screen_functional_test.dart` (grupo `Hero spent/liquidity mirrors Budget vs Actual real total (#1217)`) e corri-os antes de tocar em `dashboard_screen.dart`. Falharam pela razão certa:
  `Expected: exactly one matching candidate / Actual: _TextWidgetFinder:<Found 0 widgets with text "2 189,85 € spent": []>` — o Hero mostrava o valor orçamentado (1 945,00 €) em vez do real (2 189,85 €), reproduzindo exatamente o bug relatado.
- **Casos cobertos:**
  - `real > budgeted` — reproduz o cenário exato do issue (orçamento 1 945,00 €, real 2 189,85 €); confirma que o Hero mostra o real e não o orçamentado, e que a Liquidez Mensal é `3000 - 2189.85`, não `3000 - 1945.00`.
  - `real < budgeted` — inverso, para garantir que a correção não ficou hardcoded para "real é sempre maior".
  - `actualExpenses` vazio — garante que o "gasto" é 0 €, não o total orçamentado, quando não há despesas reais lançadas (mês novo).
  - Os 8 testes funcionais já existentes de `dashboard_screen_functional_test.dart` (incluindo o teste de drill-down do Orçamento vs Real) continuam a passar sem alteração — confirma que o bloco Orçamento vs Real não regrediu.
- **Sanity-check:** revertido `lib/screens/dashboard_screen.dart` (mantendo os testes), corrida a suite — os 3 testes novos voltaram a falhar com a mensagem original ("Found 0 widgets with text ... spent"). Restaurado o fix via `git apply` do patch guardado; suite voltou a passar por inteiro.
- Ficheiro de teste: `test/functional/dashboard_screen_functional_test.dart`.
- Resultado final: `flutter test` completo — **2434 testes passaram, 0 falharam**. `flutter analyze --no-fatal-infos --no-fatal-warnings` — 78 issues, idêntico ao baseline antes do fix (confirmado por `git stash`/`git stash pop`), nenhum novo erro ou warning introduzido (o único warning em `dashboard_screen.dart`, import não usado de `notification_preferences.dart`, é pré-existente e não relacionado a este fix).

## Testes

2434 passaram, 0 falharam (flutter test completo)

## Linked Issue

Fixes #1217