### PR TITLE
fix(dashboard): cartão Taxa de Poupança e dica do Coach escalam a fracção savingsRate ×100 na exibição (#1219) (#1219)

### DIFF
--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -936,10 +936,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   Widget _buildSavingsRateCard(BuildContext context, S l10n) {
     final currentRate = summary.savingsRate;
+    // savingsRate is a fraction (0..1); scale ×100 once for display and for
+    // the point-based colour thresholds — comparing the raw fraction against
+    // 20/10 would make every valid rate look <10% (always red).
+    final ratePct = currentRate * 100;
     final saved = summary.netLiquidity > 0 ? summary.netLiquidity : 0.0;
-    final rateColor = currentRate >= 20
+    final rateColor = ratePct >= 20
         ? AppColors.ok(context)
-        : currentRate >= 10
+        : ratePct >= 10
             ? AppColors.warn(context)
             : AppColors.bad(context);
 
@@ -972,7 +976,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                     l10n.dashboardSavingsRateTitle.toUpperCase()),
               ),
               Text(
-                '${currentRate.toStringAsFixed(1)}%',
+                formatPercentage(currentRate),
                 style: CalmText.amount(context, size: 18)
                     .copyWith(color: rateColor),
               ),
@@ -1028,13 +1032,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Widget _buildCoachInsightCard(BuildContext context, S l10n) {
     String insight;
     IconData insightIcon;
-    if (summary.savingsRate < 10 && summary.totalExpenses > 0) {
+    // savingsRate is a fraction; thresholds are in percentage points.
+    if (summary.savingsRate < 0.10 && summary.totalExpenses > 0) {
       insight = l10n.dashboardCoachLowSavings;
       insightIcon = Icons.warning_amber_outlined;
     } else if (summary.totalExpenses > summary.totalNetWithMeal * 0.9) {
       insight = l10n.dashboardCoachHighSpending;
       insightIcon = Icons.trending_down;
-    } else if (summary.savingsRate >= 20) {
+    } else if (summary.savingsRate >= 0.20) {
       insight = l10n.dashboardCoachGoodSavings;
       insightIcon = Icons.emoji_events_outlined;
     } else {

--- a/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
+++ b/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
@@ -7,6 +7,7 @@ import 'package:monthly_management/models/budget_summary.dart';
 import 'package:monthly_management/models/local_dashboard_config.dart';
 import 'package:monthly_management/models/purchase_record.dart';
 import 'package:monthly_management/screens/dashboard_screen.dart';
+import 'package:monthly_management/theme/app_colors.dart';
 import 'package:monthly_management/utils/formatters.dart';
 import 'package:monthly_management/widgets/calm/calm_list_tile.dart';
 
@@ -793,6 +794,154 @@ void main() {
         find.text('${l10n.expenseTrackerActual}: ${formatCurrency(585.60)}'),
         findsOneWidget,
       ); // Orçamento vs Real
+    });
+  });
+
+  group(
+      'Savings Rate dedicated card & coach tip scale fraction ×100 (#1219)',
+      () {
+    final l10n = SEn();
+
+    Widget buildSavingsDashboard({required double savingsRate}) {
+      return wrapWithTestApp(
+        DashboardScreen(
+          settings: const AppSettings(),
+          summary: BudgetSummary(
+            totalGross: 1500,
+            totalNetWithMeal: 1000,
+            totalExpenses: 550,
+            totalDeductions: 200,
+            totalIRS: 150,
+            totalSS: 50,
+            netLiquidity: 450,
+            savingsRate: savingsRate,
+          ),
+          purchaseHistory: const PurchaseHistory(),
+          dashboardConfig: const LocalDashboardConfig(
+            showSalaryBreakdown: false,
+            showPurchaseHistory: false,
+            showCharts: false,
+            showStressIndex: false,
+            showMonthReview: false,
+            showUpcomingBills: false,
+            showTaxDeductions: false,
+            showSavingsGoals: false,
+            showExpensesBreakdown: false,
+            showBudgetStreaks: false,
+            showCashFlowForecast: false,
+            showBurnRate: false,
+            showTopCategories: false,
+            showQuickActions: false,
+            showSpendingAnomalies: false,
+            showSummaryCards: false,
+            showBudgetVsActual: false,
+            showSavingsRate: true,
+            showCoachInsight: true,
+          ),
+          expenseHistory: const {},
+          actualExpenses: const [],
+          monthlyBudgets: const {},
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: () {},
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+          onOpenCoach: () {},
+        ),
+      );
+    }
+
+    testWidgets(
+        'savingsRate 0.449: dedicated card shows the ×100 percentage (not the raw fraction 0.4%) and the good-savings coach tip',
+        (tester) async {
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.449));
+      await tester.pumpAndSettle();
+
+      // The defect: the dedicated card rendered the raw fraction (0.4%),
+      // while the summary card / Coach / export all scale ×100 at display.
+      expect(find.text('0.4%'), findsNothing);
+      expect(find.text(formatPercentage(0.449)), findsOneWidget);
+      // Coach tip must be the good-savings one, not the false low-savings alarm.
+      expect(find.text(l10n.dashboardCoachGoodSavings), findsOneWidget);
+      expect(find.text(l10n.dashboardCoachLowSavings), findsNothing);
+    });
+
+    testWidgets(
+        'savingsRate 0.08: dedicated card shows 8.0% and the low-savings tip (pre-existing behaviour preserved)',
+        (tester) async {
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.08));
+      await tester.pumpAndSettle();
+
+      expect(find.text(formatPercentage(0.08)), findsOneWidget);
+      expect(find.text(l10n.dashboardCoachLowSavings), findsOneWidget);
+      expect(find.text(l10n.dashboardCoachGoodSavings), findsNothing);
+    });
+
+    testWidgets(
+        'value colour follows the rate in points: 0.449 → ok, 0.15 → warn, 0.08 → bad',
+        (tester) async {
+      Color? colorOf(String text) =>
+          tester.widget<Text>(find.text(text)).style?.color;
+
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.449));
+      await tester.pumpAndSettle();
+      expect(colorOf(formatPercentage(0.449)),
+          AppColors.ok(tester.element(find.text(formatPercentage(0.449)))));
+
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.15));
+      await tester.pumpAndSettle();
+      expect(colorOf(formatPercentage(0.15)),
+          AppColors.warn(tester.element(find.text(formatPercentage(0.15)))));
+
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.08));
+      await tester.pumpAndSettle();
+      expect(colorOf(formatPercentage(0.08)),
+          AppColors.bad(tester.element(find.text(formatPercentage(0.08)))));
+    });
+
+    testWidgets(
+        'boundary 0.20: exact good-savings threshold → ok colour and good-savings tip',
+        (tester) async {
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.20));
+      await tester.pumpAndSettle();
+
+      expect(find.text(formatPercentage(0.20)), findsOneWidget);
+      expect(
+        tester.widget<Text>(find.text(formatPercentage(0.20))).style?.color,
+        AppColors.ok(tester.element(find.text(formatPercentage(0.20)))),
+      );
+      expect(find.text(l10n.dashboardCoachGoodSavings), findsOneWidget);
+    });
+
+    testWidgets(
+        'boundary 0.10: exact low-savings threshold → warn colour, no low-savings alarm (tip is strictly "below 10%")',
+        (tester) async {
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: 0.10));
+      await tester.pumpAndSettle();
+
+      expect(find.text(formatPercentage(0.10)), findsOneWidget);
+      expect(
+        tester.widget<Text>(find.text(formatPercentage(0.10))).style?.color,
+        AppColors.warn(tester.element(find.text(formatPercentage(0.10)))),
+      );
+      expect(find.text(l10n.dashboardCoachLowSavings), findsNothing);
+      expect(find.text(l10n.dashboardCoachGoodSavings), findsNothing);
+    });
+
+    testWidgets(
+        'negative savingsRate -0.05: shows the negative ×100 percentage in red (not clamped to 0, not a fraction)',
+        (tester) async {
+      await tester.pumpWidget(buildSavingsDashboard(savingsRate: -0.05));
+      await tester.pumpAndSettle();
+
+      expect(find.text('-0.1%'), findsNothing); // the buggy fraction rendering
+      expect(find.text(formatPercentage(-0.05)), findsOneWidget);
+      expect(
+        tester.widget<Text>(find.text(formatPercentage(-0.05))).style?.color,
+        AppColors.bad(tester.element(find.text(formatPercentage(-0.05)))),
+      );
     });
   });
 }


