### PR TITLE
AI Coach: respostas do LLM respeitam o locale da app — sendChatMessage/analyze/analyzeMidMonth aceitam languageCode e os call sites passam o locale activo (#1277)

### DIFF
--- a/monthy_budget_flutter/lib/controllers/coach_chat_controller.dart
+++ b/monthy_budget_flutter/lib/controllers/coach_chat_controller.dart
@@ -123,6 +123,7 @@ class CoachChatController extends ChangeNotifier {
     required AppSettings settings,
     required PurchaseHistory purchaseHistory,
     required void Function(SubscriptionState) onSubscriptionChanged,
+    required String languageCode,
   }) async {
     if (text.trim().isEmpty || _loading) return true;
 
@@ -207,6 +208,7 @@ class CoachChatController extends ChangeNotifier {
         effectiveMode: effectiveMode,
         lastMicroAction: _subscription.lastMicroAction,
         lastMicroActionDate: _subscription.lastMicroActionDate,
+        languageCode: languageCode,
       );
 
       // Parse delimiters from reply

--- a/monthy_budget_flutter/lib/screens/coach_screen.dart
+++ b/monthy_budget_flutter/lib/screens/coach_screen.dart
@@ -223,6 +223,10 @@ class _CoachScreenState extends State<CoachScreen> with WidgetsBindingObserver {
     final text = _composerController.text.trim();
     if (text.isEmpty || _loading) return;
 
+    // Resolve the active app locale before any async gap so the LLM replies
+    // in the user's language (same pattern as _checkRecommendation).
+    final appLanguage = Localizations.localeOf(context).languageCode;
+
     // Pre-flight: free-tier users without a local API key can't reach the
     // edge function; trial/premium users use server-side auth and don't need one.
     if (!AiCoachService.canUseAI(_subscription, apiKey: widget.apiKey)) {
@@ -335,6 +339,7 @@ class _CoachScreenState extends State<CoachScreen> with WidgetsBindingObserver {
         effectiveMode: effectiveMode,
         lastMicroAction: _subscription.lastMicroAction,
         lastMicroActionDate: _subscription.lastMicroActionDate,
+        languageCode: appLanguage,
       );
 
       if (!mounted) return;

--- a/monthy_budget_flutter/lib/services/ai_coach_service.dart
+++ b/monthy_budget_flutter/lib/services/ai_coach_service.dart
@@ -77,6 +77,22 @@ class AiCoachService {
         _messageStorage =
             messageStorage ?? CoachMessageStorage(AppDatabase.instance);
 
+  /// Maps an app locale language code to the human language the LLM is
+  /// instructed to reply in. Unknown or empty codes fall back to `pt` — the
+  /// historical default of this service.
+  static const Map<String, String> _responseLanguageByCode = {
+    'pt': 'português europeu',
+    'en': 'English',
+    'fr': 'français',
+    'es': 'español',
+  };
+
+  /// Resolves the response-language instruction for [languageCode].
+  static String _responseLanguageInstruction(String? languageCode) {
+    final code = languageCode?.trim().toLowerCase() ?? '';
+    return _responseLanguageByCode[code] ?? 'português europeu';
+  }
+
   /// Sanitize user input before interpolating into prompts.
   ///
   /// Truncates to [_maxUserMessageLength] and strips sequences that could
@@ -314,6 +330,7 @@ class AiCoachService {
     CoachMode? effectiveMode,
     String? lastMicroAction,
     DateTime? lastMicroActionDate,
+    String languageCode = 'pt',
   }) async {
     final safeMessage = sanitizeUserInput(userMessage);
     var groundedUserMessage = _buildGroundedUserMessage(
@@ -347,6 +364,7 @@ class AiCoachService {
         summary: summary,
         purchaseHistory: purchaseHistory,
         effectiveMode: effectiveMode,
+        languageCode: languageCode,
       ),
     );
     return _requestChatCompletion(
@@ -425,6 +443,7 @@ ${recentPurchasesText.isEmpty ? '- sem compras registadas' : recentPurchasesText
     required BudgetSummary summary,
     required PurchaseHistory purchaseHistory,
     int maxTokens = 1000,
+    String languageCode = 'pt',
   }) async {
     final stress = calculateStressIndex(
       summary: summary,
@@ -440,7 +459,8 @@ ${recentPurchasesText.isEmpty ? '- sem compras registadas' : recentPurchasesText
           'role': 'system',
           'content':
               'És um analista financeiro pessoal para utilizadores portugueses. '
-              'Responde sempre em português europeu. Sê directo e analítico — '
+              'Responde sempre em ${_responseLanguageInstruction(languageCode)}. '
+              'Sê directo e analítico — '
               'usa sempre números concretos do contexto fornecido. '
               'Estrutura a resposta exactamente nas 3 partes pedidas. '
               'Não introduzas dados, benchmarks ou referências externas que não foram fornecidos.',
@@ -468,6 +488,7 @@ ${recentPurchasesText.isEmpty ? '- sem compras registadas' : recentPurchasesText
     required BudgetSummary summary,
     required PurchaseHistory purchaseHistory,
     required BudgetPaceResult pace,
+    String languageCode = 'pt',
   }) async {
     final stress = calculateStressIndex(
       summary: summary,
@@ -497,7 +518,8 @@ ${recentPurchasesText.isEmpty ? '- sem compras registadas' : recentPurchasesText
         {
           'role': 'system',
           'content': 'És um consultor de orçamento doméstico português. '
-              'Responde sempre em português europeu. Sê prático e directo.',
+              'Responde sempre em ${_responseLanguageInstruction(languageCode)}. '
+              'Sê prático e directo.',
         },
         {'role': 'user', 'content': prompt.toString()},
       ],
@@ -792,6 +814,7 @@ ${recentPurchasesText.isEmpty ? '- sem compras registadas' : recentPurchasesText
     required BudgetSummary summary,
     required PurchaseHistory purchaseHistory,
     CoachMode? effectiveMode,
+    String languageCode = 'pt',
   }) {
     final stress = calculateStressIndex(
       summary: summary,
@@ -810,7 +833,8 @@ ${recentPurchasesText.isEmpty ? '- sem compras registadas' : recentPurchasesText
 
     final buf = StringBuffer();
     buf.write('Es um coach financeiro pessoal para utilizadores portugueses. '
-        'Responde sempre em portugues europeu, de forma direta e pratica, '
+        'Responde sempre em ${_responseLanguageInstruction(languageCode)}, '
+        'de forma direta e pratica, '
         'respondendo primeiro a pergunta exata do utilizador. '
         'Evita formatos fixos (nao responder em "3 partes" a menos que seja pedido). '
         'Mantem continuidade da conversa e usa o historico para responder. '

--- a/monthy_budget_flutter/test/controllers/coach_chat_controller_test.dart
+++ b/monthy_budget_flutter/test/controllers/coach_chat_controller_test.dart
@@ -203,6 +203,7 @@ void main() {
           settings: _minimalSettings(),
           purchaseHistory: _emptyPurchaseHistory(),
           onSubscriptionChanged: (_) {},
+          languageCode: 'pt',
         );
 
         expect(result, isTrue);

--- a/monthy_budget_flutter/test/services/ai_coach_service_test.dart
+++ b/monthy_budget_flutter/test/services/ai_coach_service_test.dart
@@ -1,7 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
 import 'package:monthly_management/constants/app_constants.dart';
+import 'package:monthly_management/models/app_settings.dart';
+import 'package:monthly_management/models/budget_summary.dart';
+import 'package:monthly_management/models/coach_insight.dart';
+import 'package:monthly_management/models/purchase_record.dart';
 import 'package:monthly_management/models/subscription_state.dart';
+import 'package:monthly_management/repositories/household_repository.dart';
 import 'package:monthly_management/services/ai_coach_service.dart';
+import 'package:monthly_management/services/edge_function_client.dart';
+import 'package:monthly_management/utils/stress_index.dart';
 
 void main() {
   group('AiCoachService edge-function fallback helpers', () {
@@ -144,4 +153,224 @@ void main() {
       expect(messages[1]['content'], 'hello');
     });
   });
+
+  group('AiCoachService response language', () {
+    const settings = AppSettings();
+    const summary = BudgetSummary();
+    const purchaseHistory = PurchaseHistory();
+    const pace = BudgetPaceResult(
+      dailyPace: 20,
+      expectedPace: 25,
+      projectedTotal: 500,
+      projectedOverspend: 100,
+      isOverPace: true,
+      severity: 'warning',
+      daysElapsed: 15,
+      daysRemaining: 15,
+    );
+
+    Future<String> chatSystemPrompt({
+      String languageCode = 'pt',
+      CoachMode? effectiveMode,
+    }) async {
+      final built = _buildCapturingService();
+      await built.service.sendChatMessage(
+        apiKey: 'sk-test',
+        userMessage: 'Como poupar mais?',
+        history: [],
+        contextWindow: 4,
+        settings: settings,
+        summary: summary,
+        purchaseHistory: purchaseHistory,
+        effectiveMode: effectiveMode,
+        languageCode: languageCode,
+      );
+      return _capturedSystemPrompt(built.edge);
+    }
+
+    test('sendChatMessage with en instructs an English reply', () async {
+      final prompt = await chatSystemPrompt(languageCode: 'en');
+      expect(prompt, contains('English'));
+      expect(prompt, isNot(contains('portugues europeu')));
+    });
+
+    test('sendChatMessage with fr instructs a French reply', () async {
+      final prompt = await chatSystemPrompt(languageCode: 'fr');
+      expect(prompt, contains('français'));
+    });
+
+    test('sendChatMessage with es instructs a Spanish reply', () async {
+      final prompt = await chatSystemPrompt(languageCode: 'es');
+      expect(prompt, contains('español'));
+    });
+
+    test('sendChatMessage with pt keeps the European Portuguese instruction',
+        () async {
+      final prompt = await chatSystemPrompt(languageCode: 'pt');
+      expect(prompt, contains('português europeu'));
+    });
+
+    test('sendChatMessage without languageCode defaults to pt', () async {
+      final built = _buildCapturingService();
+      await built.service.sendChatMessage(
+        apiKey: 'sk-test',
+        userMessage: 'Como poupar mais?',
+        history: [],
+        contextWindow: 4,
+        settings: settings,
+        summary: summary,
+        purchaseHistory: purchaseHistory,
+      );
+      expect(_capturedSystemPrompt(built.edge), contains('português europeu'));
+    });
+
+    test('sendChatMessage with unknown languageCode falls back to pt',
+        () async {
+      final prompt = await chatSystemPrompt(languageCode: 'de');
+      expect(prompt, contains('português europeu'));
+    });
+
+    test('delimiter tokens stay literal regardless of response language',
+        () async {
+      final prompt = await chatSystemPrompt(
+        languageCode: 'en',
+        effectiveMode: CoachMode.pro,
+      );
+      expect(prompt, contains('[SESSION_INSIGHT]'));
+      expect(prompt, contains('[/SESSION_INSIGHT]'));
+      expect(prompt, contains('[MICRO_ACTION]'));
+      expect(prompt, contains('[/MICRO_ACTION]'));
+    });
+
+    test('analyze with en instructs an English reply', () async {
+      final built = _buildCapturingService();
+      await built.service.analyze(
+        apiKey: 'sk-test',
+        householdId: 'hh1',
+        settings: settings,
+        summary: summary,
+        purchaseHistory: purchaseHistory,
+        languageCode: 'en',
+      );
+      expect(_capturedSystemPrompt(built.edge), contains('English'));
+    });
+
+    test('analyzeMidMonth with fr instructs a French reply', () async {
+      final built = _buildCapturingService();
+      await built.service.analyzeMidMonth(
+        apiKey: 'sk-test',
+        householdId: 'hh1',
+        settings: settings,
+        summary: summary,
+        purchaseHistory: purchaseHistory,
+        pace: pace,
+        languageCode: 'fr',
+      );
+      expect(_capturedSystemPrompt(built.edge), contains('français'));
+    });
+
+    test('contextWindow still bounds history when languageCode is passed',
+        () async {
+      final built = _buildCapturingService();
+      await built.service.sendChatMessage(
+        apiKey: 'sk-test',
+        userMessage: 'nova pergunta',
+        history: [
+          CoachChatMessage(
+            role: 'user',
+            content: 'm1',
+            timestamp: DateTime(2026, 1, 1),
+          ),
+          CoachChatMessage(
+            role: 'assistant',
+            content: 'm2',
+            timestamp: DateTime(2026, 1, 2),
+          ),
+        ],
+        contextWindow: 1,
+        settings: settings,
+        summary: summary,
+        purchaseHistory: purchaseHistory,
+        languageCode: 'en',
+      );
+      final messages = built.edge.lastBody!['messages'] as List<dynamic>;
+      final contents =
+          messages.map((m) => (m as Map)['content'] as String).toList();
+      expect(contents, hasLength(3));
+      expect(contents[1], 'm2'); // only the latest history message survives
+      // The user turn is the grounded prompt wrapping the raw question.
+      expect(contents[2], contains('nova pergunta'));
+    });
+
+    test('Pro micro-action continuity context is still injected', () async {
+      final built = _buildCapturingService();
+      await built.service.sendChatMessage(
+        apiKey: 'sk-test',
+        userMessage: 'Olá',
+        history: [],
+        contextWindow: 4,
+        settings: settings,
+        summary: summary,
+        purchaseHistory: purchaseHistory,
+        effectiveMode: CoachMode.pro,
+        lastMicroAction: 'Poupa 10 euros',
+        lastMicroActionDate: DateTime(2026, 8, 1),
+        languageCode: 'en',
+      );
+      final messages = built.edge.lastBody!['messages'] as List<dynamic>;
+      final userMsg = messages.last as Map;
+      expect(userMsg['content'] as String,
+          contains('[Contexto de continuidade]'));
+      expect(userMsg['content'] as String, contains('Poupa 10 euros'));
+    });
+  });
+}
+
+class _FakeCoachInsightRepository implements CoachInsightRepository {
+  @override
+  Future<List<CoachInsight>> loadInsights(String householdId,
+          {int limit = 20}) async =>
+      [];
+  @override
+  Future<List<CoachInsight>> saveInsight(
+          CoachInsight insight, String householdId) async =>
+      [];
+  @override
+  Future<List<CoachInsight>> deleteInsight(
+          String id, String householdId) async =>
+      [];
+  @override
+  Future<void> clearInsights(String householdId) async {}
+}
+
+class _CapturingEdgeClient extends EdgeFunctionClient {
+  _CapturingEdgeClient()
+      : super(
+          httpClient: http_testing.MockClient(
+            (_) async => http.Response('{}', 200),
+          ),
+        );
+
+  Map<String, dynamic>? lastBody;
+
+  @override
+  Future<EdgeFunctionResponse> invoke(Map<String, dynamic> body) async {
+    lastBody = body;
+    return const EdgeFunctionResponse(status: 200, data: {'content': 'ok'});
+  }
+}
+
+({AiCoachService service, _CapturingEdgeClient edge}) _buildCapturingService() {
+  final edge = _CapturingEdgeClient();
+  final service = AiCoachService(
+    insightRepository: _FakeCoachInsightRepository(),
+    httpClient: http_testing.MockClient((_) async => http.Response('{}', 200)),
+    edgeClient: edge,
+  );
+  return (service: service, edge: edge);
+}
+
+String _capturedSystemPrompt(_CapturingEdgeClient edge) {
+  final messages = edge.lastBody!['messages'] as List<dynamic>;
+  return (messages.first as Map)['content'] as String;
 }


### PR DESCRIPTION
## Resumo

AI Coach: respostas do LLM respeitam o locale da app — sendChatMessage/analyze/analyzeMidMonth aceitam languageCode e os call sites passam o locale activo

## O que mudou

### `monthy_budget_flutter/lib/services/ai_coach_service.dart`
- Novo mapeamento estático `_responseLanguageByCode` (`pt` → `português europeu`, `en` → `English`, `fr` → `français`, `es` → `español`) e helper `_responseLanguageInstruction(String? languageCode)` que normaliza (trim + lowercase) e cai em `português europeu` para códigos vazios ou desconhecidos — o default histórico do serviço.
- `sendChatMessage`, `analyze`, `analyzeMidMonth` e `_buildChatSystemPrompt` ganharam o parâmetro `String languageCode = 'pt'`.
- Nos três system prompts, a frase fixa `Responde sempre em português/portugues europeu` passou a ser interpolada com `_responseLanguageInstruction(languageCode)`. Nada mais nos prompts mudou: os delimitadores `[SESSION_INSIGHT]…[/SESSION_INSIGHT]` e `[MICRO_ACTION]…[/MICRO_ACTION]` (e a instrução à volta deles) continuam literais, e os dados injectados (categorias, valores em €, datas, contexto financeiro) ficaram intactos.

### `monthy_budget_flutter/lib/screens/coach_screen.dart`
- Em `_sendCurrentMessage`, o locale é resolvido **no prólogo síncrono** do método (`Localizations.localeOf(context).languageCode`, o mesmo padrão já usado em `_checkRecommendation`) e passado como `languageCode` a `sendChatMessage`. Coloquei a resolução antes de qualquer `await` para não criar `use_build_context_synchronously`.

### `monthy_budget_flutter/lib/controllers/coach_chat_controller.dart`
- `sendMessage` ganhou `required String languageCode` e repassa-o a `sendChatMessage`. O controller não tem `BuildContext`, por isso não resolve o locale internamente — o chamador (widget) é obrigado a fornecer o código.

### Testes
- `test/services/ai_coach_service_test.dart`: novo grupo `AiCoachService response language` com 11 testes (fakes `_CapturingEdgeClient` que sobrescreve `invoke` para capturar `body['messages']`, e `_FakeCoachInsightRepository`).
- `test/controllers/coach_chat_controller_test.dart`: a única chamada a `sendMessage` ganhou `languageCode: 'pt'` (o teste do early-return de texto vazio).

## Porque assim

Segui o plano do curator. Decisões registadas:
- **Parâmetro com default vs required no serviço:** escolhi `String languageCode = 'pt'` em `sendChatMessage`/`analyze`/`analyzeMidMonth` para não quebrar chamadores externos e para satisfazer o AC de "locale ausente → comportamento actual" (omitir o parâmetro cai em `pt`). No controller escolhi `required` porque, sem `BuildContext`, o controller não pode nem deve resolver o locale — a assinatura força o futuro widget chamador a fornecê-lo.
- **Resolução do locale antes de qualquer `await`:** a primeira versão resolvia `Localizations.localeOf(context)` logo antes da chamada a `sendChatMessage`, o que acordou `use_build_context_synchronously` (o método já atravessou `await`s). Mover a resolução para o prólogo síncrono resolve o lint e é semanticamente idêntico (o locale não muda no intervalo de milissegundos).
- **Grafia do prompt PT do chat:** o texto fixo anterior era `portugues europeu` (sem acentos); a instrução PT passa a `português europeu` (acentuada), igual à grafia que `analyze`/`analyzeMidMonth` já usavam. Comportamento semântico idêntico — só normaliza a grafia.
- **Não toquei** nos delimitadores, nos dados injectados, nem no texto de persona (`para utilizadores portugueses`) — só a frase de instrução de idioma mudou, como o issue manda.

## Critérios de aceitação

- [x] `sendChatMessage`, `_buildChatSystemPrompt`, `analyze` e `analyzeMidMonth` aceitam um parâmetro de idioma (`languageCode`, default `'pt'`).
- [x] Com `languageCode: 'en'`, o system prompt contém a instrução `English` — verificado nos argumentos capturados pelo `_CapturingEdgeClient` (teste `sendChatMessage with en instructs an English reply`; idem `analyze with en`).
- [x] Com `languageCode: 'fr'` e `'es'`, o mesmo em `français` e `español` (testes `fr` e `es` do chat; `analyzeMidMonth with fr`).
- [x] Com `languageCode: 'pt'`, sem parâmetro, ou com código desconhecido (`'de'`), a instrução é `português europeu` — comportamento actual não regride (3 testes dedicados).
- [x] Os delimitadores `[SESSION_INSIGHT]`/`[MICRO_ACTION]` continuam literais independentemente do idioma (teste `delimiter tokens stay literal…` com `en` + `CoachMode.pro`).
- [x] Nenhum outro comportamento muda: `contextWindow` continua a limitar o histórico (teste `contextWindow still bounds history…`) e a injecção de micro-acção Pro (teste `Pro micro-action continuity context is still injected`).
- [x] `coach_screen.dart` resolve o idioma via `Localizations.localeOf(context).languageCode` e passa-o a `sendChatMessage` (verificado por inspecção; o padrão é o mesmo de `_checkRecommendation`).
- [x] `CoachChatController.sendMessage()` aceita e repassa `required String languageCode` sem o resolver internamente.
- [x] `flutter analyze` não introduz avisos novos nos ficheiros alterados.

## Testes

- **Passo vermelho:**
  1. O teste novo não compilava porque a API não aceitava nenhum parâmetro de idioma: `Error: No named parameter with the name 'languageCode'` (5 ocorrências). Esta é a metade estrutural do defeito — o serviço não tem como receber o locale.
  2. Depois de adicionar apenas a assinatura (sem mapeamento), 8 testes falhavam na asserção, provando que a instrução estava hardcoded em PT:
     - `Expected: contains 'English'` / `Actual: 'Es um coach financeiro pessoal para utilizadores portugueses. Responde sempre em portugues europeu, de forma direta e pratica, …'`
     - `Expected: contains 'français'` / `Actual: '…Responde sempre em portugues europeu, …'`
     - `Expected: contains 'español'` / `Actual: '…'` (idem)
     - `analyze`: `Expected: contains 'English'` / `Actual: '…Responde sempre em português europeu. Sê directo e analítico — …'`
     - `analyzeMidMonth`: `Expected: contains 'français'` / `Actual: '…Responde sempre em português europeu. Sê prático e directo.'`
- **Casos cobertos** (para além do caminho feliz): cada idioma suportado (`en`/`fr`/`es`/`pt`), **ausência do parâmetro** (default `pt`), **código desconhecido** (`de` → `pt`, o inverso do fix: garantir que códigos fora do mapa não mudam o comportamento), **delimitadores literais**, e **regressões** de `contextWindow` e da injecção de micro-acção Pro.
- **Sanity-check:** neutralizei temporariamente o mapeamento (`_responseLanguageInstruction` a devolver sempre `português europeu`, mantendo as assinaturas). A suite do serviço falhou nos 5 testes de idioma (`en`/`fr`/`es` do chat + `analyze en` + `analyzeMidMonth fr`) e passou nos testes de `pt`/default/desconhecido — prova de que os testes estão ligados ao comportamento, não à estrutura. Restaurei o mapeamento e voltei ao verde (23/23).
- **Resultado da suite completa:** `flutter test` → `2513 passaram, 2 falharam`. As 2 falhas são pré-existentes e não relacionadas com este issue: `test/performance/performance_benchmarks_test.dart` (`dashboard initial render stays within budget` — 1749ms vs orçamento 500ms; `shopping list scroll stays within frame budget` — 66.9ms vs 19ms). **Provei que são pré-existentes**: fiz `git stash` (árvore limpa), corri o mesmo ficheiro e as mesmas 2 falhas repetiram-se (dashboard 2068ms, scroll 78ms) — são benchmarks sensíveis à carga da máquina, em código (DashboardScreen / lista de compras) que este diff não toca. Não os apaguei nem marquei como `skip`.
- Ficheiros de teste: `test/services/ai_coach_service_test.dart` (23 testes, todos passam), `test/controllers/coach_chat_controller_test.dart` (13 testes, todos passam).

## Testes

2513 passaram, 2 falharam (pré-existentes, performance_benchmarks_test.dart: dashboard render e shopping scroll — falham também na árvore limpa sem as alterações)

## Linked Issue

Fixes #1277