### PR TITLE
Dashboard idle-render loop fixed: onSnapshotExpenses only fires once per monthKey, and expense-history/actual-expense notifiers skip no-op state writes (#1236)

### DIFF
--- a/monthy_budget_flutter/lib/providers/expense_providers.dart
+++ b/monthy_budget_flutter/lib/providers/expense_providers.dart
@@ -1,14 +1,28 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/actual_expense.dart';
 import '../models/expense_snapshot.dart';
+
+/// Deep equality for the map-of-list shapes used by the notifiers below.
+/// [ExpenseSnapshot] and [ActualExpense] already implement value `==`, so
+/// this correctly treats two freshly-loaded-but-identical snapshots/maps as
+/// equal instead of always differing by default `Map`/`List` identity.
+const _deepEquals = DeepCollectionEquality();
 
 /// Actual expenses for the viewed month (#632 increment 9). Storage-only;
 /// CRUD + persistence (ActualExpenseService) stays in AppHome.
 class ActualExpensesNotifier extends Notifier<List<ActualExpense>> {
   @override
   List<ActualExpense> build() => const [];
-  void set(List<ActualExpense> v) => state = v;
+  void set(List<ActualExpense> v) {
+    // #1236: skip the write (and therefore the notification) when the new
+    // list is deep-equal to what's already stored — otherwise any
+    // unconditional caller re-triggers a full rebuild of every listener for
+    // no observable change, which is how the dashboard render loop happened.
+    if (_deepEquals.equals(state, v)) return;
+    state = v;
+  }
 }
 
 final actualExpensesProvider =
@@ -21,7 +35,10 @@ class ActualExpenseHistoryNotifier
     extends Notifier<Map<String, List<ActualExpense>>> {
   @override
   Map<String, List<ActualExpense>> build() => const {};
-  void set(Map<String, List<ActualExpense>> v) => state = v;
+  void set(Map<String, List<ActualExpense>> v) {
+    if (_deepEquals.equals(state, v)) return;
+    state = v;
+  }
 }
 
 final actualExpenseHistoryProvider =
@@ -35,7 +52,10 @@ class ExpenseHistoryNotifier
     extends Notifier<Map<String, List<ExpenseSnapshot>>> {
   @override
   Map<String, List<ExpenseSnapshot>> build() => const {};
-  void set(Map<String, List<ExpenseSnapshot>> v) => state = v;
+  void set(Map<String, List<ExpenseSnapshot>> v) {
+    if (_deepEquals.equals(state, v)) return;
+    state = v;
+  }
 }
 
 final expenseHistoryProvider =

--- a/monthy_budget_flutter/lib/screens/dashboard_screen.dart
+++ b/monthy_budget_flutter/lib/screens/dashboard_screen.dart
@@ -121,6 +121,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
   bool _tourShown = false;
   TutorialCoachMark? _activeTour;
 
+  // #1236: monthKey for which onSnapshotExpenses() has already been
+  // requested. Without this, the postFrameCallback below re-armed on every
+  // single build() — including builds triggered by its own async result
+  // landing in a provider — producing a tight render+I/O loop that pinned
+  // the main thread near 100% while idle. Only call it again when the
+  // relevant month actually changes, mirroring the stress-history guard.
+  String? _snapshottedMonthKey;
+
   // Convenience accessors so helper methods don't need widget. prefix everywhere.
   AppSettings get settings => widget.settings;
   BudgetSummary get summary => widget.summary;
@@ -216,7 +224,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
             ..[monthKey] = stressResult.score;
           onSaveSettings(settings.copyWith(stressHistory: updated));
         }
-        onSnapshotExpenses();
+        // #1236: only request a snapshot once per distinct monthKey, not
+        // once per build/frame — see _snapshottedMonthKey doc-comment.
+        if (_snapshottedMonthKey != monthKey) {
+          _snapshottedMonthKey = monthKey;
+          onSnapshotExpenses();
+        }
       });
     }
 

--- a/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
+++ b/monthy_budget_flutter/test/functional/dashboard_screen_functional_test.dart
@@ -944,4 +944,59 @@ void main() {
       );
     });
   });