### PR DESCRIPTION
## Resumo

fix(dashboard): cartão Taxa de Poupança e dica do Coach escalam a fracção savingsRate ×100 na exibição (#1219)

## O que mudou

**`lib/screens/dashboard_screen.dart`** — o cartão dedicado "TAXA DE POUPANÇA" e a dica do Coach no Início tratavam `summary.savingsRate` (fracção 0..1) como se fosse percentagem. Quatro pontos do mesmo defeito, corrigidos:

1. **Valor do cartão** (`_buildSavingsRateCard`): mostrava `'${currentRate.toStringAsFixed(1)}%'` → com `savingsRate: 0.449` renderizava "0.4%". Passa a usar `formatPercentage(currentRate)` → "44,9%" (pt) / "44.9%" (en), o mesmo helper já usado no cartão resumo (linha ~1136), unificando o separador decimal localizado com o resto da app.
2. **Cor** (`_buildSavingsRateCard`): os limiares comparavam a fracção com `20`/`10`, caindo sempre em `bad` (vermelho) para qualquer fracção válida. Introduzi `final ratePct = currentRate * 100;` e os limiares passam a `ratePct >= 20` (ok) / `ratePct >= 10` (warn) / senão bad.
3. **Dica falsa do Coach** (`_buildCoachInsightCard`): `savingsRate < 10` era sempre verdadeiro para uma fracção → mostrava sempre "abaixo de 10%". Passa a `savingsRate < 0.10`.
4. **"Poupança boa" inalcançável** (`_buildCoachInsightCard`): `savingsRate >= 20` nunca era verdadeiro. Passa a `savingsRate >= 0.20`.

Não mexi no cartão resumo (linha ~1136), na tab Mais (`more_context_builder.dart`), no export, no AI coach service, nem nas barras de tendência do cartão (que já calculam em pontos percentuais).

**`test/functional/dashboard_screen_functional_test.dart`** — novo grupo com 6 testes que pumbam `DashboardScreen` real (`showSavingsRate: true`, `showCoachInsight: true`, `onOpenCoach` fornecido) e asseguram o valor ×100, as cores e a dica certa.

## Porque assim

Seguí o plano do curator na íntegra. A convenção da app é escalar ×100 no momento da exibição (`export_service.dart:269`, `ai_coach_service.dart:761`, `savings_rate_insight_card.dart:33`, `more_context_builder.dart:88`, `budget_charts.dart:427`, `stress_index.dart:84`, `formatters.dart`). O `dashboard_screen.dart` era o único sítio a usar a fracção directamente. Usei `ratePct = currentRate * 100` para a cor e `formatPercentage(currentRate)` para o valor — duas opções que o curator propôs, adoptando a mais localizada para o valor (idêntico ao cartão resumo na mesma linha de ecrã) e a mais legível para os limiares.

Alternativas descartadas:
- **Comparar a fracção directamente** (`currentRate >= 0.20`) — funcionaria, mas mistura as duas unidades no mesmo método; `ratePct` mantém tudo em pontos percentuais, coerente com as barras de tendência (linha 957) que já usam essa unidade.
- **Manter `toStringAsFixed(1)` + `%` com `* 100`** — funcionaria para en, mas quebraria o separador pt-PT (44,9% com vírgula) que o resto da app já usa via `formatPercentage`.

Nota de âmbito (curator): o cartão resumo (1136) usa `savingsRate > 0 ? savingsRate : 0`, escondendo taxas negativas a 0,0%. Não é o defeito reportado — deixei como está para manter o fix focado.

## Critérios de aceitação

- [x] Com `BudgetSummary(savingsRate: 0.449, ...)`, o cartão dedicado "TAXA DE POUPANÇA" mostra **44,9%** (pt-PT) ou **44.9%** (en) — nunca "0.4%". *Valor via `formatPercentage(currentRate)`; teste 1 assere `find.text(formatPercentage(0.449))` e `find.text('0.4%')` ausente.*
- [x] Com `savingsRate: 0.449`, a cor do valor no cartão dedicado é `AppColors.ok` (verde, porque ≥ 20%) — não vermelho. *`ratePct = 44.9 >= 20` → ok; teste 3.*
- [x] Com `savingsRate: 0.449`, a dica do Coach no Início é a de poupança boa ("Está a poupar mais de 20%"), **não** a de "abaixo de 10%". *`savingsRate >= 0.20` → good-savings; teste 1.*
- [x] Com `savingsRate: 0.08` (poupança real baixa), a dica continua a ser "abaixo de 10%" e o valor mostra **8,0%** a vermelho. *`savingsRate < 0.10` → low-savings; testes 2 e 3.*
- [x] Com `savingsRate: 0.15`, a cor é `AppColors.warn` (amarelo, 10–20%). *`15 >= 10 && < 20` → warn; teste 3.*
- [x] O cartão resumo "Taxa Poupança" (`dashboard_screen.dart:1136`) e a tab Mais ("A poupar 45% este mês") continuam a mostrar valores correctos — **inalterados**. *Diff apenas toca `_buildSavingsRateCard` e `_buildCoachInsightCard`.*
- [x] As barras de tendência do cartão dedicado continuam a desenhar-se com os mesmos valores relativos — **inalteradas**. *Diff não toca nas linhas 946-960 / 986-1019.*

## Testes

- **Passo vermelho:** o teste do cartão dedicado, escrito e corrido **antes** do fix, falhou com:
  - `0.449`: `Expected: no matching candidates / Actual: _TextWidgetFinder:<Found 1 widget with text "0.4%": [Text("0.4%", ..., color: Color(alpha: 1.0000, red: 0.7255, green: 0.1098, blue: 0.1098)...)]>` — a fracção crua renderizada, a vermelho.
  - `0.08`: `Expected: exactly one matching candidate / Actual: _TextWidgetFinder:<Found 0 widgets with text "8,0%": []>` — o valor não escalado (renderizava "0.1%").
  - Cores: `Bad state: No element` — o texto ×100 não existia para lhe ler a cor.
- **Casos cobertos:** para além do caminho feliz (0.449 → 44,9% verde + boa poupança):
  - **Valores reais baixos** (0.08 → 8,0% vermelho + dica "abaixo de 10%") — garante que o fix não mascara poupanças genuinamente baixas.
  - **Fronteira exacta** 0.20 → ok + boa poupança; **fronteira exacta** 0.10 → warn + **sem** alarme de "abaixo de 10%" (a mensagem é estritamente "below 10%").
  - **Negativos** (-0.05 → "-5,0%" a vermelho, não clampado a 0, não a fracção "-0.1%").
  - **O inverso do fix:** `find.text('0.4%')` e `find.text('-0.1%')` assegurados ausentes; a dica de boa poupança assegurada ausente quando a taxa é baixa.
- **Sanity-check:** revertido o fix de produção mantendo os testes → os 6 testes do grupo falham (`Some tests failed`); restaurado o fix → os 6 passam.
- `test/functional/dashboard_screen_functional_test.dart` — resultado final da suite completa: **2442 passaram, 0 falharam**.

## Testes

2442 passaram, 0 falharam

## Linked Issue

Fixes #1219