### PR TITLE
Top Categories usa l10n.dashboardHeroBudgetLabel em vez do literal ' de ' hardcoded (#1226)

### DIFF
--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -844,7 +844,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       leadingColor: AppColors.categoryColorByName(categoryName),
       title: _budgetCategoryLabel(categoryName, l10n),
       subtitle: budgetAmount > 0
-          ? '${formatCurrency(value)} de ${formatCurrency(budgetAmount)}'
+          ? '${formatCurrency(value)} ${l10n.dashboardHeroBudgetLabel(formatCurrency(budgetAmount))}'
           : formatCurrency(value),
       trailing: trailing,
       onTap: widget.onOpenExpenseTracker,

--- a/monthy_budget_flutter/test/screens/dashboard_top_categories_l10n_1226_test.dart
+++ b/monthy_budget_flutter/test/screens/dashboard_top_categories_l10n_1226_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:monthly_management/app_shell.dart';
+import 'package:monthly_management/models/actual_expense.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/models/budget_summary.dart';
+import 'package:monthly_management/models/local_dashboard_config.dart';
+import 'package:monthly_management/models/purchase_record.dart';
+import 'package:monthly_management/screens/dashboard_screen.dart';
+import 'package:monthly_management/utils/formatters.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  final expense = ActualExpense(
+    id: 'e1',
+    category: 'housing',
+    amount: 685.0,
+    date: DateTime(2026, 8, 1),
+    monthKey: '2026-08',
+  );
+
+  Widget buildDashboard({required Locale locale}) => wrapWithTestApp(
+        DashboardScreen(
+          settings: const AppSettings(),
+          summary: const BudgetSummary(totalGross: 2000, totalExpenses: 685),
+          purchaseHistory: const PurchaseHistory(),
+          dashboardConfig: const LocalDashboardConfig(),
+          expenseHistory: const {},
+          actualExpenses: [expense],
+          monthlyBudgets: const {'housing': 685.0},
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: () {},
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+        ),
+        controller: AppShellController(locale: locale),
+      );
+
+  final amount = formatCurrency(685.0); // '685,00 €' — currency format
+  // is fixed to Country.pt regardless of app locale; only the separator
+  // word between the two amounts is what this issue is about.
+
+  group('#1226 Top Categories subtitle — no hardcoded PT word', () {
+    testWidgets('en locale shows "of" separator, not the PT "de"',
+        (tester) async {
+      await tester.pumpWidget(buildDashboard(locale: const Locale('en')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('$amount of $amount'), findsOneWidget);
+      expect(find.text('$amount de $amount'), findsNothing);
+    });
+
+    testWidgets('pt locale keeps "de" separator (no regression)',
+        (tester) async {
+      await tester.pumpWidget(buildDashboard(locale: const Locale('pt')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('$amount de $amount'), findsOneWidget);
+    });
+
+    testWidgets('es locale uses the translated dashboardHeroBudgetLabel',
+        (tester) async {
+      await tester.pumpWidget(buildDashboard(locale: const Locale('es')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('$amount de $amount'), findsOneWidget);
+    });
+
+    testWidgets('fr locale uses the translated dashboardHeroBudgetLabel',
+        (tester) async {
+      await tester.pumpWidget(buildDashboard(locale: const Locale('fr')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('$amount de $amount'), findsOneWidget);
+    });
+
+    testWidgets(
+        'no budget set (budgetAmount <= 0) shows bare amount, no suffix word at all',
+        (tester) async {
+      final noBudgetExpense = ActualExpense(
+        id: 'e2',
+        category: 'housing',
+        amount: 685.0,
+        date: DateTime(2026, 8, 1),
+        monthKey: '2026-08',
+      );
+      await tester.pumpWidget(wrapWithTestApp(
+        DashboardScreen(
+          settings: const AppSettings(),
+          summary:
+              const BudgetSummary(totalGross: 2000, totalExpenses: 685),
+          purchaseHistory: const PurchaseHistory(),
+          dashboardConfig: const LocalDashboardConfig(),
+          expenseHistory: const {},
+          actualExpenses: [noBudgetExpense],
+          monthlyBudgets: const {}, // no budget for 'housing' -> budgetAmount == 0
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: () {},
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+        ),
+        controller: AppShellController(locale: const Locale('en')),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(amount), findsOneWidget);
+      expect(find.text('$amount of $amount'), findsNothing);
+      expect(find.text('$amount de $amount'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Resumo

Top Categories usa l10n.dashboardHeroBudgetLabel em vez do literal ' de ' hardcoded

## O que mudou

Em `lib/screens/dashboard_screen.dart`, dentro de `_topCategoryRow(...)`, a linha do subtítulo passou de:

```dart
subtitle: budgetAmount > 0
    ? '${formatCurrency(value)} de ${formatCurrency(budgetAmount)}'
    : formatCurrency(value),
```

para:

```dart
subtitle: budgetAmount > 0
    ? '${formatCurrency(value)} ${l10n.dashboardHeroBudgetLabel(formatCurrency(budgetAmount))}'
    : formatCurrency(value),
```

É o único hunk alterado (1 linha). Não foram tocados o cartão hero (linha 453, mesma chave usada directamente), o `else` branch (`formatCurrency(value)` sem sufixo), nem os ficheiros `.arb`/`generated` — a chave `dashboardHeroBudgetLabel` já existia traduzida nos 4 locales e já tinha a forma certa ('of {amount}' / 'de {amount}').

## Porque assim

Segui o plano do curator ao pé da letra: reusar `l10n.dashboardHeroBudgetLabel`, o mesmo padrão já usado na linha 453 para o cartão hero, em vez de criar nova chave l10n. Não havia ambiguidade a resolver — o plano batia certo com o código lido directamente (linha actual 847, não 812 como no issue original do critic, que ficou desactualizada por mudanças subsequentes no ficheiro).

## Critérios de aceitação

- [x] Locale `en`, categoria com `budgetAmount > 0` → `'{valor} of {orçamento}'` sem a palavra 'de'. Testado com `685,00 € of 685,00 €`.
- [x] Locale `pt` → `'{valor} de {orçamento}'` inalterado. Testado.
- [x] Locale `es` e `fr` → usam a tradução de `dashboardHeroBudgetLabel` ('de {amount}' em ambos). Testado.
- [x] `budgetAmount <= 0` → mostra só `formatCurrency(value)`, sem sufixo. Testado (nem 'of' nem 'de' aparecem).
- [x] Cartão hero (linha 453) não tocado — confirmado por `git diff` (só 1 linha mudou, fora do range do hero).
- [x] Nenhuma outra ocorrência de `' de '` hardcoded no bloco `_topCategoryRow`/`_buildTopCategoriesCard` — confirmado por grep no bloco (783–825), zero ocorrências.

## Testes

- **Passo vermelho:** primeiro tentei `find.text('685,00 € of 685,00 €')` e `find.text('685,00 € de 685,00 €')` com strings literais com espaço normal antes do '€' — ambos falharam com "Found 0 widgets" porque `formatCurrency` usa NBSP (U+00A0, code unit 160) antes do símbolo, não espaço normal (32). Corrigido construindo a string esperada via `formatCurrency(685.0)` em vez de a hardcodar. Com isso, o teste 'en locale' falhou pela razão certa: `Expected: exactly one matching candidate / Actual: Found 0 widgets with text "685,00 € of 685,00 €"` — confirmando que a app produzia 'de' em vez de 'of' em locale inglês.
- **Casos cobertos:** locale `en` (bug principal), `pt` (não-regressão — comportamento original), `es` e `fr` (tradução já existente na chave, AC explícito), e o inverso do fix — `budgetAmount <= 0` mostra apenas o valor, sem qualquer sufixo 'of'/'de' (garante que o branch `else` não foi tocado).
- **Sanity-check:** `git stash push -- lib/screens/dashboard_screen.dart` (reverte só o fix, mantendo o teste novo), corri a suite nova → exactamente o teste 'en locale' falhou com o erro original ("Found 0 widgets with text '685,00 € of 685,00 €'"), os outros 4 continuaram a passar (não distinguem o defeito). `git stash pop` restaurou o fix, suite voltou a passar 5/5.
- Ficheiro de teste: `test/screens/dashboard_top_categories_l10n_1226_test.dart` (novo).
- Resultado final: `flutter test` completo — 2473 testes passaram, 0 falharam (inclui os 5 novos). `flutter analyze --no-fatal-infos --no-fatal-warnings` — 78 issues antes e depois (nenhum novo; o único warning em `dashboard_screen.dart` — unused_import de `notification_preferences.dart` — é pré-existente, fora do diff).

## Testes

2473 testes passaram, 0 falharam (inclui 5 novos em dashboard_top_categories_l10n_1226_test.dart). flutter analyze: 78 issues antes e depois (0 novos).

## Linked Issue

Fixes #1226