### PR TITLE
Idempotent-by-id append em _addExpense e _scanReceipt corrige a duplicação de vista em Despesas (#1233) (#1233)

### DIFF
--- a/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
+++ b/monthy_budget_flutter/lib/screens/expense_tracker_screen.dart
@@ -187,8 +187,15 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
       if (!mounted) return;
       setState(
         () =>
-            _expenses = [..._expenses, expense]
-              ..sort((a, b) => b.date.compareTo(a.date)),
+            // Idempotent by id (#1233): widget.onAdd may trigger an
+            // optimistic provider update in the parent that reaches this
+            // widget via didUpdateWidget while the await above is still
+            // pending, syncing this same expense into `_expenses` first.
+            // Without the id filter, this append would add it a second time.
+            _expenses = [
+              ..._expenses.where((e) => e.id != expense.id),
+              expense,
+            ]..sort((a, b) => b.date.compareTo(a.date)),
       );
     }
   }
@@ -217,8 +224,11 @@ class _ExpenseTrackerScreenState extends State<ExpenseTrackerScreen> {
     if (!mounted) return;
     setState(
       () =>
-          _expenses = [..._expenses, expense]
-            ..sort((a, b) => b.date.compareTo(a.date)),
+          // Idempotent by id (#1233) — same race as in _addExpense above.
+          _expenses = [
+            ..._expenses.where((e) => e.id != expense.id),
+            expense,
+          ]..sort((a, b) => b.date.compareTo(a.date)),
     );
   }
 

--- a/monthy_budget_flutter/test/screens/expense_tracker_screen_test.dart
+++ b/monthy_budget_flutter/test/screens/expense_tracker_screen_test.dart
@@ -1,11 +1,83 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/actual_expense.dart';
+import 'package:monthly_management/onboarding/expense_tracker_tour.dart';
 import 'package:monthly_management/screens/expense_tracker_screen.dart';
 import 'package:monthly_management/widgets/expense_detail_sheet.dart';
 
 import '../helpers/test_app.dart';
 import '../helpers/test_helpers.dart';
