### PR TITLE
Localiza a categoria antes de a interpolar na observação 'X% acima do orçamento' da aba Mais (#1224)

### DIFF
--- a/monthy_budget_flutter/lib/utils/more_context_builder.dart
+++ b/monthy_budget_flutter/lib/utils/more_context_builder.dart
@@ -3,6 +3,7 @@ import '../models/app_settings.dart';
 import '../models/budget_summary.dart';
 import '../screens/more_screen.dart' show MoreObservation;
 import '../widgets/calm/calm_observation_card.dart';
+import 'category_helpers.dart';
 
 /// Top spending category used to generate the headline observation.
 ///
@@ -111,7 +112,10 @@ class MoreContextBuilder {
         MoreObservation(
           id: 'cat-over-${overBudget.category}',
           kind: CalmObservationKind.warning,
-          title: l10n.moreObsCatOverTitle(overBudget.category, overshoot),
+          title: l10n.moreObsCatOverTitle(
+            localizedCategoryLabel(overBudget.category, l10n),
+            overshoot,
+          ),
           body: l10n.moreObsCatOverBody,
         ),
       );

--- a/monthy_budget_flutter/test/utils/more_context_builder_test.dart
+++ b/monthy_budget_flutter/test/utils/more_context_builder_test.dart
@@ -9,9 +9,13 @@ import 'package:monthly_management/widgets/calm/calm_observation_card.dart';
 
 void main() {
   late S l10n;
+  late S l10nPt;
+  late S l10nFr;
 
   setUpAll(() async {
     l10n = await S.delegate.load(const Locale('en'));
+    l10nPt = await S.delegate.load(const Locale('pt'));
+    l10nFr = await S.delegate.load(const Locale('fr'));
   });
 
   BudgetSummary summaryWith({
@@ -221,6 +225,82 @@ void main() {
       expect(ctx.observations.first.title, contains('16'));
       expect(ctx.observations.first.title, isNot(contains('140')));
     });
+
+    test(
+      'over-budget title shows the localized category label, not the raw '
+      'storage key (#1224)',
+      () {
+        // TopCategoryUsage.category carries the raw storage key ('lazer'),
+        // exactly what _topCategoryUsage() returns in production — not a
+        // pre-translated label like the other tests in this file use.
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10n,
+        );
+        final expectedLabel = ExpenseCategory.lazer.localizedLabel(l10n);
+        expect(ctx.observations.first.title, contains(expectedLabel));
+        expect(ctx.observations.first.title, isNot(contains('lazer')));
+      },
+    );
+
+    test(
+      'over-budget title is localized to pt-PT (raw key coincides with the '
+      'word, but must still resolve through the enum) (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10nPt,
+        );
+        final expectedLabel = ExpenseCategory.lazer.localizedLabel(l10nPt);
+        expect(ctx.observations.first.title, contains(expectedLabel));
+      },
+    );
+
+    test(
+      'over-budget title is localized to fr — the raw pt key must not leak '
+      'into a non-pt locale (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10nFr,
+        );
+        final expectedLabel = ExpenseCategory.lazer.localizedLabel(l10nFr);
+        expect(ctx.observations.first.title, contains(expectedLabel));
+        expect(ctx.observations.first.title, isNot(contains('lazer')));
+      },
+    );
+
+    test(
+      'custom category (not in the ExpenseCategory enum) is shown as-is, '
+      'in every locale (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(
+            category: 'Streaming',
+            percent: 143,
+          ),
+          l10n: l10nFr,
+        );
+        expect(ctx.observations.first.title, contains('Streaming'));
+      },
+    );
+
+    test(
+      'observation id keeps the raw storage key even after the title is '
+      'localized (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10nFr,
+        );
+        expect(ctx.observations.first.id, 'cat-over-lazer');
+      },
+    );
   });
 
   group('budgetByCategory', () {


### PR DESCRIPTION
## Resumo

Localiza a categoria antes de a interpolar na observação 'X% acima do orçamento' da aba Mais

## O que mudou

Em `lib/utils/more_context_builder.dart`:
- Importado `category_helpers.dart`.
- Na construção da observação de categoria acima do orçamento, `l10n.moreObsCatOverTitle(overBudget.category, overshoot)` passou a `l10n.moreObsCatOverTitle(localizedCategoryLabel(overBudget.category, l10n), overshoot)`.
- `overBudget.category` (a chave crua, ex. `'lazer'`) NÃO foi alterado em mais nenhum ponto: continua a ser usado tal-e-qual no `id` da observação (`'cat-over-${overBudget.category}'`) e em qualquer lookup contra `budgetByCategory`. A localização acontece só no ponto de apresentação (`title`), como o plano do curator pedia.

Em `test/utils/more_context_builder_test.dart`:
- `setUpAll` passou a carregar também `l10nPt` e `l10nFr` (além do `l10n` en já existente).
- Adicionados 5 testes novos ao grupo `observations`, todos usando a chave de armazenamento crua (`'lazer'`), não um rótulo já traduzido — ao contrário dos testes pré-existentes desse grupo, que usam `'Leisure'`/`'Food'` (não representam o valor real produzido em produção por `_topCategoryUsage()`).

## Porque assim

Segui o plano do curator sem desvios: a chamada em falta é local, isolada ao ponto de interpolação, e usa o helper `localizedCategoryLabel` já existente em `category_helpers.dart` (o mesmo usado, sob outro nome local, no dashboard). Não toquei em `overBudget.category`, `TopCategoryUsage`, nem em `_topCategoryUsage()` em `app_home.dart` — nenhum deles fazia parte do defeito nem do plano.

## Critérios de aceitação

- [x] `MoreContextBuilder.build` com `TopCategoryUsage(category: 'lazer', percent: 143)` e `l10n` en produz um título que contém `'Leisure'` e NÃO contém `'lazer'` — testado.
- [x] O mesmo teste com `l10n` pt-PT produz um título que contém `'Lazer'` — testado.
- [x] O mesmo teste com `l10n` fr produz o rótulo francês (`'Loisirs'`, via `ExpenseCategory.lazer.localizedLabel(l10nFr)`) e NÃO contém `'lazer'` — testado.
- [x] Categoria personalizada (`'Streaming'`, fora do enum) continua a aparecer sem alteração em qualquer locale — testado com `l10nFr`.
- [x] O `id` da observação (`'cat-over-lazer'`) continua a usar a chave crua — testado explicitamente.
- [x] Os 10 testes já existentes no ficheiro continuam a passar sem alteração — confirmado (fazem parte dos 24 no ficheiro, todos verdes).
- [x] Nenhuma outra chamada a `l10n.moreObsCatOverTitle` no repositório ficou por corrigir — confirmado via grep: só existe 1 call site em código de produção (`more_context_builder.dart:115`), já corrigido.

## Testes

**Passo vermelho:** antes do fix, os 3 testes que exercitam directamente o defeito (en, pt, fr) falharam assim:
```
Expected: contains 'Leisure'
  Actual: 'lazer 43% over budget'

Expected: contains 'Lazer'
  Actual: 'lazer 43% acima do orçamento'

Expected: contains 'Loisirs'
  Actual: 'lazer dépasse de 43% le budget'
```

**Casos cobertos:**
- Locale en, pt e fr — a categoria 'lazer' resolvida para cada rótulo localizado (fronteira: pt é o caso em que a chave crua coincide por acaso com o rótulo certo, por isso é o teste mais fácil de deixar passar por engano — cobri-o explicitamente).
- Categoria personalizada fora do enum ('Streaming') — comportamento de fallback preservado, testado num locale não-pt para confirmar que não há regressão aí.
- Inverso do fix: o `id` da observação continua a usar a chave crua, não o rótulo — garante que não localizei a estrutura de dados por engano, só a apresentação.

**Sanity-check:** revertido `lib/utils/more_context_builder.dart` (via `git stash` isolado a esse ficheiro, mantendo os testes), a suite `more_context_builder_test.dart` falhou exactamente nos 3 testes que expõem o defeito (mensagens acima) — os outros 2 testes novos (categoria personalizada, id) continuaram a passar, como esperado, porque não dependem do fix. Restaurado o fix (`git stash pop`), suite completa a 24/24.

Ficheiros de teste: `test/utils/more_context_builder_test.dart` — resultado final: 24 testes no ficheiro, todos a passar. Suite completa do projecto: 2462 testes, todos a passar. `flutter analyze`: 78 issues antes e depois (todos pré-existentes, nenhum em `more_context_builder.dart` nem no ficheiro de teste tocado).

## Testes

2462 testes passaram, 0 falharam (inclui 24 em more_context_builder_test.dart, 5 novos). flutter analyze: 78 issues antes e depois, nenhum novo, nenhum nos ficheiros alterados.

## Linked Issue

Fixes #1224