### PR TITLE
Adiciona overlayColor ao NavigationBar para suprimir a state-layer no separador seleccionado (#1221)

### DIFF
--- a/monthy_budget_flutter/lib/app_home.dart
+++ b/monthy_budget_flutter/lib/app_home.dart
@@ -41,6 +41,7 @@ import 'models/actual_expense.dart';
 import 'models/monthly_budget.dart';
 import 'widgets/add_expense_sheet.dart';
 import 'widgets/calm/calm.dart';
+import 'widgets/nav_bar_overlay_color.dart';
 import 'screens/expense_tracker_screen.dart';
 import 'models/local_dashboard_config.dart';
 import 'models/expense_snapshot.dart';
@@ -2408,6 +2409,9 @@ class _AppHomeState extends ConsumerState<AppHome> with WidgetsBindingObserver {
                 },
                 backgroundColor: AppColors.surface(context),
                 indicatorColor: AppColors.navIndicator(context),
+                overlayColor: WidgetStateProperty.resolveWith(
+                  navBarOverlayColor,
+                ),
                 height: 72,
                 labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
                 destinations: [

--- a/monthy_budget_flutter/lib/widgets/nav_bar_overlay_color.dart
+++ b/monthy_budget_flutter/lib/widgets/nav_bar_overlay_color.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// State-layer overlay color for the bottom [NavigationBar]'s destinations.
+///
+/// Without an explicit `overlayColor`, Flutter's Material 3 default paints a
+/// semi-transparent `onSurface` state layer over the selection indicator
+/// whenever a destination is hovered/focused/pressed. That layer is
+/// transient for tapped destinations (it fades once the gesture ends), but
+/// it is *persistent* for a destination that receives keyboard/semantics
+/// focus on first frame — on Flutter Web the initial tab (e.g. "Início")
+/// gets that focus at load, so its indicator pill rendered visibly darker
+/// than the other tabs' pill, which is reached only via a transient tap.
+///
+/// The indicator pill already communicates selection, so the state layer is
+/// suppressed for the selected destination — but only for it, to keep the
+/// hover/focus/press feedback for keyboard/mouse users on the *unselected*
+/// destinations intact. See issue #1221.
+Color? navBarOverlayColor(Set<WidgetState> states) {
+  if (states.contains(WidgetState.selected)) {
+    return Colors.transparent;
+  }
+  return null;
+}

--- a/monthy_budget_flutter/test/widgets/nav_bar_overlay_color_test.dart
+++ b/monthy_budget_flutter/test/widgets/nav_bar_overlay_color_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/widgets/nav_bar_overlay_color.dart';
+
+// Regression test for #1221: the bottom NavigationBar's selected-tab pill
+// showed a neutral-gray overlay on "Início" (focused since first frame) but
+// the correct accentSoft lilac on the other three tabs (only ever reached
+// via a transient tap that doesn't leave a lingering overlay). Root cause:
+// no `overlayColor` was set on the NavigationBar, so Flutter's Material 3
+// default state-layer (~10% onSurface) painted over the indicator whenever
+// a destination was focused/hovered/pressed. The fix suppresses that layer
+// specifically for the selected destination, since the indicator pill
+// already communicates selection and needs no extra tint.
+void main() {
+  group('navBarOverlayColor', () {
+    test('suppresses the state layer for the selected destination', () {
+      final resolved = navBarOverlayColor({WidgetState.selected});
+      expect(resolved, Colors.transparent);
+    });
+
+    test(
+      'suppresses the state layer even when selected AND focused '
+      '(the exact combination that broke the initial "Início" tab)',
+      () {
+        final resolved = navBarOverlayColor({
+          WidgetState.selected,
+          WidgetState.focused,
+        });
+        expect(resolved, Colors.transparent);
+      },
+    );
+
+    test('keeps the default overlay for an unselected, unfocused destination', () {
+      final resolved = navBarOverlayColor({});
+      expect(resolved, isNull);
+    });
+
+    test(
+      'keeps the default focus overlay for a NOT-selected destination '
+      '(accessibility: keyboard focus must stay visible)',
+      () {
+        final resolved = navBarOverlayColor({WidgetState.focused});
+        expect(resolved, isNull);
+      },
+    );
+
+    test('keeps the default hover overlay for a NOT-selected destination', () {
+      final resolved = navBarOverlayColor({WidgetState.hovered});
+      expect(resolved, isNull);
+    });
+
+    test('keeps the default press overlay for a NOT-selected destination', () {
+      final resolved = navBarOverlayColor({WidgetState.pressed});
+      expect(resolved, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Resumo

Adiciona overlayColor ao NavigationBar para suprimir a state-layer no separador seleccionado

## O que mudou

- `lib/widgets/nav_bar_overlay_color.dart` (novo): função pura `navBarOverlayColor(Set<WidgetState> states)` que devolve `Colors.transparent` quando `WidgetState.selected` está presente, e `null` (comportamento por omissão do Material 3) caso contrário.
- `lib/app_home.dart`: import da nova função; `NavigationBar` da bottom nav (linha ~2403) passa a definir `overlayColor: WidgetStateProperty.resolveWith(navBarOverlayColor)`. `indicatorColor` e a definição em `app_theme.dart` (`NavigationBarThemeData`, linhas 190-207) permanecem inalterados.

Antes desta alteração, o `NavigationBar` não tinha `overlayColor`, pelo que o SDK aplicava a state-layer por omissão do Material 3 (~10% `onSurface`) sobre o indicador em `hovered`/`focused`/`pressed`. Essa camada é transitória num separador alcançado por tap (desaparece com o gesto), mas persistente num separador que recebe foco de teclado/semântica ao arrancar a app (o 'Início', primeiro nó focável em Flutter Web) — daí a pill cinza/navy só no Início. Agora a state-layer é suprimida apenas quando o destino já está seleccionado, porque o pill já comunica esse estado.

## Porque assim

Segui o plano do curator sem desvios: extraí a função `overlayColor` para um ficheiro isolado e testável (`lib/widgets/nav_bar_overlay_color.dart`) em vez de a inlinear no `NavigationBar`, precisamente para poder testá-la sem montar `AppHome` (que depende de Supabase/AppDatabase e não é pump-ável em widget tests — ver `pattern_fabclearance_apphome_pump_infeasibility`). A função é pura (`Set<WidgetState> -> Color?`), sem `BuildContext`, o que a torna trivialmente unit-testável e reutilizável se outro `NavigationBar`/`TabBar` vier a precisar do mesmo comportamento.

Não toquei em `AppColors.navIndicator`/`accentSoft` nem em `NavigationBarThemeData` — confirmados como correctos pelo curator (grep: só duas definições de `indicatorColor` em `lib/`, aplicadas sem condição por separador).

## Critérios de aceitação

- [x] `lib/app_home.dart` define `overlayColor` no `NavigationBar` da bottom nav — feito via `WidgetStateProperty.resolveWith(navBarOverlayColor)`.
- [x] Com a app recém-arrancada (Início seleccionado, sem tap), o pill deixa de ter overlay sobre o indicador — `navBarOverlayColor({selected, focused})` devolve `Colors.transparent`, testado explicitamente (é a combinação exacta que causava o bug: seleccionado E focado no arranque). Sem overlay, o indicador renderiza a cor pura `accentSoft`/`AppColors.navIndicator`, igual à dos outros separadores.
- [x] Em dark mode aplica-se a mesma lógica — a função não depende de tema/`BuildContext`, o comportamento é idêntico em light/dark (a diferença de cor entre temas vem só do token `accentSoft`, inalterado).
- [x] Feedback de hover/foco/pressão continua visível nos separadores NÃO seleccionados — testado: `navBarOverlayColor` devolve `null` (comportamento por omissão do SDK) para `{focused}`, `{hovered}`, `{pressed}` e `{}` isolados (sem `selected`).
- [x] Nenhuma alteração a ícones, `selectedIcon`, labels, badges ou ordem dos 4 destinos — confirmado pelo diff, que toca só em 2 linhas + 1 import.
- [x] `AppColors.navIndicator`/`accentSoft` e `NavigationBarThemeData` (`app_theme.dart:190-207`) permanecem inalterados — confirmado, zero alterações a `app_theme.dart` no diff.

## Testes

**Passo vermelho:** escrevi `test/widgets/nav_bar_overlay_color_test.dart` antes de criar `lib/widgets/nav_bar_overlay_color.dart`. Ao correr, falhou com:
```
test/widgets/nav_bar_overlay_color_test.dart:3:8: Error: Error when reading 'lib/widgets/nav_bar_overlay_color.dart': No such file or directory
import 'package:monthly_management/widgets/nav_bar_overlay_color.dart';
...
Error: Method not found: 'navBarOverlayColor'.
```
É a razão certa: o contrato (função extraída) ainda não existia — não um `NoSuchMethodError` de widget mal montado.

**Casos cobertos** (6 testes, cada um falha por uma razão diferente):
1. `{selected}` → `Colors.transparent` (caminho feliz: suprime overlay no seleccionado).
2. `{selected, focused}` → `Colors.transparent` — o caso exacto do bug original (Início focado+seleccionado no arranque); prova que a supressão sobrevive à combinação de estados que causava a discrepância.
3. `{}` → `null` (nenhum estado activo, comportamento por omissão preservado).
4. `{focused}` → `null` — inverso do fix: garante que o anel de foco de teclado continua visível em separadores NÃO seleccionados (regressão de acessibilidade que o curator sinalizou como armadilha).
5. `{hovered}` → `null` — idem para hover de rato.
6. `{pressed}` → `null` — idem para feedback de toque/clique.

**Sanity-check:** reverti `lib/app_home.dart` (`git checkout --`) e removi temporariamente `lib/widgets/nav_bar_overlay_color.dart`; corri a suite de testes novos — falhou com o mesmo erro de compilação ("Method not found: navBarOverlayColor"). Restaurei ambos os ficheiros; a suite voltou a passar (6/6).

Ficheiros de teste: `test/widgets/nav_bar_overlay_color_test.dart`. Resultado final da suite completa: `flutter test` → 2456 testes passaram, 0 falharam.

## Testes

2456 testes passaram, 0 falharam (inclui os 6 novos em test/widgets/nav_bar_overlay_color_test.dart). flutter analyze: 78 issues antes e depois (todos pré-existentes em ficheiros de teste não relacionados; zero issues em lib/app_home.dart ou lib/widgets/nav_bar_overlay_color.dart).

## Linked Issue

Fixes #1221