+
+  group('onSnapshotExpenses is not re-armed on every build (#1236)', () {
+    // hasData=true (totalGross > 0) is the precondition that arms the
+    // postFrameCallback in DashboardScreen.build(). Every field below is
+    // held constant across pumps — nothing here changes the widget's
+    // observable state, only the widget *instance* changes, which is
+    // exactly what happens in production when a parent (DashboardContainer/
+    // AppHome) rebuilds without the underlying month/data changing.
+    Widget buildIdleDashboard(VoidCallback onSnapshotExpenses) {
+      return wrapWithTestApp(
+        DashboardScreen(
+          settings: const AppSettings(),
+          summary: const BudgetSummary(
+            totalGross: 1000,
+            totalNetWithMeal: 1000,
+            totalExpenses: 500,
+            netLiquidity: 500,
+          ),
+          purchaseHistory: const PurchaseHistory(),
+          dashboardConfig: const LocalDashboardConfig(),
+          expenseHistory: const {},
+          actualExpenses: const [],
+          monthlyBudgets: const {},
+          recurringExpenses: const [],
+          actualExpenseHistory: const {},
+          onOpenSettings: () {},
+          onSaveSettings: (_) {},
+          onSnapshotExpenses: onSnapshotExpenses,
+          onAddExpense: () {},
+          onOpenExpenseTracker: () {},
+        ),
+      );
+    }
+
+    testWidgets(
+        'sitting idle across several rebuilds calls onSnapshotExpenses at most once for the same month',
+        (tester) async {
+      var callCount = 0;
+
+      // Simulate several idle rebuilds of the same DashboardScreen instance
+      // (same monthKey, same data) — as would happen if a sibling provider
+      // ticks while the user sits on the tab without interacting.
+      for (var i = 0; i < 5; i++) {
+        await tester.pumpWidget(buildIdleDashboard(() => callCount++));
+        await tester.pump();
+      }
+
+      expect(
+        callCount,
+        1,
+        reason:
+            'onSnapshotExpenses must fire once per distinct monthKey, not once per build/frame',
+      );
+    });
+  });
 }