+
+/// Reproduces the AppHome wiring for `onAdd` (#1233): the parent updates its
+/// own state list *before* the persistence await resolves — mirroring
+/// `_addActualExpense`'s `actualExpensesProvider.set([...])` followed by
+/// `await _actualExpenseService.add(...)`. That optimistic-then-await shape
+/// is what lets the tracker's `didUpdateWidget` sync race with its own local
+/// append in `_addExpense`.
+class _OptimisticParent extends StatefulWidget {
+  final List<ActualExpense> initialExpenses;
+  const _OptimisticParent({required this.initialExpenses});
+
+  @override
+  State<_OptimisticParent> createState() => _OptimisticParentState();
+}
+
+class _OptimisticParentState extends State<_OptimisticParent> {
+  late List<ActualExpense> _expenses;
+
+  @override
+  void initState() {
+    super.initState();
+    _expenses = List.of(widget.initialExpenses);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpenseTrackerScreen(
+      settings: makeSettings(
+        expenses: [makeExpense(category: 'habitacao', label: 'Rent')],
+      ),
+      expenses: _expenses,
+      householdId: 'house-1',
+      onAdd: (expense) async {
+        setState(() => _expenses = [expense, ..._expenses]);
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      },
+      onUpdate: (_) async {},
+      onDelete: (_) async {},
+      onLoadMonth: (_) async => _expenses,
+    );
+  }
+}
+
+Future<void> _openSheetAndFillAmount(WidgetTester tester, String amount) async {
+  await tester.tap(find.byType(FloatingActionButton));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextFormField).first, amount);
+  // 'habitacao' is the 6th ExpenseCategory value, matching the single
+  // budgeted expense in makeSettings above.
+  await tester.tap(find.byType(ChoiceChip).at(5));
+  await tester.pump();
+}
+
+Future<void> _tapSave(WidgetTester tester) async {
+  await tester.dragUntilVisible(
+    find.text('Save'),
+    find.byType(ListView),
+    const Offset(0, -200),
+  );
+  await tester.tap(find.text('Save'));
+  // First pump: flushes the microtask that resumes `_addExpense` after the
+  // sheet pops, which runs `onAdd`'s synchronous optimistic `setState` — the
+  // parent rebuild reaches the tracker's `didUpdateWidget` sync in this same
+  // pump, before `onAdd`'s persistence await resolves.
+  await tester.pump();
+  // Second pump: advances the fake clock past onAdd's simulated I/O delay,
+  // letting `_addExpense`'s post-await local append run.
+  await tester.pump(const Duration(milliseconds: 10));
+  await tester.pumpAndSettle();
+}
 
 void main() {
   testWidgets('tapping an expense opens detail sheet with location map', (
@@ -48,5 +120,62 @@ void main() {
     expect(find.byType(ExpenseDetailSheet), findsOneWidget);
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.text('Lisbon, Portugal'), findsOneWidget);
+  });
+
+  group('#1233 — adding an expense while the parent rebuilds optimistically', () {
+    testWidgets(
+        'bills count rises by exactly 1 and the total is not doubled',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithTestApp(const _OptimisticParent(initialExpenses: [])),
+      );
+      await tester.pumpAndSettle();
+
+      final summary = find.byKey(ExpenseTrackerTourKeys.summary);
+      expect(find.descendant(of: summary, matching: find.text('0')),
+          findsOneWidget);
+
+      await _openSheetAndFillAmount(tester, '77.77');
+      await _tapSave(tester);
+
+      expect(
+        find.descendant(of: summary, matching: find.text('1')),
+        findsOneWidget,
+        reason: 'Contas deve subir exactamente 1, não 2',
+      );
+      expect(find.descendant(of: summary, matching: find.text('2')),
+          findsNothing);
+      // "Este mês" total must be the entered value, not double it. Scoped
+      // to the summary row: the same value legitimately also appears once
+      // in the recent-expenses card and once in the category section.
+      // NB: formatCurrency (pt-PT / intl) joins the amount and symbol with a
+      // NON-BREAKING SPACE (U+00A0), not a regular space.
+      expect(
+          find.descendant(of: summary, matching: find.text('77,77 €')),
+          findsOneWidget);
+      expect(find.text('155,54 €'), findsNothing);
+    });
+
+    testWidgets(
+        'two consecutive adds without reload increase the count by exactly N, no drift',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithTestApp(const _OptimisticParent(initialExpenses: [])),
+      );
+      await tester.pumpAndSettle();
+
+      await _openSheetAndFillAmount(tester, '10.00');
+      await _tapSave(tester);
+      await _openSheetAndFillAmount(tester, '20.00');
+      await _tapSave(tester);
+
+      final summary = find.byKey(ExpenseTrackerTourKeys.summary);
+      expect(
+        find.descendant(of: summary, matching: find.text('2')),
+        findsOneWidget,
+        reason: '2 adições consecutivas devem somar +2, não +4',
+      );
+      expect(find.text('30,00 €'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Resumo

Idempotent-by-id append em _addExpense e _scanReceipt corrige a duplicação de vista em Despesas (#1233)

## O que mudou

Em `lib/screens/expense_tracker_screen.dart`, tanto `_addExpense` (linha ~188) como `_scanReceipt` (linha ~218) faziam `_expenses = [..._expenses, expense]..sort(...)` depois de `await widget.onAdd(expense)`. Passaram a fazer:

```dart
_expenses = [
  ..._expenses.where((e) => e.id != expense.id),
  expense,
]..sort((a, b) => b.date.compareTo(a.date));
```

Ou seja, o append local é agora idempotente por `id`: primeiro remove qualquer cópia já presente com o mesmo id (por exemplo, a que `didUpdateWidget` já tenha sincronizado a partir do pai) e só depois adiciona a versão corrente. `didUpdateWidget` (linhas 129-138) e o próprio append local não foram removidos — continuam ambos necessários (o primeiro sincroniza mutações externas/mês corrente; o segundo é o único caminho que mostra a despesa quando se adiciona a um mês não corrente).

## Porque assim

Segui exactamente o plano do curator: causa raiz é duplicação de **estado de UI**, não dupla gravação. `widget.onAdd` (que em produção é `_addActualExpense` em `app_home.dart`) faz um `set` optimista no `actualExpensesProvider` antes do `await` da persistência resolver; isso reconstrói o `AppHome`, que entrega ao `ExpenseTrackerScreen` uma `expenses` já contendo a nova despesa, e o `didUpdateWidget` sincroniza `_expenses` com ela — tudo isto pode acontecer **antes** de `await widget.onAdd(expense)` retornar. Quando retorna, o append local antigo adicionava a mesma despesa uma segunda vez, sem verificar se já lá estava. Tornar o append idempotente por id resolve na raiz, independentemente da ordem dos frames — não fixa a persistência (que já estava correcta, uma única escrita por submissão) nem mexe no `didUpdateWidget`, exactamente como o curator recomendou ("não fazer").

Considerei a alternativa estrutural registada pelo curator (tracker puramente provider-driven, sem `_expenses` local) mas é um refactor maior fora do âmbito deste issue — não implementada, como o curator já antecipava.

## Critérios de aceitação

- [x] Contas +1 e Este mês +V (não +2V) num estado limpo — coberto pelo teste `bills count rises by exactly 1 and the total is not doubled`.
- [x] A despesa aparece exactamente uma vez no cartão "Este mês" (verificado com `find.descendant` restrito à Row da key `ExpenseTrackerTourKeys.summary`); o mesmo valor aparecendo também no cartão RECENTES e na secção POR CATEGORIA é o comportamento correcto (uma única linha, mostrada em vários sítios) — confirmado ao correr o teste com fix e reverificar que `77,77 €` aparece 3 vezes no ecrã todo mas só 1 vez dentro do summary.
- [x] N adições consecutivas sem reload = +N, sem drift — coberto pelo segundo teste (duas adições de 10,00€ e 20,00€ → Contas=2, total=30,00€, não 4/40,00€).
- [x] Mês não corrente continua a mostrar a despesa uma vez — não regrediu: o append idempotente não altera o comportamento quando `didUpdateWidget` não sincroniza (mês não corrente), continua a ser o único caminho e o `.where` não remove nada porque o id ainda não estava presente.
- [x] `_scanReceipt` também corrigido (mesmo padrão, mesma causa raiz) — não há teste de widget dedicado para o fluxo de scan porque `ReceiptScanSheet`/`ReceiptReviewSheet` exigem câmara/ML Kit fora do alcance de um widget test; a correcção é estruturalmente idêntica e a lógica de dedupe é a mesma testada em `_addExpense`.
- [x] Editar continua a produzir uma única linha — `_editExpense` já usava `map` por id (linha 253-255), não foi tocado.
- [x] Apagar+undo — `_deleteExpense` já usava `where` por id (linha 288), não foi tocado.
- [x] Persistência continua a gravar uma única linha por submissão — não foi tocada (o bug nunca esteve lá); `widget.onAdd` continua a ser chamado exactamente uma vez por submissão.

## Testes

**Passo vermelho:** escrevi `test/screens/expense_tracker_screen_test.dart` com um parente de teste (`_OptimisticParent`) que replica o padrão do `AppHome`: `onAdd` faz `setState` optimista com a lista do pai *antes* de `await Future.delayed(...)`, para que `didUpdateWidget` do tracker sincronize a despesa enquanto o `onAdd` do `_addExpense` ainda está pendente — exactamente a race do bug real. Sequência de pumps: `tap('Save')` → `pump()` (flush do microtask que resume `_addExpense` e corre o `setState` optimista do pai, cujo rebuild já atinge o `didUpdateWidget` do tracker neste mesmo pump) → `pump(Duration(milliseconds: 10))` (avança o relógio falso para lá do delay simulado, deixando o append local do `_addExpense` correr). Antes do fix, o teste falhava com:
```
Expected: exactly one matching candidate
  Actual: _DescendantWidgetFinder:<Found 0 widgets with text "1" descending from widgets with key [...tour_et_summary]: []>
```
Confirmei com uma sonda de debug (removida depois) que o valor real mostrado era `BILLS: "2"` e `THIS MONTH: "155,54 €"` (dobro de `77,77 €`) — a falha era pela razão certa, não um erro de harness.

**Casos cobertos:**
- Caminho nominal com valor reconhecível (77,77€) — count e total exactos.
- Repetição (duas adições consecutivas sem reload) — AC explícito do curator contra drift acumulado; é o caso de "acção repetida" pedido nas instruções gerais.
- Regressão do teste pré-existente (`tapping an expense opens detail sheet...`) continua a passar sem alterações — prova que o dedupe por id não quebra o fluxo normal de detalhe/mapa.

Não escrevi um teste separado para `_scanReceipt` pelas razões explicadas acima (dependências de câmara/ML Kit não mockáveis num widget test); a correcção é o mesmo padrão de uma linha, mecanicamente idêntico ao já coberto.

**Sanity-check:** `git stash push -- lib/screens/expense_tracker_screen.dart` (reverteu só o fix de produção, mantendo os testes), corri `flutter test test/screens/expense_tracker_screen_test.dart` → 2 dos 3 testes falharam com a mesma assinatura do passo vermelho original ("Contas deve subir exactamente 1, não 2" e "2 adições consecutivas devem somar +2, não +4"); `git stash pop` restaurou o fix; corri de novo → 3/3 passaram.

**Ficheiros de teste:** `test/screens/expense_tracker_screen_test.dart`.

**Resultado da suite completa:** `flutter test` (2466 testes) → 2464 passaram, 2 falharam. As 2 falhas (`test/performance/performance_benchmarks_test.dart`: "dashboard initial render stays within budget" e "shopping list scroll stays within frame budget") são pré-existentes e não relacionadas — orçamentos de frame fixos (<19ms) que este hardware não cumpre; confirmei que falham da mesma forma a correr esse ficheiro isolado (sem carga de suite completa) e que o diff desta correcção não toca em `dashboard_screen.dart` nem em nenhum ficheiro de shopping list (`git diff --stat` mostra só `expense_tracker_screen.dart` e o seu teste).

`flutter analyze --no-fatal-infos --no-fatal-warnings`: 78 issues antes e depois (nenhum novo; nenhum nos ficheiros tocados).

## Testes

expense_tracker_screen_test.dart: 3 passaram (2 novos + 1 pré-existente), 0 falharam. Suite completa: 2464 passaram, 2 falharam (pré-existentes, em test/performance/performance_benchmarks_test.dart, não relacionados — orçamento de frame timing-dependente do hardware, confirmado falhar da mesma forma isolado do meu diff).

## Linked Issue

Fixes #1233