### PR TITLE
Top Categorias passa a incluir purchaseHistory na categoria alimentacao, igual ao Orçamento vs Real (#1218)

### DIFF
--- a/monthy_budget_flutter/lib/models/actual_expense.dart
+++ b/monthy_budget_flutter/lib/models/actual_expense.dart
@@ -204,6 +204,25 @@ class CategoryBudgetSummary {
   bool get isOver => actual > budgeted;
   bool get isCustom => budgeted == 0;
 
+  /// Merges a food-purchase-history total into the 'alimentacao' key of
+  /// [actualsByCategory], mutating and returning it. Purchases finalised
+  /// via the shopping list checkout never create an [ActualExpense] (see
+  /// `_finalizeShopping` in `app_home.dart`), so every place that aggregates
+  /// real food spend must add them explicitly — extracted here so the
+  /// aggregation can't drift between call sites again (#1218: 'Top
+  /// Categorias' and 'Orçamento vs Real' showed two different totals for
+  /// the same category because only one of them applied this merge).
+  static Map<String, double> mergeFoodPurchases(
+    Map<String, double> actualsByCategory,
+    double foodPurchaseSpent,
+  ) {
+    if (foodPurchaseSpent > 0) {
+      actualsByCategory['alimentacao'] =
+          (actualsByCategory['alimentacao'] ?? 0) + foodPurchaseSpent;
+    }
+    return actualsByCategory;
+  }
+
   static List<CategoryBudgetSummary> buildSummaries(
     List<ExpenseItem> budgetItems,
     List<ActualExpense> actuals, {
@@ -223,10 +242,7 @@ class CategoryBudgetSummary {
     }
 
     // Merge food purchase history into alimentacao actual
-    if (foodPurchaseSpent > 0) {
-      actualsByCategory['alimentacao'] =
-          (actualsByCategory['alimentacao'] ?? 0) + foodPurchaseSpent;
-    }
+    mergeFoodPurchases(actualsByCategory, foodPurchaseSpent);
 
     // Sum per-category default amounts, then apply monthly overrides
     final defaultByCategory = <String, double>{};

--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -787,6 +787,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
       categoryTotals[e.category] =
           (categoryTotals[e.category] ?? 0) + e.amount;
     }
+    // Merge food purchase history into 'alimentacao', same as
+    // _buildCategoryBudgetSummaries() does for the Orçamento vs Real card —
+    // otherwise the two blocks show different totals for the same category
+    // (#1218).
+    final now = DateTime.now();
+    CategoryBudgetSummary.mergeFoodPurchases(
+      categoryTotals,
+      purchaseHistory.spentInMonth(now.year, now.month),
+    );
     final sorted = categoryTotals.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     final top = sorted.take(5).toList();

--- a/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
+++ b/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
@@ -670,4 +670,129 @@ void main() {
       expect(find.text(formatCurrency(3000)), findsOneWidget);
     });
   });
