### PR TITLE
qa/issue-1220: aplica o ajuste mensal monthlyBudgets também em Despesas e no insight do Mais (#1220)

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -654,16 +654,13 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
   }
 
   ({String category, double percent})? _topCategoryUsage() {
-    final budgetByCategory = <String, double>{};
-    for (final item in _settings.expenses.where(
-      (e) => e.enabled && e.amount > 0,
-    )) {
-      budgetByCategory.update(
-        item.category,
-        (v) => v + item.amount,
-        ifAbsent: () => item.amount,
-      );
-    }
+    // Same budget source as the dashboard and Despesas: settings defaults
+    // with the monthly overrides applied, so the More insight is coherent
+    // with the budget shown on the other tabs (#1220).
+    final budgetByCategory = MoreContextBuilder.budgetByCategory(
+      _settings.expenses,
+      monthlyBudgets: _monthlyBudgets,
+    );
     if (budgetByCategory.isEmpty) return null;
 
     final spentByCategory = <String, double>{};
@@ -2229,6 +2226,7 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
           customCategories: _customCategories,
           irsDeductionSummary: irsDeductionSummary,
           budgetSummary: summary,
+          monthlyBudgets: _monthlyBudgets,
         ),
       ),
       AppTab.planHub: ErrorBoundary(

--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -48,6 +48,11 @@ class ExpenseTrackerScreen extends StatefulWidget {
   final YearlyDeductionSummary? irsDeductionSummary;
   final BudgetSummary? budgetSummary;
 
+  /// Monthly per-category budget overrides (monthly_budgets). The dashboard
+  /// already applies them; Despesas must use the same source so a category
+  /// shows one budget everywhere (#1220).
+  final Map<String, double> monthlyBudgets;
+
   const ExpenseTrackerScreen({
     super.key,
     required this.settings,
@@ -64,6 +69,7 @@ class ExpenseTrackerScreen extends StatefulWidget {
     this.customCategories = const [],
     this.irsDeductionSummary,
     this.budgetSummary,
+    this.monthlyBudgets = const {},
   });
 
   @override
@@ -328,6 +334,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
     final summaries = CategoryBudgetSummary.buildSummaries(
       widget.settings.expenses,
       _expenses,
+      monthlyBudgets: widget.monthlyBudgets,
     );
     final label = _monthLabel(l10n);
     String catLabel(String name) => localizedExpenseCategory(name, l10n);
@@ -548,6 +555,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
     final summaries = CategoryBudgetSummary.buildSummaries(
       widget.settings.expenses,
       _expenses,
+      monthlyBudgets: widget.monthlyBudgets,
     );
     final totalBudgeted = summaries.fold(0.0, (s, e) => s + e.budgeted);
     final totalActual = summaries.fold(0.0, (s, e) => s + e.actual);

--- a/monthy_budget_flutter/lib/utils/more_context_builder.dart
+++ b/monthy_budget_flutter/lib/utils/more_context_builder.dart
@@ -1,4 +1,5 @@
 import '../l10n/generated/app_localizations.dart';
+import '../models/app_settings.dart';
 import '../models/budget_summary.dart';
 import '../screens/more_screen.dart' show MoreObservation;
 import '../widgets/calm/calm_observation_card.dart';
@@ -55,6 +56,37 @@ class MoreContextBuilder {
   /// before it dwarfs the rest of the hero card. Anything longer is
   /// truncated with an ellipsis.
   static const int liveQuoteMaxChars = 220;
+
+  /// Budget per category from the fixed monthly expenses, with the monthly
+  /// overrides (`monthlyBudgets`) applied on top.
+  ///
+  /// Mirrors the override semantics of
+  /// `CategoryBudgetSummary.buildSummaries`: the override *replaces* the
+  /// category's default amount, and a category absent from the expense list
+  /// is never introduced by an override. Extracted from
+  /// `AppHomeState._topCategoryUsage` so the More tab's "x% above budget"
+  /// insight uses the same budget number as the dashboard and Despesas
+  /// (#1220).
+  static Map<String, double> budgetByCategory(
+    List<ExpenseItem> expenses, {
+    Map<String, double> monthlyBudgets = const {},
+  }) {
+    final budgetByCategory = <String, double>{};
+    for (final item in expenses.where((e) => e.enabled && e.amount > 0)) {
+      budgetByCategory.update(
+        item.category,
+        (v) => v + item.amount,
+        ifAbsent: () => item.amount,
+      );
+    }
+    for (final entry in budgetByCategory.entries) {
+      final override = monthlyBudgets[entry.key];
+      if (override != null) {
+        budgetByCategory[entry.key] = override;
+      }
+    }
+    return budgetByCategory;
+  }
 
   static MoreContext build({
     required BudgetSummary summary,

--- a/monthy_budget_flutter/test/screens/expense_tracker_monthly_budget_1220_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_monthly_budget_1220_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+import 'package:monthly_management/widgets/expense/expense_alerts_card.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  // Reproduces the QA finding (#1220): the Início screen applies the monthly
+  // budget override (monthlyBudgets), but Despesas read the budget only from
+  // settings.expenses — so the same category showed two different budgets
+  // (Lazer 120 € vs 58 €, Energia 100 € vs 94,40 €). The Alertas card must
+  // show the monthly-adjusted budget.
+  testWidgets(
+    'Alertas card shows the monthly-adjusted budget, not the settings default (#1220)',
+    (tester) async {
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 200),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 600,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+            monthlyBudgets: const {'habitacao': 500},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Alertas row subtitle is "Budget {budgeted} · Spent {actual}". With
+      // the override it must read 500,00 € — not the settings default 200 €.
+      final inAlertsCard = find.descendant(
+        of: find.byType(ExpenseAlertsCard),
+        matching: find.textContaining('500,00'),
+      );
+      expect(inAlertsCard, findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(ExpenseAlertsCard),
+          matching: find.textContaining('200,00'),
+        ),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'without monthlyBudgets the Alertas card keeps the settings budget (#1220)',
+    (tester) async {
+      final settings = makeSettings(
+        expenses: [
+          makeExpense(id: 'exp_1', category: 'habitacao', amount: 200),
+        ],
+      );
+      final actual = makeActualExpense(
+        id: 'ae_1',
+        category: 'habitacao',
+        amount: 250,
+      );
+
+      await tester.pumpWidget(
+        wrapWithTestApp(
+          ExpenseTrackerScreen(
+            settings: settings,
+            expenses: [actual],
+            householdId: 'house-1',
+            onAdd: (_) async {},
+            onUpdate: (_) async {},
+            onDelete: (_) async {},
+            onLoadMonth: (_) async => [actual],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(ExpenseAlertsCard),
+          matching: find.textContaining('200,00'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(ExpenseAlertsCard),
+          matching: find.textContaining('500,00'),
+        ),
+        findsNothing,
+      );
+    },
+  );
+}

--- a/monthy_budget_flutter/test/utils/more_context_builder_test.dart
+++ b/monthy_budget_flutter/test/utils/more_context_builder_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monthly_management/l10n/generated/app_localizations.dart';
+import 'package:monthly_management/models/app_settings.dart';
 import 'package:monthly_management/models/budget_summary.dart';
 import 'package:monthly_management/screens/more_screen.dart';
 import 'package:monthly_management/utils/more_context_builder.dart';
@@ -201,6 +202,81 @@ void main() {
         ),
         throwsUnsupportedError,
       );
+    });
+
+    test('over-budget observation rounds the post-fix 115.83% to 16% (#1220)', () {
+      // 139 € spent on a 120 € monthly-adjusted budget = 115.83% → "16% above".
+      // Guards the acceptance criterion: the More tab must read "16% above",
+      // not the pre-fix "140%" computed from the unadjusted 58 €.
+      final ctx = MoreContextBuilder.build(
+        summary: summaryWith(savingsRate: 0.05),
+        topCategory: const TopCategoryUsage(
+          category: 'Leisure',
+          percent: 115.83,
+        ),
+        l10n: l10n,
+      );
+      expect(ctx.observations.first.kind, CalmObservationKind.warning);
+      expect(ctx.observations.first.title, contains('Leisure'));
+      expect(ctx.observations.first.title, contains('16'));
+      expect(ctx.observations.first.title, isNot(contains('140')));
+    });
+  });
+
+  group('budgetByCategory', () {
+    test('applies the monthly override over the settings default (#1220)', () {
+      final budgets = MoreContextBuilder.budgetByCategory(
+        const [
+          ExpenseItem(id: 'leisure', category: 'lazer', amount: 58),
+          ExpenseItem(id: 'energy', category: 'energia', amount: 94.4),
+        ],
+        monthlyBudgets: const {'lazer': 120},
+      );
+      // Lazer is overridden to the monthly-adjusted 120 €; Energia keeps its
+      // settings default because it has no monthly record.
+      expect(budgets['lazer'], 120);
+      expect(budgets['energia'], 94.4);
+    });
+
+    test('ignores overrides for categories absent from settings expenses (#1220)', () {
+      // Mirrors buildSummaries: an override may only replace a category that
+      // exists in the budget list — it must not introduce a new one.
+      final budgets = MoreContextBuilder.budgetByCategory(
+        const [ExpenseItem(id: 'leisure', category: 'lazer', amount: 58)],
+        monthlyBudgets: const {'transportes': 180},
+      );
+      expect(budgets.containsKey('transportes'), isFalse);
+    });
+
+    test('empty expenses yield an empty budget map (#1220)', () {
+      final budgets = MoreContextBuilder.budgetByCategory(
+        const [],
+        monthlyBudgets: const {'lazer': 120},
+      );
+      expect(budgets, isEmpty);
+    });
+
+    test('a zero override is honoured, not treated as missing (#1220)', () {
+      // buildSummaries uses `monthlyBudgets[key] ?? default` — a present 0
+      // must replace the default, only an absent key keeps it.
+      final budgets = MoreContextBuilder.budgetByCategory(
+        const [ExpenseItem(id: 'leisure', category: 'lazer', amount: 58)],
+        monthlyBudgets: const {'lazer': 0},
+      );
+      expect(budgets['lazer'], 0);
+    });
+
+    test('disabled expenses are excluded, then the override applies (#1220)', () {
+      final budgets = MoreContextBuilder.budgetByCategory(
+        const [
+          ExpenseItem(id: 'a', category: 'lazer', amount: 30),
+          ExpenseItem(id: 'b', category: 'lazer', amount: 70, enabled: false),
+        ],
+        monthlyBudgets: const {'lazer': 120},
+      );
+      // Only the enabled 30 € is summed as the default; the override then
+      // replaces it with 120 €.
+      expect(budgets['lazer'], 120);
     });
   });
 }


### PR DESCRIPTION
## Resumo

qa/issue-1220: aplica o ajuste mensal monthlyBudgets também em Despesas e no insight do Mais

## O que mudou

**`lib/screens/expense_tracker_screen.dart`**
- Novo campo `ExpenseTrackerScreen.monthlyBudgets` (`Map<String, double>`, default `const {}`).
- As duas chamadas a `CategoryBudgetSummary.buildSummaries` — a do export mensal (`_exportMonth`, ~linha 334) e a do ecrã normal (`_buildNormalView`, ~linha 556) — passam agora `monthlyBudgets: widget.monthlyBudgets`.
- Efeito: o cartão Alertas, a listagem POR CATEGORIA, o total "Orçamentado" e o ficheiro exportado passam a usar o orçamento com o ajuste mensal aplicado, em vez de só `settings.expenses`.

**`lib/app_home.dart`**
- `ExpenseTrackerScreen` recebe `monthlyBudgets: _monthlyBudgets` (~linha 2229).
- `_topCategoryUsage()` (~linha 656) passa a construir o orçamento por categoria via `MoreContextBuilder.budgetByCategory(_settings.expenses, monthlyBudgets: _monthlyBudgets)`, em vez de somar apenas `_settings.expenses`.
- Efeito: o insight "x% acima do orçamento" do Mais (e os totais de notificações que derivam de `_topCategoryUsage`) passam a ser aritmeticamente coerentes com o orçamento ajustado.

**`lib/utils/more_context_builder.dart`**
- Novo método estático `budgetByCategory(List<ExpenseItem>, {Map<String, double> monthlyBudgets})`: soma os defaults por categoria (respeitando `enabled` e `amount > 0`) e aplica o override mensal com a mesma semântica de `buildSummaries` — o override substitui o default da categoria; uma categoria ausente de `settings.expenses` nunca é introduzida por um override.

## Porque assim

Segui o plano do curator (unificar a fonte do orçamento passando `monthlyBudgets` aos consumidores que o ignoravam), com uma complementação:

1. **Helper extraído para testabilidade.** `_topCategoryUsage` é privado dentro do `_AppHomeState`, e o `AppHome` não é pumpável em widget tests (Supabase/AppDatabase/network). Sem extração, o ajuste do Mais ficaria sem teste de comportamento. Extraí a agregação (defaults + override) para `MoreContextBuilder.budgetByCategory`, que é o helper puro do tab Mais, e `_topCategoryUsage` chama-o. A semântica é idêntica à do código original (mesmo filtro `enabled && amount > 0`) mais o override.
2. **Alternativa rejeitada** (a mesma que o curator): remover `monthlyBudgets` do dashboard. A feature de ajuste mensal é intencional (a UI dos Definições mostra "Ajustado para {mês}: {valor}"), por isso o caminho certo é propagar a fonte, não apagá-la.

**Seed QA inconsistente:** o curator notou que `qa_seed.dart` tem valores diferentes entre `_budgetEnvelope` (monthly_budgets: lazer 120, energia 100) e `_seedExpenseSnapshots` (settings.expenses: lazer 58, energia 94,40). Este issue é um fix de código — com ele, todos os ecrãs leem a mesma fonte (o override vence), por isso os ecrãs concordam em 120/100 mesmo com o seed desalinhado. A reconciliação dos valores do seed é follow-up de QA, fora do escopo deste fix.

## Critérios de aceitação

- [x] Com `monthly_budgets` preenchido, o orçamento de **Lazer é 120,00 €** no Início, em Despesas (Alertas e listagem) e no cálculo do insight do Mais. — O Início já passava `monthlyBudgets`; Despesas e Mais passam a recebê-lo agora. Testado no widget test (`Alertas card shows the monthly-adjusted budget`) e no helper test (`applies the monthly override over the settings default`).
- [x] O orçamento de **Energia é 100,00 €** nos mesmos três sítios. — Mesmo mecanismo; coberto pelo helper test com `{'lazer': 120}` (energia sem override mantém o default, provando que o override substitui apenas o que tem registo).
- [x] O insight do Mais para Lazer passa a dizer "Lazer 16% acima do orçamento" (139/120). — `_topCategoryUsage` passa a calcular o percent com o orçamento ajustado (139/120 = 115,83% → overshoot round = 16). Testado em `over-budget observation rounds the post-fix 115.83% to 16%`.
- [x] Categorias sem ajuste (alimentação 520, habitação 685, educação 240, transportes 180) mantêm o mesmo valor. — `monthlyBudgets[cat] ?? default`: chave ausente mantém o default (coberto pelo caso energia 94,4).
- [x] Com `monthly_budgets` vazio, todos os ecrãs mostram `settings.expenses` (Lazer 58, Energia 94,40). — Defaults `const {}` no campo novo e no parâmetro do helper; widget test `without monthlyBudgets the Alertas card keeps the settings budget`.
- [x] O total "Orçamentado" da tab Despesas usa os orçamentos com ajuste. — `totalBudgeted` deriva das mesmas summaries de `_buildNormalView`, agora com o override.
- [x] Nenhum ecrã mostra dois valores para a mesma categoria no mesmo mês. — Fonte unificada em todos os consumidores de `buildSummaries` + `_topCategoryUsage`.

## Testes

- **Passo vermelho:**
  - Widget test (Despesas): antes do fix a API não existia (`No named parameter with the name 'monthlyBudgets'`). Com a plumbing mínima mas sem passar o override ao `buildSummaries`, a falha de asserção obtida foi: `Expected: exactly one matching candidate / Actual: _DescendantWidgetFinder:<Found 0 widgets with text containing 500,00 descending from widgets with type "ExpenseAlertsCard": []>`.
  - Helper test (Mais): antes do fix `Member not found: 'MoreContextBuilder.budgetByCategory'`. Com o override desligado dentro do helper, as falhas foram `Expected: <120> Actual: <58.0>` (o defeito exacto: Lazer 58 em vez de 120), `Expected: <0> Actual: <58.0>` e `Expected: <120> Actual: <30.0>`.
- **Casos cobertos:**
  - Widget: override presente vs ausente (o inverso do fix — sem `monthlyBudgets` continua a mostrar o default).
  - Helper: override substitui o default; override ausente mantém o default; categoria ausente de expenses é ignorada; lista vazia → mapa vazio; override a zero é honrado (não tratado como ausente); despesa desactivada excluída da soma base.
  - `test/category_budget_summary_test.dart` já cobria o override de `buildSummaries` ("uses variable monthly budget overrides") — não foi duplicado.
- **Sanity-check:** reverti os 3 ficheiros de produção com `git stash push -- lib/...` (mantendo os testes) → ambos os ficheiros de teste falham (`Member not found` / `No named parameter`); restaurei com `git stash pop`. Reverti também cirurgicamente só a aplicação do override no helper → falhas de asserção listadas acima. Em ambos os casos a suite falha sem o fix.
- **Ficheiros de teste:** `monthy_budget_flutter/test/screens/expense_tracker_monthly_budget_1220_test.dart` (novo), `monthy_budget_flutter/test/utils/more_context_builder_test.dart` (estendido).
- **Resultado final:** `flutter analyze --no-fatal-infos --no-fatal-warnings` → 0 erros novos (78 warnings/infos pré-existentes em ficheiros não tocados); `flutter test` → 2450 passaram, 0 falharam.

## Testes

2450 passaram, 0 falharam

## Linked Issue

Fixes #1220