### PR TITLE
i18n: localiza o label de semantics 'More info about' dos botões de info via chave ARB moreInfoAbout (#1225) (#1225)

### DIFF
--- a/monthy_budget_flutter/lib/l10n/app_en.arb
+++ b/monthy_budget_flutter/lib/l10n/app_en.arb
@@ -2589,6 +2589,14 @@
     "insightsTaxOutcome": "Estimate annual tax outcome",
 
     "moreTitle": "More",
+    "moreInfoAbout": "More info about {title}",
+    "@moreInfoAbout": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
     "moreDetailedDashboard": "Detailed Dashboard",
     "moreDetailedDashboardSubtitle": "Open full financial dashboard with all cards",
     "moreSavingsSubtitle": "Track and update your goal progress",

--- a/monthy_budget_flutter/lib/l10n/app_es.arb
+++ b/monthy_budget_flutter/lib/l10n/app_es.arb
@@ -2467,6 +2467,14 @@
     "insightsTaxOutcome": "Estimar resultado fiscal anual",
 
     "moreTitle": "Más",
+    "moreInfoAbout": "Más información sobre {title}",
+    "@moreInfoAbout": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
     "moreDetailedDashboard": "Panel Detallado",
     "moreDetailedDashboardSubtitle": "Abrir panel financiero completo con todas las tarjetas",
     "moreSavingsSubtitle": "Seguir y actualizar el progreso de tus metas",

--- a/monthy_budget_flutter/lib/l10n/app_fr.arb
+++ b/monthy_budget_flutter/lib/l10n/app_fr.arb
@@ -2467,6 +2467,14 @@
     "insightsTaxOutcome": "Estimer le resultat fiscal annuel",
 
     "moreTitle": "Plus",
+    "moreInfoAbout": "Plus d'informations sur {title}",
+    "@moreInfoAbout": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
     "moreDetailedDashboard": "Tableau de Bord Detaille",
     "moreDetailedDashboardSubtitle": "Ouvrir le tableau de bord financier complet",
     "moreSavingsSubtitle": "Suivre et mettre a jour la progression des objectifs",

--- a/monthy_budget_flutter/lib/l10n/app_pt.arb
+++ b/monthy_budget_flutter/lib/l10n/app_pt.arb
@@ -4883,6 +4883,15 @@
 
     "moreTitle": "Mais",
     "@moreTitle": { "description": "Title for the More screen" },
+    "moreInfoAbout": "Mais informação sobre {title}",
+    "@moreInfoAbout": {
+        "description": "Accessibility label for info buttons",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
     "moreDetailedDashboard": "Painel Detalhado",
     "@moreDetailedDashboard": { "description": "Detailed dashboard tile title" },
     "moreDetailedDashboardSubtitle": "Abrir painel financeiro completo com todos os cartões",

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations.dart
@@ -8261,6 +8261,12 @@ abstract class S {
   /// **'Mais'**
   String get moreTitle;
 
+  /// Accessibility label for info buttons
+  ///
+  /// In pt, this message translates to:
+  /// **'Mais informação sobre {title}'**
+  String moreInfoAbout(String title);
+
   /// Detailed dashboard tile title
   ///
   /// In pt, this message translates to:

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_en.dart
@@ -4621,6 +4621,11 @@ class SEn extends S {
   String get moreTitle => 'More';
 
   @override
+  String moreInfoAbout(String title) {
+    return 'More info about $title';
+  }
+
+  @override
   String get moreDetailedDashboard => 'Detailed Dashboard';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_es.dart
@@ -4659,6 +4659,11 @@ class SEs extends S {
   String get moreTitle => 'Más';
 
   @override
+  String moreInfoAbout(String title) {
+    return 'Más información sobre $title';
+  }
+
+  @override
   String get moreDetailedDashboard => 'Panel Detallado';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_fr.dart
@@ -4669,6 +4669,11 @@ class SFr extends S {
   String get moreTitle => 'Plus';
 
   @override
+  String moreInfoAbout(String title) {
+    return 'Plus d\'informations sur $title';
+  }
+
+  @override
   String get moreDetailedDashboard => 'Tableau de Bord Detaille';
 
   @override

--- a/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
+++ b/monthy_budget_flutter/lib/l10n/generated/app_localizations_pt.dart
@@ -4656,6 +4656,11 @@ class SPt extends S {
   String get moreTitle => 'Mais';
 
   @override
+  String moreInfoAbout(String title) {
+    return 'Mais informação sobre $title';
+  }
+
+  @override
   String get moreDetailedDashboard => 'Painel Detalhado';
 
   @override

--- a/monthy_budget_flutter/lib/widgets/info_icon_button.dart
+++ b/monthy_budget_flutter/lib/widgets/info_icon_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../l10n/generated/app_localizations.dart';
 import '../theme/app_colors.dart';
 import 'calm/calm.dart';
 
@@ -10,9 +11,10 @@ class InfoIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = S.of(context);
     return Semantics(
       button: true,
-      label: 'More info about $title',
+      label: l10n.moreInfoAbout(title),
       child: InkWell(
         onTap: () => _showSheet(context),
         customBorder: const CircleBorder(),

--- a/monthy_budget_flutter/test/widgets/info_icon_button_test.dart
+++ b/monthy_budget_flutter/test/widgets/info_icon_button_test.dart
@@ -1,10 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/l10n/generated/app_localizations.dart';
 import 'package:monthly_management/widgets/info_icon_button.dart';
 
-void main() {
-  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+Widget wrap(Widget child, {Locale locale = const Locale('en')}) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    locale: locale,
+    home: Scaffold(body: child),
+  );
+}
 
+void main() {
   testWidgets('renders info icon', (tester) async {
     await tester.pumpWidget(wrap(
       const InfoIconButton(title: 'Test Title', body: 'Test body text'),
@@ -32,5 +46,42 @@ void main() {
     await tester.tap(find.byIcon(Icons.close));
     await tester.pumpAndSettle();
     expect(find.text('B'), findsNothing);
+  });
+
+  testWidgets('semantics label is translated in pt locale', (tester) async {
+    await tester.pumpWidget(wrap(
+      const InfoIconButton(title: 'ORÇAMENTO VS REAL', body: 'B'),
+      locale: const Locale('pt'),
+    ));
+    final semantics = tester.getSemantics(find.byType(InfoIconButton));
+    expect(semantics.label, 'Mais informação sobre ORÇAMENTO VS REAL');
+    expect(semantics.label, isNot(contains('More info about')));
+  });
+
+  testWidgets('semantics label is translated in fr locale', (tester) async {
+    await tester.pumpWidget(wrap(
+      const InfoIconButton(title: 'BUDGET VS RÉEL', body: 'B'),
+      locale: const Locale('fr'),
+    ));
+    final semantics = tester.getSemantics(find.byType(InfoIconButton));
+    expect(semantics.label, "Plus d'informations sur BUDGET VS RÉEL");
+  });
+
+  testWidgets('semantics label is translated in es locale', (tester) async {
+    await tester.pumpWidget(wrap(
+      const InfoIconButton(title: 'PRESUPUESTO VS REAL', body: 'B'),
+      locale: const Locale('es'),
+    ));
+    final semantics = tester.getSemantics(find.byType(InfoIconButton));
+    expect(semantics.label, 'Más información sobre PRESUPUESTO VS REAL');
+  });
+
+  testWidgets('semantics label stays in English for en locale', (tester) async {
+    await tester.pumpWidget(wrap(
+      const InfoIconButton(title: 'BUDGET VS ACTUAL', body: 'B'),
+      locale: const Locale('en'),
+    ));
+    final semantics = tester.getSemantics(find.byType(InfoIconButton));
+    expect(semantics.label, 'More info about BUDGET VS ACTUAL');
   });
 }


### PR DESCRIPTION
## Resumo

i18n: localiza o label de semantics 'More info about' dos botões de info via chave ARB moreInfoAbout (#1225)

## O que mudou

- `lib/widgets/info_icon_button.dart` — o label de acessibilidade do botão de informação deixou de usar o literal inglês hardcoded `'More info about $title'` e passou a obter a string via `S.of(context).moreInfoAbout(title)` (import novo de `../l10n/generated/app_localizations.dart`). A assinatura pública (parâmetros `title`/`body`, já traduzidos pelos chamadores) não mudou; só a fonte do label de semantics mudou. O corpo do bottom sheet continua a usar `title`/`body` tal como passados.
- `lib/l10n/app_pt.arb`, `app_en.arb`, `app_fr.arb`, `app_es.arb` — nova chave `moreInfoAbout` com placeholder `title` (String), seguindo o padrão já existente de chaves com placeholder (ex. `filterBy`). Traduções: pt `Mais informação sobre {title}`, en `More info about {title}`, fr `Plus d'informations sur {title}`, es `Más información sobre {title}`. Descrição (`@moreInfoAbout`) apenas no template pt, como é o padrão dos restantes ficheiros.
- `lib/l10n/generated/app_localizations*.dart` (5 ficheiros) — regenerados via `flutter gen-l10n` (l10n.yaml usa `template-arb-file: app_pt.arb`); contêm agora o getter `String moreInfoAbout(String title)` em cada locale. Não editados à mão.
- `test/widgets/info_icon_button_test.dart` — o wrapper do teste passou a incluir `localizationsDelegates` (`S.delegate` + GlobalMaterial/Widgets/Cupertino) e `supportedLocales` (padrão já usado noutros testes, ex. `add_expense_sheet_test.dart`), e foram adicionados 4 testes de semantics por locale.

## Porque assim

Seguido o plano do curator sem desvios. A causa raiz estava isolada ao prefixo: o widget `InfoIconButton` é partilhado por 15+ pontos de uso, mas os `title` já chegam traduzidos via `l10n.*`; o defeito era o literal Dart `'More info about '` que nunca passa pelo pipeline de tradução. A correção troca a fonte do prefixo para a chave ARB, mantendo tudo o resto intacto. Alternativa descartada: meter o prefixo como parâmetro — propagaria o problema para os 15+ chamadores e duplicaria a lógica de concatenação.

## Critérios de aceitação

- [x] `lib/widgets/info_icon_button.dart` já não contém a string literal `'More info about'` — verificado por grep; a única ocorrência do prefixo em inglês fora dos testes é a tradução en legítima no ARB/generated.
- [x] O label de semantics é obtido via `S.of(context).moreInfoAbout(title)` — `info_icon_button.dart:14,17`.
- [x] `app_pt.arb`, `app_en.arb`, `app_fr.arb`, `app_es.arb` têm todos a chave `moreInfoAbout` com as traduções indicadas.
- [x] `app_localizations*.dart` regenerados (não editados à mão) com o getter `String moreInfoAbout(String title)` em todos os locales; diff mínimo (só o getter novo).
- [x] Com `locale: Locale('pt')`, o label é `'Mais informação sobre ORÇAMENTO VS REAL'` — teste `semantics label is translated in pt locale`.
- [x] Com `Locale('fr')` e `Locale('es')`, traduzido nos respetivos idiomas — testes `in fr locale` / `in es locale`.
- [x] Com `Locale('en')`, o label continua `'More info about ...'` — teste `semantics label stays in English for en locale`.
- [x] `title`/`body` do bottom sheet inalterados — os testes de interação existentes (`opens bottom sheet on tap`, `close button dismisses`) continuam a verificar o texto original passado pelo chamador; só o label de semantics mudou de fonte.
- [x] Todos os testes existentes que usam `InfoIconButton` passam — verificado com a suite completa (os dois ficheiros de teste que referenciam o widget têm `localizationsDelegates`: o teste do widget via wrapper local, `expense_tracker_budget_row_1203_test.dart` via `wrapWithTestApp`).

## Testes

- **Passo vermelho:** o teste `semantics label is translated in pt locale` (e fr/es) falha antes do fix com `Expected: 'Mais informação sobre ORÇAMENTO VS REAL' Actual: 'More info about ORÇAMENTO VS REAL'` (idem fr/es com o prefixo inglês). Falha pela razão certa — o prefixo hardcoded — não por erro de compilação ou widget ausente. Resultado antes do fix: `00:00 +4 -3: Some tests failed.`
- **Casos cobertos:** 4 locales (pt, fr, es — o fix — e en — o inverso do fix, garante que o inglês não regressa); o teste pt inclui também `isNot(contains('More info about'))` para o prefixo não reaparecer. Os testes pré-existentes de interação (render, abrir sheet, fechar) garantem que `title`/`body` do sheet ficam inalterados. Fronteiras/vazios/repetição não se aplicam: é um label de string com placeholder, sem lógica numérica ou de estado; o caso vazio (`title: ''`) produziria `'Mais informação sobre '` mas nenhum chamador passa título vazio (os títulos vêm de `l10n.*Title`).
- **Sanity-check:** revertido `lib/widgets/info_icon_button.dart` para a versão com o literal hardcoded (mantendo os testes), a suite falhou nos 3 testes de locale com as mesmas mensagens do passo vermelho; restaurado o fix, os 7 testes do ficheiro voltaram a passar.
- Ficheiros de teste: `test/widgets/info_icon_button_test.dart` (7 testes).
- Resultado final: `flutter analyze --no-fatal-infos --no-fatal-warnings` sem erros novos nos ficheiros alterados (78 issues pré-existentes em ficheiros não tocados); `flutter test` → **2466 passaram, 0 falharam**.

## Testes

2466 passaram, 0 falharam (flutter test completo)

## Linked Issue

Fixes #1225