+
+  // Regression coverage for #1218: 'Top Categorias' summed only
+  // actualExpenses for 'alimentacao', while 'Orçamento vs Real' also merged
+  // purchaseHistory.spentInMonth(...) into the same category — same page,
+  // two different totals for the same concept.
+  group('Top Categories mirrors Budget vs Actual real total for alimentacao (#1218)',
+      () {
+    final l10n = SEn();
+    final now = DateTime.now();
+
+    Widget buildDashboard({
+      required List<ActualExpense> actualExpenses,
+      required PurchaseHistory purchaseHistory,
+    }) {
+      return wrapWithTestApp(
+        DashboardScreen(
+          settings: const AppSettings(),
+          summary: const BudgetSummary(
+            totalGross: 3000,
+            totalNetWithMeal: 3000,
+            totalExpenses: 775.00,
+            netLiquidity: 2225.00,
+          ),
+          purchaseHistory: purchaseHistory,
+          dashboardConfig: const LocalDashboardConfig(
+            showHeroCard: false,
+            showSummaryCards: false,
+            showSalaryBreakdown: false,
+            showBudgetVsActual: true,
+            showPurchaseHistory: false,
+            showCharts: false,
+            showStressIndex: false,
+            showMonthReview: false,
+            showUpcomingBills: false,
+            showTaxDeductions: false,
+            showSavingsGoals: false,
+            showExpensesBreakdown: false,
+            showBudgetStreaks: false,
+            showCashFlowForecast: false,
+            showBurnRate: false,
+            showTopCategories: true,
+            showSavingsRate: false,
+            showCoachInsight: false,
+            showQuickActions: false,
+            showSpendingAnomalies: false,
+          ),
+          expenseHistory: const {},
+          actualExpenses: actualExpenses,
+          monthlyBudgets: const {},
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: () {},
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+        ),
+      );
+    }
+
+    testWidgets(
+        'transactions + supermarket purchases: both cards show the merged total',
+        (tester) async {
+      await tester.pumpWidget(buildDashboard(
+        actualExpenses: [
+          ActualExpense(
+            id: 'a1',
+            category: 'alimentacao',
+            amount: 585.60,
+            date: DateTime(now.year, now.month, 5),
+            monthKey: '${now.year}-${now.month.toString().padLeft(2, '0')}',
+          ),
+        ],
+        purchaseHistory: PurchaseHistory(records: [
+          PurchaseRecord(
+            id: 'p1',
+            date: DateTime(now.year, now.month, 12),
+            amount: 189.40,
+            itemCount: 6,
+          ),
+        ]),
+      ));
+      await tester.pumpAndSettle();
+
+      // Top Categorias must show the SAME merged total (585,60 + 189,40 =
+      // 775,00) that Orçamento vs Real already shows for 'alimentacao' —
+      // before the fix, Top Categorias only summed actualExpenses (585,60 €).
+      expect(find.text(formatCurrency(775.00)), findsOneWidget); // Top Categorias subtitle
+      expect(
+        find.text('${l10n.expenseTrackerActual}: ${formatCurrency(775.00)}'),
+        findsOneWidget,
+      ); // Orçamento vs Real total row
+      expect(find.text(formatCurrency(585.60)), findsNothing);
+      expect(
+        find.text('${l10n.expenseTrackerActual}: ${formatCurrency(585.60)}'),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+        'no supermarket purchases this month: Top Categories unaffected (no regression)',
+        (tester) async {
+      await tester.pumpWidget(buildDashboard(
+        actualExpenses: [
+          ActualExpense(
+            id: 'a1',
+            category: 'alimentacao',
+            amount: 585.60,
+            date: DateTime(now.year, now.month, 5),
+            monthKey: '${now.year}-${now.month.toString().padLeft(2, '0')}',
+          ),
+        ],
+        purchaseHistory: const PurchaseHistory(),
+      ));
+      await tester.pumpAndSettle();
+
+      // purchaseHistory.spentInMonth() == 0 → both cards must show exactly
+      // the transaction total, unchanged from current behaviour.
+      expect(find.text(formatCurrency(585.60)), findsOneWidget); // Top Categorias
+      expect(
+        find.text('${l10n.expenseTrackerActual}: ${formatCurrency(585.60)}'),
+        findsOneWidget,
+      ); // Orçamento vs Real
+    });
+  });
 }


### PR DESCRIPTION
## Resumo

Top Categorias passa a incluir purchaseHistory na categoria alimentacao, igual ao Orçamento vs Real

## O que mudou

- `lib/models/actual_expense.dart`: extraído o método estático `CategoryBudgetSummary.mergeFoodPurchases(Map<String,double>, double)`, que soma um total de compras de supermercado à chave `'alimentacao'` de um mapa categoria→valor (só se > 0). `CategoryBudgetSummary.buildSummaries(...)` foi refatorado para chamar este helper em vez de repetir a lógica inline — o comportamento de `buildSummaries` não mudou, só deixou de ter uma cópia da lógica de merge.
- `lib/screens/dashboard_screen.dart`: `_buildTopCategoriesCard` (usada por 'Top Categorias') passou a chamar `CategoryBudgetSummary.mergeFoodPurchases(categoryTotals, purchaseHistory.spentInMonth(now.year, now.month))` depois de somar `actualExpenses`, antes de ordenar/cortar para as top 5. Antes só somava `actualExpenses`.

## Porque assim

Segui o plano do curator (usar `purchaseHistory.spentInMonth(now.year, now.month)` e aplicar o mesmo merge que `_buildCategoryBudgetSummaries` já aplica), mas em vez de copiar a lógica de merge uma terceira vez extraí-a para `CategoryBudgetSummary.mergeFoodPurchases` — é exactamente a sugestão do curator ('idealmente extrair essa lógica de merge para um helper partilhado') e o padrão que o próprio `dashboard_screen.dart` já usa para o caso #1217 (comentário em `dashboard_screen.dart:1287-1290`: 'Computed once per build() and shared... so gasto do mês cannot diverge between them again'). Com isto os dois sítios que fazem este merge (o `buildSummaries` usado por Orçamento vs Real, e agora Top Categorias) chamam a mesma função, tornando a divergência estruturalmente impossível de reintroduzir.

Considerei também reescrever `_buildTopCategoriesCard` para consumir directamente a lista já computada `categoryBudgetSummaries` (passada a `_buildBudgetVsActualCard`), o que uniformizaria TODAS as categorias, não só alimentação. Descartei essa opção: `categoryBudgetSummaries` inclui categorias orçamentadas com actual=0 (que hoje não aparecem em Top Categorias porque o mapa só tem entradas vindas de `actualExpenses`), o que alteraria quantas linhas aparecem no card em famílias com poucas categorias com gasto real — comportamento fora do âmbito do issue e não coberto pelos critérios de aceitação. A correção mínima e cirúrgica (mexer só na chave 'alimentacao', só quando `foodPurchaseSpent > 0`) é a que o curator pediu e a que menos risco de side-effect introduz.

Não toquei em `total = summary.totalExpenses` (linha do denominador da percentagem no trailing) nem no ecrã Despesas nem no cartão 'Histórico de Compras', como pedido pelo curator.

## Critérios de aceitação

- [x] Com 585,60 € em transações + 189,40 € em compras de supermercado do mês, 'Top Categorias' e 'Orçamento vs Real' mostram ambos 775,00 € para Alimentação — testado em `dashboard_screen_functional_test.dart`, grupo '#1218', primeiro teste.
- [x] Categorias sem registo em purchaseHistory continuam a mostrar exactamente a soma das suas transações — `mergeFoodPurchases` só mexe na chave 'alimentacao'; outras categorias (ex.: 'lazer' no teste pré-existente 'Top Categories row taps drill into expense tracker') não são tocadas.
- [x] Ecrã Despesas continua a mostrar 585,60 € — não alterado (`expense_tracker_screen.dart` fora de âmbito, sem alterações).
- [x] Cartão 'Histórico de Compras' continua a listar compras sem alterações — `_buildPurchaseHistoryCard` não foi tocado.
- [x] Quando `spentInMonth()` é 0, comportamento idêntico ao actual — testado no segundo teste do grupo #1218 ('no supermarket purchases this month'), que passa sem alteração desde antes do fix (é a prova de que o merge é no-op quando foodSpent=0).
- [x] Testes existentes em `dashboard_screen_functional_test.dart` com `purchaseHistory: PurchaseHistory(records: [...])` continuam a passar — suite completa corrida, 2436 testes passam.

## Testes

**Passo vermelho:** escrito o teste 'transactions + supermarket purchases: both cards show the merged total' antes do fix. Falhou com:
```
Expected: exactly one matching candidate
  Actual: _TextWidgetFinder:<Found 0 widgets with text "775,00 €": []>
```
— ou seja, Top Categorias não mostrava o total merged, exactamente o defeito descrito no issue.

**Casos cobertos:**
- Caminho feliz: transações + compras do mês → total merged em ambos os cartões (585,60 + 189,40 = 775,00).
- Inverso/regressão: sem nenhuma compra de supermercado no mês (`PurchaseHistory()` vazio) → ambos os cartões mostram só a soma das transações (585,60), sem regressão para quem não usa a lista de compras.
- Reaproveitado o teste pré-existente 'Top Categories row taps drill into expense tracker' (categoria 'lazer', sem purchaseHistory) para confirmar que categorias não-alimentação ficam intocadas.

**Sanity-check:** `git stash` dos dois ficheiros de produção (mantendo os testes), corrida da suite — os 2 testes novos falharam com a mensagem exacta acima; o resto passou. `git stash pop` para restaurar o fix, suite voltou a passar por inteiro (13/13 no ficheiro, 2436/2436 na suite completa).

Ficheiros de teste: `test/functional/dashboard_screen_functional_test.dart`. Resultado final: **2436 testes passaram, 0 falharam**. `flutter analyze`: 78 issues antes e depois (nenhum novo).

## Testes

2436 testes passaram, 0 falharam (13/13 em dashboard_screen_functional_test.dart, incluindo 2 novos). flutter analyze: 78 issues antes e depois do fix (0 novos).

## Linked Issue

Fixes #1218