### PR TITLE
QA: promover dev para main (2 commit(s))

### DIFF
--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -583,7 +583,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      CalmEyebrow(l10n.expenseTrackerMovementEyebrow),
+                      CalmEyebrow(l10n.expenseTrackerMovementEyebrow.toUpperCase()),
                       const SizedBox(height: 4),
                       Text(
                         l10n.expenseTrackerExpensesTitle,
@@ -686,7 +686,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        CalmEyebrow(l10n.expenseTrackerThisMonthEyebrow),
+                        CalmEyebrow(l10n.expenseTrackerThisMonthEyebrow.toUpperCase()),
                         const SizedBox(height: 4),
                         FittedBox(
                           fit: BoxFit.scaleDown,
@@ -712,7 +712,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        CalmEyebrow(l10n.expenseTrackerAvgPerDayEyebrow),
+                        CalmEyebrow(l10n.expenseTrackerAvgPerDayEyebrow.toUpperCase()),
                         const SizedBox(height: 4),
                         FittedBox(
                           fit: BoxFit.scaleDown,
@@ -738,7 +738,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        CalmEyebrow(l10n.expenseTrackerBillsEyebrow),
+                        CalmEyebrow(l10n.expenseTrackerBillsEyebrow.toUpperCase()),
                         const SizedBox(height: 4),
                         Text(
                           '${_expenses.length}',
@@ -871,7 +871,7 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
                         sliver: SliverToBoxAdapter(
                           child: Row(
                             children: [
-                              CalmEyebrow(l10n.expenseTrackerByCategoryEyebrow),
+                              CalmEyebrow(l10n.expenseTrackerByCategoryEyebrow.toUpperCase()),
                               const Spacer(),
                               Text(
                                 '${summaries.length}',

--- a/monthy_budget_flutter/lib/utils/more_context_builder.dart
+++ b/monthy_budget_flutter/lib/utils/more_context_builder.dart
@@ -3,6 +3,7 @@ import '../models/app_settings.dart';
 import '../models/budget_summary.dart';
 import '../screens/more_screen.dart' show MoreObservation;
 import '../widgets/calm/calm_observation_card.dart';
+import 'category_helpers.dart';
 
 /// Top spending category used to generate the headline observation.
 ///
@@ -111,7 +112,10 @@ class MoreContextBuilder {
         MoreObservation(
           id: 'cat-over-${overBudget.category}',
           kind: CalmObservationKind.warning,
-          title: l10n.moreObsCatOverTitle(overBudget.category, overshoot),
+          title: l10n.moreObsCatOverTitle(
+            localizedCategoryLabel(overBudget.category, l10n),
+            overshoot,
+          ),
           body: l10n.moreObsCatOverBody,
         ),
       );

--- a/monthy_budget_flutter/test/screens/expense_tracker_eyebrow_uppercase_1222_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_eyebrow_uppercase_1222_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/app_shell.dart';
+import 'package:monthly_management/screens/expense_tracker_screen.dart';
+
+import '../helpers/test_app.dart';
+import '../helpers/test_helpers.dart';
+
+/// Reproduces #1222: every other CalmEyebrow in the app is rendered in
+/// UPPERCASE via an explicit `.toUpperCase()` at the call site (see
+/// dashboard_screen.dart), but the 5 CalmEyebrow call sites in
+/// expense_tracker_screen.dart pass the l10n string as-is, so they render
+/// in the title-case the ARB stores them in (e.g. 'Movimento' instead of
+/// 'MOVIMENTO'). See lib/screens/expense_tracker_screen.dart:586,689,715,
+/// 741,874.
+void main() {
+  Future<void> pumpScreen(WidgetTester tester, {Locale locale = const Locale('pt')}) async {
+    final settings = makeSettings(
+      expenses: [
+        makeExpense(id: 'exp_1', category: 'habitacao', amount: 2500),
+      ],
+    );
+    final actual = makeActualExpense(
+      id: 'ae_1',
+      category: 'habitacao',
+      amount: 2000.45,
+    );
+
+    await tester.pumpWidget(
+      wrapWithTestApp(
+        ExpenseTrackerScreen(
+          settings: settings,
+          expenses: [actual],
+          householdId: 'house-1',
+          onAdd: (_) async {},
+          onUpdate: (_) async {},
+          onDelete: (_) async {},
+          onLoadMonth: (_) async => [actual],
+        ),
+        controller: AppShellController(locale: locale),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'all 5 CalmEyebrow labels in the Despesas screen render in UPPERCASE (pt) (#1222)',
+    (tester) async {
+      await pumpScreen(tester);
+
+      expect(
+        find.text('MOVIMENTO'),
+        findsOneWidget,
+        reason: "header eyebrow must read 'MOVIMENTO', matching the "
+            "uppercase pattern of every other screen's eyebrow",
+      );
+      expect(find.text('Movimento'), findsNothing);
+
+      expect(find.text('ESTE MÊS'), findsOneWidget);
+      expect(find.text('Este Mês'), findsNothing);
+
+      expect(find.text('MÉDIA/DIA'), findsOneWidget);
+      expect(find.text('Média/Dia'), findsNothing);
+
+      expect(find.text('CONTAS'), findsOneWidget);
+      expect(find.text('Contas'), findsNothing);
+
+      expect(find.text('POR CATEGORIA'), findsOneWidget);
+      expect(find.text('Por Categoria'), findsNothing);
+
+      // The big Fraunces title stays title-case — only the eyebrow changes.
+      expect(find.text('Despesas'), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'CalmEyebrow labels in the Despesas screen render in UPPERCASE (en) (#1222)',
+    (tester) async {
+      await pumpScreen(tester, locale: const Locale('en'));
+
+      expect(find.text('ACTIVITY'), findsOneWidget);
+      expect(find.text('Activity'), findsNothing);
+
+      expect(find.text('THIS MONTH'), findsOneWidget);
+      expect(find.text('AVG/DAY'), findsOneWidget);
+      expect(find.text('BILLS'), findsOneWidget);
+      expect(find.text('BY CATEGORY'), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/monthy_budget_flutter/test/utils/more_context_builder_test.dart
+++ b/monthy_budget_flutter/test/utils/more_context_builder_test.dart
@@ -9,9 +9,13 @@ import 'package:monthly_management/widgets/calm/calm_observation_card.dart';
 
 void main() {
   late S l10n;
+  late S l10nPt;
+  late S l10nFr;
 
   setUpAll(() async {
     l10n = await S.delegate.load(const Locale('en'));
+    l10nPt = await S.delegate.load(const Locale('pt'));
+    l10nFr = await S.delegate.load(const Locale('fr'));
   });
 
   BudgetSummary summaryWith({
@@ -221,6 +225,82 @@ void main() {
       expect(ctx.observations.first.title, contains('16'));
       expect(ctx.observations.first.title, isNot(contains('140')));
     });
+
+    test(
+      'over-budget title shows the localized category label, not the raw '
+      'storage key (#1224)',
+      () {
+        // TopCategoryUsage.category carries the raw storage key ('lazer'),
+        // exactly what _topCategoryUsage() returns in production — not a
+        // pre-translated label like the other tests in this file use.
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10n,
+        );
+        final expectedLabel = ExpenseCategory.lazer.localizedLabel(l10n);
+        expect(ctx.observations.first.title, contains(expectedLabel));
+        expect(ctx.observations.first.title, isNot(contains('lazer')));
+      },
+    );
+
+    test(
+      'over-budget title is localized to pt-PT (raw key coincides with the '
+      'word, but must still resolve through the enum) (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10nPt,
+        );
+        final expectedLabel = ExpenseCategory.lazer.localizedLabel(l10nPt);
+        expect(ctx.observations.first.title, contains(expectedLabel));
+      },
+    );
+
+    test(
+      'over-budget title is localized to fr — the raw pt key must not leak '
+      'into a non-pt locale (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10nFr,
+        );
+        final expectedLabel = ExpenseCategory.lazer.localizedLabel(l10nFr);
+        expect(ctx.observations.first.title, contains(expectedLabel));
+        expect(ctx.observations.first.title, isNot(contains('lazer')));
+      },
+    );
+
+    test(
+      'custom category (not in the ExpenseCategory enum) is shown as-is, '
+      'in every locale (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(
+            category: 'Streaming',
+            percent: 143,
+          ),
+          l10n: l10nFr,
+        );
+        expect(ctx.observations.first.title, contains('Streaming'));
+      },
+    );
+
+    test(
+      'observation id keeps the raw storage key even after the title is '
+      'localized (#1224)',
+      () {
+        final ctx = MoreContextBuilder.build(
+          summary: summaryWith(savingsRate: 0.05),
+          topCategory: const TopCategoryUsage(category: 'lazer', percent: 143),
+          l10n: l10nFr,
+        );
+        expect(ctx.observations.first.id, 'cat-over-lazer');
+      },
+    );
   });
 
   group('budgetByCategory', () {


### PR DESCRIPTION
## Summary

Promoção automática de `dev` para `main`: 2 commit(s)
com correções que passaram review **e** verificação de QA na app a correr.

## Release Notes

- Merge remote-tracking branch 'origin/main' into HEAD
- qa/issue-1224: Localiza a categoria antes de a interpolar na observação 'X% acima do orçamento' da aba Mais (#1224) (#1279)
- Uppercase os 5 eyebrows do ecrã Despesas (CalmEyebrow) para consistência com o resto da app (#1222) (#1276)

## Linked Issue

Fixes #1222
Fixes #1224
Fixes #1276
Fixes #1279