--- a/monthy_budget_flutter/test/providers/expense_providers_test.dart
+++ b/monthy_budget_flutter/test/providers/expense_providers_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monthly_management/models/actual_expense.dart';
+import 'package:monthly_management/models/expense_snapshot.dart';
+import 'package:monthly_management/providers/expense_providers.dart';
+
+void main() {
+  group('expenseHistoryProvider (#1236)', () {
+    ExpenseSnapshot snapshot() => const ExpenseSnapshot(
+          expenseId: 'exp1',
+          label: 'Renda',
+          category: 'casa',
+          amount: 500,
+          enabled: true,
+        );
+
+    test('set() with content deep-equal to current state does not notify',
+        () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var notifications = 0;
+      container.listen<Map<String, List<ExpenseSnapshot>>>(
+        expenseHistoryProvider,
+        (_, _) => notifications++,
+        fireImmediately: false,
+      );
+
+      // Two DIFFERENT Map/List instances, but with identical content — this
+      // mirrors what _snapshotExpenses() produces on every reload: a freshly
+      // deserialised history that happens to match what's already loaded.
+      container
+          .read(expenseHistoryProvider.notifier)
+          .set({'2026-08': [snapshot()]});
+      container
+          .read(expenseHistoryProvider.notifier)
+          .set({'2026-08': [snapshot()]});
+
+      expect(notifications, 1,
+          reason:
+              'second set() carries no new information and must not notify listeners');
+    });
+
+    test('set() with genuinely different content still notifies', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var notifications = 0;
+      container.listen<Map<String, List<ExpenseSnapshot>>>(
+        expenseHistoryProvider,
+        (_, _) => notifications++,
+        fireImmediately: false,
+      );
+
+      container
+          .read(expenseHistoryProvider.notifier)
+          .set({'2026-08': [snapshot()]});
+      container.read(expenseHistoryProvider.notifier).set({
+        '2026-08': [snapshot()],
+        '2026-09': [snapshot()],
+      });
+
+      expect(notifications, 2,
+          reason: 'a real content change must still reach listeners');
+    });
+  });
+
+  group('actualExpenseHistoryProvider (#1236)', () {
+    ActualExpense expense() => ActualExpense(
+          id: 'e1',
+          category: 'casa',
+          amount: 100,
+          date: DateTime(2026, 8, 1),
+          monthKey: '2026-08',
+        );
+
+    test('set() with content deep-equal to current state does not notify',
+        () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var notifications = 0;
+      container.listen<Map<String, List<ActualExpense>>>(
+        actualExpenseHistoryProvider,
+        (_, _) => notifications++,
+        fireImmediately: false,
+      );
+
+      container
+          .read(actualExpenseHistoryProvider.notifier)
+          .set({'2026-08': [expense()]});
+      container
+          .read(actualExpenseHistoryProvider.notifier)
+          .set({'2026-08': [expense()]});
+
+      expect(notifications, 1);
+    });
+  });
+
+  group('actualExpensesProvider (#1236)', () {
+    ActualExpense expense() => ActualExpense(
+          id: 'e1',
+          category: 'casa',
+          amount: 100,
+          date: DateTime(2026, 8, 1),
+          monthKey: '2026-08',
+        );
+
+    test('set() with content deep-equal to current state does not notify',
+        () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var notifications = 0;
+      container.listen<List<ActualExpense>>(
+        actualExpensesProvider,
+        (_, _) => notifications++,
+        fireImmediately: false,
+      );
+
+      container.read(actualExpensesProvider.notifier).set([expense()]);
+      container.read(actualExpensesProvider.notifier).set([expense()]);
+
+      expect(notifications, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Resumo

Dashboard idle-render loop fixed: onSnapshotExpenses only fires once per monthKey, and expense-history/actual-expense notifiers skip no-op state writes

## O que mudou

- `lib/screens/dashboard_screen.dart`: adicionado o campo `String? _snapshottedMonthKey` a `_DashboardScreenState`. No `postFrameCallback` dentro de `build()` (linhas ~212-224), `onSnapshotExpenses()` deixou de ser chamado incondicionalmente sempre que `hasData` é verdadeiro — agora só é chamado quando `monthKey` difere do último valor já processado, espelhando o guard já existente para `settings.stressHistory` duas linhas acima. O guard do stress-history (linhas 213-217) não foi tocado.
- `lib/providers/expense_providers.dart`: `ExpenseHistoryNotifier.set`, `ActualExpenseHistoryNotifier.set` e `ActualExpensesNotifier.set` deixaram de escrever `state = v` incondicionalmente. Agora comparam o novo valor com o estado actual via `DeepCollectionEquality` (`package:collection`) e retornam sem escrever/nunca notificar quando o conteúdo é deep-equal — mesmo quando `Map`/`List` são instâncias novas (o que acontece sempre que `loadHistory()` recarrega do storage). `ExpenseSnapshot` e `ActualExpense` já implementam `operator ==` por valor, por isso a comparação profunda é correcta e barata (dados já materializados em memória).

## Porque assim

Segui o plano do curator nos dois pontos: (1) parar de re-armar o postFrameCallback a cada build, gate por `monthKey`; (2) tornar os notifiers idempotentes com deep-equality. Ambos os fixes foram implementados, como o curator recomendou ("do both, since either alone leaves a foot-gun") — o primeiro corta o gatilho, o segundo é defesa em profundidade contra qualquer outro caller incondicional futuro.

Não toquei em `ExpenseSnapshotService.snapshotIfNeeded` nem no guard do stress-history (213-217), como o plano pediu explicitamente para não alterar.

## Critérios de aceitação

- [x] Início parado 6s sem interacção — o loop de render+I/O que causava 87-100% de CPU foi eliminado na raiz (postFrameCallback deixa de re-armar `onSnapshotExpenses` a cada build). Não medi CPU num dispositivo real (fora do alcance desta sessão headless), mas o teste unitário prova que a causa mecânica confirmada pelo curator (chamada em cada build/frame) deixou de existir.
- [x] Despesas não mostra CPU residual — o mecanismo de "backlog drain" descrito pelo curator dependia de múltiplas chamadas `.set()` em sequência a notificarem sempre; com a deep-equality nos notifiers, chamadas repetidas com o mesmo conteúdo não notificam mais nenhum listener (incluindo `_AppHomeState.build()`), o que corta a amplificação.
- [x] `onSnapshotExpenses` chamado no máximo uma vez por `monthKey` distinto por montagem do `DashboardScreen` — verificado em `test/functional/dashboard_screen_functional_test.dart`, novo grupo `onSnapshotExpenses is not re-armed on every build (#1236)`: 5 rebuilds idênticos (mesmo monthKey/dados) → contador fica em 1, não 5.
- [x] `ExpenseHistoryNotifier.set` (e os notifiers irmãos `ActualExpenseHistoryNotifier`, `ActualExpensesNotifier`) não notificam quando o conteúdo é deep-equal ao estado actual — verificado em `test/providers/expense_providers_test.dart` (3 grupos, um por notifier).
- [x] Persistência do snapshot continua a funcionar: `test/functional/dashboard_screen_functional_test.dart` mantém intactos os testes existentes que dependem de `onSnapshotExpenses`/`expenseHistory` (#1217, #1218, #1219 continuam a passar); adicionei um teste explícito em `expense_providers_test.dart` ("set() with genuinely different content still notifies") a provar que uma mudança real de conteúdo (novo mês adicionado ao mapa) continua a notificar — não regride o `trend_sheet.dart`.
- [x] Persistência do stress-history inalterada — o bloco `if (settings.stressHistory[monthKey] != stressResult.score) {...}` não foi tocado; testes existentes de dashboard continuam a passar.
- [x] `flutter analyze` limpo (78 issues antes e depois — todos pré-existentes, nenhum nos ficheiros alterados) e os testes indicados (`dashboard_screen_functional_test.dart`, `dashboard_container_test.dart`) passam.

## Testes

- **Passo vermelho (dashboard):** `Expected: <1> Actual: <5>` — `onSnapshotExpenses must fire once per distinct monthKey, not once per build/frame`, ao fazer `pumpWidget` do mesmo `DashboardScreen` (mesmo monthKey/dados) 5 vezes seguidas.
- **Passo vermelho (notifiers):** `Expected: <1> Actual: <2>` em cada um dos 3 notifiers, ao chamar `.set()` duas vezes com Maps/Listas de conteúdo idêntico mas instâncias diferentes.
- **Casos cobertos:**
  - Rebuilds repetidos sem mudança de estado (o caso central do bug — #1236).
  - Conteúdo deep-equal com instâncias `Map`/`List` novas, para os 3 notifiers (`ExpenseHistoryNotifier`, `ActualExpenseHistoryNotifier`, `ActualExpensesNotifier`) — prova que a comparação por valor funciona, não apenas por identidade.
  - O inverso: conteúdo genuinamente diferente (mês novo adicionado) continua a notificar — garante que a idempotência não quebra a propagação real de dados/trend_sheet.
- **Sanity-check:** revertido `lib/screens/dashboard_screen.dart` e `lib/providers/expense_providers.dart` (mantendo os testes), corridos os 4 testes novos — todos falharam exactamente como no passo vermelho (incl. `Expected: <1> Actual: <5>` de novo no teste do dashboard). Fix restaurado via `git apply` do patch guardado; suite voltou a passar por inteiro.
- Ficheiros de teste: `test/functional/dashboard_screen_functional_test.dart` (+1 grupo/teste), `test/providers/expense_providers_test.dart` (novo, 4 testes).
- Resultado final: 2502 testes corridos na suite completa, 2500 passaram, 2 falharam — ambos em `test/performance/performance_benchmarks_test.dart` ("dashboard initial render stays within budget", "shopping list scroll stays within frame budget"), confirmados como flakiness pré-existente do ambiente (reproduzi a mesma falha com `git stash` a remover completamente as minhas alterações — falham igualmente sem o fix, com magnitudes semelhantes, incluindo no teste da shopping list que não toca em código nenhum alterado por este issue). Não são regressão deste PR.

## Testes

2502 testes corridos, 2500 passaram, 2 falharam (flakiness pré-existente em test/performance/performance_benchmarks_test.dart, confirmado independente do fix via git stash). Todos os testes relevantes a este issue (dashboard_screen_functional_test.dart: 26/26, expense_providers_test.dart: 4/4, dashboard_container_test.dart incluído) passam. flutter analyze: 78 issues antes e depois (nenhum novo).

## Linked Issue

Fixes #1236